### PR TITLE
fix: runtime schema docs + gitignore .claude/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ archive/
 Thumbs.db
 desktop.ini
 
+# Local Claude Code settings
+.claude/
+
 # Editor files
 .vscode/
 .idea/

--- a/quantum.json.example
+++ b/quantum.json.example
@@ -203,5 +203,12 @@
     }
   ],
   "progress": [],
-  "codebasePatterns": []
+  "codebasePatterns": [],
+  "_comment_runtime_fields": "The following fields are added at runtime by the orchestrator and are not part of the initial schema:",
+  "_execution_example": {
+    "mode": "parallel",
+    "maxParallel": 4,
+    "currentWave": 2,
+    "activeWorktrees": [".ql-wt/US-002", ".ql-wt/US-003"]
+  }
 }


### PR DESCRIPTION
## Summary

Fixes the remaining MEDIUM/LOW issues from the workflow review.

| # | Severity | Fix |
|---|----------|-----|
| 4 | MEDIUM | `quantum.json` already untracked — no action needed |
| 5 | MEDIUM | `quantum.json.example` updated with runtime `execution` field documentation |
| 6 | LOW | Template double-commit — harmless, skipped |
| 7 | LOW | `.claude/` added to `.gitignore` to prevent local settings from being committed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)