### PR TITLE
fix: gap analysis fixes + marketplace discoverability

### DIFF
--- a/skills/ql-brainstorm/SKILL.md
+++ b/skills/ql-brainstorm/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ql-brainstorm
-description: Deep Socratic exploration of a feature idea before implementation. Asks questions one at a time, proposes 2-3 alternative approaches with trade-offs, presents design section-by-section for approval, and saves an approved design document. Use when starting a new feature, exploring an idea, or before writing a spec. Triggers on: brainstorm, explore idea, design this, think through, ql-brainstorm.
+description: "Part of the quantum-loop autonomous development pipeline (brainstorm \u2192 spec \u2192 plan \u2192 execute \u2192 review \u2192 verify). Deep Socratic exploration of a feature idea before implementation. Asks questions one at a time, proposes 2-3 alternative approaches with trade-offs, presents design section-by-section for approval, and saves an approved design document. Use when starting a new feature, exploring an idea, or before writing a spec. Triggers on: brainstorm, explore idea, design this, think through, ql-brainstorm."
 ---
 
 # Quantum-Loop: Brainstorm

--- a/skills/ql-execute/SKILL.md
+++ b/skills/ql-execute/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ql-execute
-description: Run the autonomous execution loop. Reads quantum.json, queries the dependency DAG, implements stories with TDD and two-stage review gates. Supports parallel execution via native worktree isolation. Use after /quantum-loop:plan has created quantum.json. Triggers on: execute, run loop, start building, ql-execute.
+description: "Part of the quantum-loop autonomous development pipeline (brainstorm \u2192 spec \u2192 plan \u2192 execute \u2192 review \u2192 verify). Run the autonomous execution loop. Reads quantum.json, queries the dependency DAG, implements stories with TDD and two-stage review gates. Supports parallel execution via native worktree isolation. Use after /quantum-loop:plan has created quantum.json. Triggers on: execute, run loop, start building, ql-execute."
 ---
 
 # Quantum-Loop: Execute

--- a/skills/ql-plan/SKILL.md
+++ b/skills/ql-plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ql-plan
-description: Convert a PRD into machine-readable quantum.json with dependency DAG, granular 2-5 minute tasks, and execution metadata. Use after creating a spec with /quantum-loop:spec. Triggers on: create plan, convert to json, plan tasks, generate quantum json, ql-plan.
+description: "Part of the quantum-loop autonomous development pipeline (brainstorm \u2192 spec \u2192 plan \u2192 execute \u2192 review \u2192 verify). Convert a PRD into machine-readable quantum.json with dependency DAG, granular 2-5 minute tasks, and execution metadata. Use after creating a spec with /quantum-loop:spec. Triggers on: create plan, convert to json, plan tasks, generate quantum json, ql-plan."
 ---
 
 # Quantum-Loop: Plan

--- a/skills/ql-review/SKILL.md
+++ b/skills/ql-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ql-review
-description: Two-stage code review. Spec compliance first, then code quality. Use after implementation or before merge. Triggers on: review code, code review, check implementation, ql-review.
+description: "Part of the quantum-loop autonomous development pipeline (brainstorm \u2192 spec \u2192 plan \u2192 execute \u2192 review \u2192 verify). Two-stage code review. Spec compliance first, then code quality. Use after implementation or before merge. Triggers on: review code, code review, check implementation, ql-review."
 ---
 
 # Quantum-Loop: Review

--- a/skills/ql-spec/SKILL.md
+++ b/skills/ql-spec/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ql-spec
-description: Generate a structured Product Requirements Document (PRD) with user stories, acceptance criteria, and functional requirements. Use when you have an approved design and need formal requirements, or when starting from scratch. Triggers on: create spec, write prd, spec out, requirements for, ql-spec.
+description: "Part of the quantum-loop autonomous development pipeline (brainstorm \u2192 spec \u2192 plan \u2192 execute \u2192 review \u2192 verify). Generate a structured Product Requirements Document (PRD) with user stories, acceptance criteria, and functional requirements. Use when you have an approved design and need formal requirements, or when starting from scratch. Triggers on: create spec, write prd, spec out, requirements for, ql-spec."
 ---
 
 # Quantum-Loop: Spec

--- a/skills/ql-verify/SKILL.md
+++ b/skills/ql-verify/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ql-verify
-description: Iron Law verification gate. Requires fresh evidence before any completion claim. Use before claiming work is done, before committing, or before marking a story as passed. Triggers on: verify, check, prove it works, ql-verify.
+description: "Part of the quantum-loop autonomous development pipeline (brainstorm \u2192 spec \u2192 plan \u2192 execute \u2192 review \u2192 verify). Iron Law verification gate. Requires fresh evidence before any completion claim. Use before claiming work is done, before committing, or before marking a story as passed. Triggers on: verify, check, prove it works, ql-verify."
 ---
 
 # Quantum-Loop: Verify


### PR DESCRIPTION
## Summary

- **Resolve 13 gaps from systemic workflow review**: DAG query output format, spawn prompt clarity, implementer integration wiring checks, template status value corrections (`completed` → `passed`), orchestrator cross-reference fix, `.gitignore` for agent logs
- **Add pipeline context to skill descriptions**: All 6 SKILL.md descriptions now reference the full quantum-loop pipeline (brainstorm → spec → plan → execute → review → verify) for marketplace discoverability on SkillsMP and skills.sh

## Changes

### Bug fixes (13 gaps)
- `lib/dag-query.sh`: Fix JSON array output format
- `lib/spawn.sh`: Clearer worktree prompt with numbered workflow steps, add `--dangerously-skip-permissions` for background agents
- `agents/implementer.md`: Add integration wiring check section, fix signal names and completion flow
- `agents/orchestrator.md`: Fix cross-reference to error handling step
- `templates/quantum-loop.sh`: Normalize all `completed` → `passed` status values, fix `REPO_ROOT` to use `$(pwd)`
- `.claude-plugin/marketplace.json`: Version bump to 0.2.0, update agent count
- `.gitignore`: Add `.quantum-logs/`
- `README.md`: Fix skill directory names to match `ql-*` convention

### Marketplace discoverability
- All 6 skills now include "Part of the quantum-loop autonomous development pipeline" in their descriptions
- Searching "quantum-loop" on SkillsMP will now surface all skills as a cohesive suite

## Test plan

- [ ] Verify `bash lib/dag-query.sh` outputs valid JSON arrays
- [ ] Verify skill descriptions render correctly in `skills search quantum-loop`
- [ ] Run sequential execution loop end-to-end
- [ ] Confirm template status values are consistently `passed` (not `completed`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)