### PR TITLE
fix: version refs, document dual scripts, remove emojis

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Clone the repo, then edit three files in `~/.claude/`:
      "name": "quantum-loop",
      "source": { "source": "url", "url": "https://github.com/andyzengmath/quantum-loop.git" },
      "description": "Spec-driven autonomous development loop",
-     "version": "1.0.0",
+     "version": "0.2.2",
      "strict": true
    }
    ```
@@ -74,7 +74,7 @@ Clone the repo, then edit three files in `~/.claude/`:
    "quantum-loop@<marketplace-name>": [{
      "scope": "user",
      "installPath": "/path/to/quantum-loop",
-     "version": "1.0.0",
+     "version": "0.2.2",
      "installedAt": "2026-02-18T00:00:00.000Z",
      "lastUpdated": "2026-02-18T00:00:00.000Z"
    }]
@@ -321,7 +321,17 @@ quantum-loop/
 └── CLAUDE.md             # Agent template (parallel-aware)
 ```
 
-**`quantum-loop.sh`** drives autonomous execution:
+**Two runner scripts** (different purposes):
+
+| Script | For | Dependencies | Granularity |
+|--------|-----|-------------|-------------|
+| `quantum-loop.sh` (root) | Plugin repo development | `jq` + `lib/*.sh` | Story-level |
+| `templates/quantum-loop.sh` | **User projects** (copy this one) | `node` only, self-contained | Task-level |
+
+The root script is used internally by the plugin. For your projects, download the templates version:
+```bash
+curl -sO https://raw.githubusercontent.com/andyzengmath/quantum-loop/main/templates/quantum-loop.sh && chmod +x quantum-loop.sh
+```
 
 **Sequential mode** (default):
 1. Reads quantum.json state

--- a/quantum-loop.sh
+++ b/quantum-loop.sh
@@ -2,9 +2,19 @@
 set -euo pipefail
 
 # =============================================================================
-# quantum-loop.sh -- Autonomous development loop with DAG-based story selection,
-# two-stage review gates, and structured error recovery.
-# Supports parallel execution via DAG-driven worktree agents.
+# quantum-loop.sh -- PLUGIN-LEVEL autonomous development loop.
+#
+# THIS SCRIPT IS FOR THE QUANTUM-LOOP PLUGIN REPO ITSELF.
+# It requires lib/*.sh modules and jq. It operates at the STORY level
+# (one story per agent invocation) and uses CLAUDE.md as the agent prompt.
+#
+# FOR USER PROJECTS: Use templates/quantum-loop.sh instead.
+# That script is self-contained (no lib/ dependency), uses node for JSON,
+# and operates at the TASK level. Download it via:
+#   curl -sO https://raw.githubusercontent.com/andyzengmath/quantum-loop/main/templates/quantum-loop.sh
+#
+# Features: DAG-based story selection, two-stage review gates,
+# structured error recovery, parallel execution via worktree agents.
 #
 # Usage:
 #   ./quantum-loop.sh [OPTIONS]


### PR DESCRIPTION
## Summary

Fixes the 3 remaining issues from the workflow review.

### Fix 1: README version mismatch (CRITICAL)
- Install examples referenced `"version": "1.0.0"` but plugin is `0.2.2`
- Fixed both occurrences on lines 68 and 77

### Fix 2: Document the two quantum-loop.sh scripts (HIGH)
- Added clear headers to both scripts explaining their purpose:
  - Root `quantum-loop.sh`: for the plugin repo itself (jq + lib/*.sh, story-level)
  - `templates/quantum-loop.sh`: for user projects (node, self-contained, task-level)
- Added comparison table to README Architecture section
- Added `curl` download instruction for the templates version

### Fix 3: Remove emojis from templates script (HIGH)
- Replaced emojis with consistent `[PASSED]`/`[FAILED]`/`[STORY DONE]`/`[WARNING]` tags
- Matches the root script's output style

## Test plan
- [x] `grep -r "1.0.0" README.md` returns nothing
- [x] Both scripts have clear "THIS SCRIPT IS FOR..." headers
- [x] No emojis in templates/quantum-loop.sh output

🤖 Generated with [Claude Code](https://claude.com/claude-code)