### PR TITLE
fix: parallel execution issues from field testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,14 +179,20 @@ Wave 3:  US-003 (API)      ─── worktree ─── [PASSED] ── merge   
 
 **How it works:**
 1. The orchestrator queries the DAG for all stories with satisfied dependencies
-2. Each story gets an isolated git worktree (`.ql-wt/<story-id>/`)
-3. A fresh Claude Code agent is spawned per worktree with the story ID in its prompt
-4. Agents implement the story, commit their changes (`git add -A && git commit`), then signal completion
-5. The orchestrator verifies changes are committed (safety commit if agent forgot), then merges the worktree branch into the feature branch
-6. The DAG is re-queried after every completion to spawn newly unblocked stories
-7. On merge conflict or failure, the story is retried in the next wave
+2. **File-conflict filtering** removes stories that share file paths with higher-priority stories in the same wave — preventing merge conflicts from parallel edits to the same file
+3. Each story gets an isolated git worktree (`.ql-wt/<story-id>/`)
+4. A fresh Claude Code agent is spawned per worktree with the story ID in its prompt
+5. Agents implement the story, commit their changes (`git add -A && git commit`), then signal completion
+6. The orchestrator runs an **inline review gate** (spec compliance + code quality) after each merge
+7. The DAG is re-queried after every completion to spawn newly unblocked stories
+8. On merge conflict or failure, the story is retried in the next wave
+9. After all stories pass, a **full-feature code review** examines the entire branch diff for cross-story consistency
 
 **Agents are fully isolated:** each works in its own worktree directory. Only the orchestrator reads/writes `quantum.json`. Agents must commit before signaling — the orchestrator includes a safety commit as a fallback, but uncommitted work in a removed worktree is lost. Agents that timeout (default 15 min) or crash are killed, their stories marked failed, and worktrees cleaned up.
+
+**Worktree nesting prevention:** If an agent is spawned inside a worktree (e.g., during mid-wave dispatch), `_resolve_repo_root()` resolves the path to the top-level repository root, preventing `.ql-wt/` directories from nesting inside each other. On Windows with long OneDrive paths, worktrees automatically fall back to a shorter temp-directory location.
+
+**Python project isolation:** Parallel worktrees share a single Python interpreter. Agents use `PYTHONPATH` injection instead of `pip install -e .` to avoid editable-install race conditions where one agent's install overwrites another's.
 
 **Two execution modes:**
 
@@ -341,13 +347,13 @@ quantum-loop/
 │   └── quality-reviewer  # Code quality check
 ├── lib/                  # Shell libraries for parallel orchestration
 │   ├── common.sh         # Shared validation utilities
-│   ├── dag-query.sh      # DAG query + cycle detection
+│   ├── dag-query.sh      # DAG query + cycle detection + file-conflict filtering
 │   ├── worktree.sh       # Git worktree lifecycle (create/remove/list)
 │   ├── spawn.sh          # Agent spawning (autonomous mode)
 │   ├── monitor.sh        # Agent polling, signal detection, merge-on-pass
 │   ├── json-atomic.sh    # Atomic quantum.json writes (tmp + mv)
 │   └── crash-recovery.sh # Orphaned worktree cleanup on startup
-├── tests/                # Shell test suites (124 tests)
+├── tests/                # Shell test suites (79+ tests)
 │   ├── test_dag_query.sh
 │   ├── test_worktree.sh
 │   ├── test_spawn.sh
@@ -385,8 +391,8 @@ curl -sO https://raw.githubusercontent.com/andyzengmath/quantum-loop/main/templa
 
 **Parallel mode** (`--parallel`):
 1. Recovers orphaned worktrees from any interrupted previous run
-2. Queries DAG for all independently executable stories
-3. Creates isolated git worktree per story (`.ql-wt/<story-id>/`)
+2. Queries DAG for all independently executable stories, filters out file conflicts
+3. Creates isolated git worktree per story (`.ql-wt/<story-id>/`, or `/tmp` fallback on long paths)
 4. Spawns background `claude --print` process per worktree (up to `--max-parallel`)
 5. Monitors agents: polls for signals, enforces 15-min timeout, detects crashes
 6. On pass: safety-commits any uncommitted changes, merges worktree branch into feature branch, re-queries DAG, spawns newly unblocked stories

--- a/agents/implementer.md
+++ b/agents/implementer.md
@@ -34,18 +34,20 @@ When running in an isolated worktree (parallel execution), the Python/Node envir
 
 Instead, use `PYTHONPATH` injection:
 ```bash
-# Python projects: prepend worktree src to PYTHONPATH
-export PYTHONPATH="$(pwd)/src:$PYTHONPATH"
+# Python projects: prepend worktree source directory to PYTHONPATH.
+# Common layouts: src/, lib/, or the package directory itself.
+# Check pyproject.toml or setup.py for the correct source root.
+export PYTHONPATH="$(pwd)/src:$PYTHONPATH"   # for src-layout projects
+# export PYTHONPATH="$(pwd):$PYTHONPATH"     # for flat-layout projects
 
 # Run tests with PYTHONPATH
 PYTHONPATH=src python -m pytest tests/ -x -v
 
-# Verify correct import path
+# Verify correct import path — should show YOUR worktree path
 python -c "import <module>; print(<module>.__file__)"
-# Should show YOUR worktree path, not another agent's
 ```
 
-For Node.js projects, worktree isolation is usually sufficient since `node_modules` is per-directory.
+For Node.js projects, worktree isolation is usually sufficient since `node_modules` is per-directory. For Go projects, worktree isolation works natively (module paths are directory-relative).
 
 ## Implementation Process
 

--- a/agents/implementer.md
+++ b/agents/implementer.md
@@ -28,6 +28,25 @@ If `quantum.json` contains a `contracts` object:
 
 If you disagree with a contract value, you **MUST** halt and ask the orchestrator to confirm (propose-and-wait) rather than silently deviating. The orchestrator will either confirm the contract or update it for all agents.
 
+## Environment Setup (Worktree Mode)
+
+When running in an isolated worktree (parallel execution), the Python/Node environment may be shared with other worktrees. **Do NOT run `pip install -e .`** — this overwrites the editable install for all worktrees, causing race conditions where your tests import another agent's code.
+
+Instead, use `PYTHONPATH` injection:
+```bash
+# Python projects: prepend worktree src to PYTHONPATH
+export PYTHONPATH="$(pwd)/src:$PYTHONPATH"
+
+# Run tests with PYTHONPATH
+PYTHONPATH=src python -m pytest tests/ -x -v
+
+# Verify correct import path
+python -c "import <module>; print(<module>.__file__)"
+# Should show YOUR worktree path, not another agent's
+```
+
+For Node.js projects, worktree isolation is usually sufficient since `node_modules` is per-directory.
+
 ## Implementation Process
 
 For each task in the story's `tasks` array, in order:

--- a/agents/orchestrator.md
+++ b/agents/orchestrator.md
@@ -214,13 +214,17 @@ Wait for agent completion notifications. Do NOT poll in a loop — Claude Code a
 
 **On STORY_PASSED:**
 - Log: `[PASSED] US-XXX - Story Title`
-- **Merge the worktree branch.** Claude Code's `isolation: "worktree"` may auto-merge, or you may need to merge manually. If quantum.json blocks the merge (modified locally for orchestrator state), use this pattern:
+- **Merge the worktree branch.** Claude Code's `isolation: "worktree"` may auto-merge, or you may need to merge manually.
+
+  **Handling quantum.json during merges:** quantum.json should be in `.gitignore` so it doesn't participate in merges. If it IS tracked (some projects track it), or if other local-only files block the merge, use this pattern:
   ```bash
-  git stash push -m "quantum.json orchestrator state" -- quantum.json
+  git stash push -m "orchestrator state" -- quantum.json
   git merge <worktree-branch> --no-edit        # or use -X ours for non-critical conflicts
-  git stash pop
+  git stash pop                                 # may conflict — see below
   ```
-  If `stash pop` conflicts on quantum.json, discard the stash and re-write quantum.json state via Python (the orchestrator is the source of truth, not the stashed copy).
+  If `stash pop` conflicts on quantum.json, **drop the stash** (`git stash drop`) and re-write quantum.json state from scratch via Python. The orchestrator's in-memory knowledge of story statuses is the source of truth, not any stashed file. Never resolve quantum.json merge conflicts by hand — always regenerate programmatically.
+
+  **Best practice:** Add `quantum.json` to `.gitignore` at the start of a feature branch to avoid this entirely. The implementer agents are already instructed not to commit quantum.json in parallel mode (see implementer.md, "Parallel mode" section).
 - Update quantum.json: story `status: "passed"`, clear `startedAt` = `null`, add progress entry
 
 **On STORY_FAILED:**
@@ -232,6 +236,25 @@ Wait for agent completion notifications. Do NOT poll in a loop — Claude Code a
 - Run the full test suite to catch semantic merge regressions
 - If tests fail after merge: `git revert -m 1 HEAD` to undo the merge commit, mark story failed
 - Run a quick wiring check on the just-merged story's new exports (LSP "Find References" preferred, grep fallback)
+
+### 3B.4: Inline Review Gate (Parallel Mode)
+
+In parallel mode, implementer agents self-review (quality checks + acceptance criteria verification). The orchestrator runs an **inline review gate** after each successful merge, equivalent to Step 3A.5 but executed by the orchestrator rather than a separate agent:
+
+**Stage 1: Spec Compliance (inline)**
+- Read the PRD acceptance criteria for the just-merged story
+- For each criterion: grep the diff (`git diff <MERGE_BASE>..HEAD`) or test output for evidence
+- If any criterion is clearly unsatisfied: ONE fix attempt inline, re-commit. If unfixable, revert the merge and mark story failed.
+
+**Stage 2: Code Quality (inline)**
+- Review the merged diff for obvious issues: missing error handling, hardcoded secrets, broken types
+- Categorize: Critical / Important / Minor
+- Pass if: 0 Critical AND < 3 Important
+- If fails: ONE fix attempt inline, re-commit
+
+**When to skip the inline review:** If the wave has 4+ stories pending merge and the orchestrator's context window is above 60% usage, defer reviews to the wave-end Integration Check (Step 3C). Log: `[REVIEW DEFERRED] US-XXX - will review at wave end`
+
+This ensures parallel execution has the same quality bar as sequential, while adapting to context window constraints.
 
 **When a complete dependency chain passes** (ALL stories in the chain have `status: "passed"` — skip if any story in the chain is still pending, in_progress, or failed):
 - Run a cross-story integration review:

--- a/agents/orchestrator.md
+++ b/agents/orchestrator.md
@@ -252,7 +252,7 @@ In parallel mode, implementer agents self-review (quality checks + acceptance cr
 - Pass if: 0 Critical AND < 3 Important
 - If fails: ONE fix attempt inline, re-commit
 
-**When to skip the inline review:** If the wave has 4+ stories pending merge and the orchestrator's context window is above 60% usage, defer reviews to the wave-end Integration Check (Step 3C). Log: `[REVIEW DEFERRED] US-XXX - will review at wave end`
+**When to defer the inline review:** If the wave has 4+ stories pending merge and the accumulated diff exceeds 2000 lines, defer reviews to the wave-end Integration Check (Step 3C) to conserve context. Log: `[REVIEW DEFERRED] US-XXX - will review at wave end (diff too large)`
 
 This ensures parallel execution has the same quality bar as sequential, while adapting to context window constraints.
 

--- a/agents/orchestrator.md
+++ b/agents/orchestrator.md
@@ -190,7 +190,8 @@ Agent tool with:
            IMPORTANT — Python projects: Do NOT run 'pip install -e .' in the worktree.
            Parallel worktrees share one Python environment, so editable installs race.
            Instead, set PYTHONPATH to your worktree's source directory before running tests:
-             export PYTHONPATH=\"$(pwd)/src:$PYTHONPATH\"
+             export PYTHONPATH=\"\$(pwd)/src:\$PYTHONPATH\"   # src-layout
+             # export PYTHONPATH=\"\$(pwd):\$PYTHONPATH\"     # flat-layout
            Or for inline commands:
              PYTHONPATH=src python -m pytest tests/ -x -v
 

--- a/agents/orchestrator.md
+++ b/agents/orchestrator.md
@@ -47,6 +47,16 @@ Find all eligible stories. A story is eligible when ALL of:
 
 Sort eligible stories by `priority` (ascending).
 
+### 2.1: File-Conflict-Aware Filtering
+
+Before deciding sequential vs parallel, check the `fileConflicts` array in quantum.json. For each entry where two or more eligible stories share a file:
+- Only include the **highest-priority** story from the conflict group in this wave
+- Defer the others to the next wave (they remain eligible but are held back)
+
+This prevents merge conflicts from parallel stories editing the same file. Also check each eligible story's `tasks[].filePaths` — if two eligible stories share any file path, treat them as conflicting even if not listed in `fileConflicts`.
+
+Log: `[DAG] Held back US-XXX (file conflict with US-YYY on <file>)`
+
 **If no eligible stories:**
 - If ALL stories have `status: "passed"` -> output `<quantum>COMPLETE</quantum>`, print summary table, stop
 - Otherwise -> output `<quantum>BLOCKED</quantum>`, report which stories are stuck and why, stop
@@ -176,6 +186,14 @@ Agent tool with:
   prompt: "Implement story <STORY_ID> from quantum.json.
            You are in an isolated worktree. Read quantum.json for context.
            Follow the implementer agent protocol in agents/implementer.md.
+
+           IMPORTANT — Python projects: Do NOT run 'pip install -e .' in the worktree.
+           Parallel worktrees share one Python environment, so editable installs race.
+           Instead, set PYTHONPATH to your worktree's source directory before running tests:
+             export PYTHONPATH=\"$(pwd)/src:$PYTHONPATH\"
+           Or for inline commands:
+             PYTHONPATH=src python -m pytest tests/ -x -v
+
            You MUST commit your changes: git add -A && git commit -m 'feat: <STORY_ID> - <Title>'
            Signal completion: <quantum>STORY_PASSED</quantum> or <quantum>STORY_FAILED</quantum>"
 ```
@@ -196,8 +214,14 @@ Wait for agent completion notifications. Do NOT poll in a loop — Claude Code a
 
 **On STORY_PASSED:**
 - Log: `[PASSED] US-XXX - Story Title`
+- **Merge the worktree branch.** Claude Code's `isolation: "worktree"` may auto-merge, or you may need to merge manually. If quantum.json blocks the merge (modified locally for orchestrator state), use this pattern:
+  ```bash
+  git stash push -m "quantum.json orchestrator state" -- quantum.json
+  git merge <worktree-branch> --no-edit        # or use -X ours for non-critical conflicts
+  git stash pop
+  ```
+  If `stash pop` conflicts on quantum.json, discard the stash and re-write quantum.json state via Python (the orchestrator is the source of truth, not the stashed copy).
 - Update quantum.json: story `status: "passed"`, clear `startedAt` = `null`, add progress entry
-- The worktree merge is handled automatically by Claude Code's isolation mode
 
 **On STORY_FAILED:**
 - Log: `[FAILED] US-XXX - Story Title`

--- a/agents/orchestrator.md
+++ b/agents/orchestrator.md
@@ -321,6 +321,37 @@ When DAG query returns no eligible stories and all stories have passed, run fina
 3. **Dead code scan:** every new function/class created during this feature has at least one call site outside its own file and tests. Use LSP "Find References" when available, fall back to grep.
 4. **If any check fails:** create a fix task, implement inline, re-test, commit. Do NOT output COMPLETE until all checks pass.
 
+## Step 4B: Full-Feature Code Review
+
+After Step 4 passes, run a holistic review of the **entire feature branch diff** — not per-story, but the combined change set. Per-story reviews catch local issues; this step catches cross-story problems that only emerge when viewed as a whole.
+
+```bash
+git diff main...HEAD --stat    # overview of all files changed
+git diff main...HEAD           # full diff for review
+```
+
+### 4B.1: Cross-Story Consistency
+- **Naming:** Did parallel agents use different names for the same concept? (e.g., `image_mode` vs `imageMode`, `_build_images_used` vs `_create_image_refs`)
+- **Duplicate logic:** Did two stories implement overlapping helpers or utility functions? If so, consolidate into one and update callers.
+- **Contradictory design:** Did one story return a list where another expects a dict? Check type consistency across story boundaries.
+
+### 4B.2: Architecture Coherence
+- Read the PRD goals section. For each goal, verify the combined implementation achieves it end-to-end (not just per-story acceptance criteria).
+- Check that the feature's data flow is complete: config → filtering → generation → validation → output. No stage should be half-wired.
+- Verify backward compatibility: run the test suite with the feature **disabled** (default config) and confirm identical behavior to the base branch.
+
+### 4B.3: Security and Quality
+- Grep the full diff for hardcoded secrets, TODO/FIXME/HACK comments, disabled tests, and `# type: ignore` suppressions.
+- Check error handling at feature boundaries: what happens when image_mode=True but no images exist? When the Vision API is unreachable?
+- Review any new async code for missing `await`, unhandled exceptions, or resource leaks.
+
+### 4B.4: Disposition
+- **If issues found:** Fix them inline, re-run tests, commit with `fix: <description>`.
+- **If clean:** Proceed to Step 5.
+- **Log:** Print a summary: `[FEATURE REVIEW] N files changed, M issues found (X fixed, Y deferred)`
+
+This review is NOT optional. Per-story reviews miss cross-cutting concerns. Field data: the most common post-merge issues (duplicate helpers, inconsistent naming, half-wired pipelines) are only visible at the full-feature level.
+
 ## Step 5: Generate Execution Observations
 
 After the main loop exits (COMPLETE, BLOCKED, or max iterations), generate an observations document:

--- a/lib/dag-query.sh
+++ b/lib/dag-query.sh
@@ -118,20 +118,27 @@ filter_file_conflicts() {
 
     # Greedily select stories: for each story in priority order,
     # include it only if none of its files overlap with already-selected stories.
+    # Note: we bind the accumulator to named variables ($claimed, $sel) inside
+    # the reduce body because jq `env` refers to shell $ENV, not the accumulator.
     reduce $eligible_stories[] as $story (
       {selected: [], claimed_files: []};
-      if ([$story.files[] | . as $f | select(
-            [.] | inside([env.claimed_files[]?]) | not
-          )] | length) == ($story.files | length)
+      .claimed_files as $claimed |
+      .selected as $sel |
+      if (
+            # Check filePaths overlap: every file in this story must NOT already
+            # be claimed. Use index() for exact-match (not inside/substring).
+            ([$story.files[] | select(. as $f | $claimed | index($f) | not)]
+             | length) == ($story.files | length)
+         )
          and
-         # Check fileConflicts: no conflict entry includes both this story
-         # and an already-selected story
          (
+           # Check fileConflicts: no conflict entry includes both this story
+           # and an already-selected story
            [ $conflict_entries[] |
              select(
                (.stories | index($story.id)) and
                ([.stories[] | . as $s | select(
-                 [env.selected[] | .id] | index($s)
+                 [$sel[].id] | index($s)
                )] | length > 0)
              )
            ] | length == 0

--- a/lib/dag-query.sh
+++ b/lib/dag-query.sh
@@ -99,6 +99,15 @@ filter_file_conflicts() {
   local json_path="$1"
   local eligible="$2"
 
+  if [[ -z "$json_path" || ! -f "$json_path" ]]; then
+    printf "ERROR: filter_file_conflicts requires a valid JSON file path\n" >&2
+    return 1
+  fi
+  if [[ -z "$eligible" ]]; then
+    printf "ERROR: filter_file_conflicts requires eligible IDs JSON array\n" >&2
+    return 1
+  fi
+
   jq -r --argjson eligible "$eligible" '
     .stories as $all |
     .fileConflicts as $fc |

--- a/lib/dag-query.sh
+++ b/lib/dag-query.sh
@@ -88,3 +88,61 @@ detect_cycles() {
   fi
   return 0
 }
+
+# filter_file_conflicts(quantum_json_path, eligible_ids_json_array)
+# Given a JSON array of eligible story IDs, filters out stories that share
+# file paths (via tasks[].filePaths or fileConflicts) with higher-priority
+# stories in the same wave. Returns a filtered JSON array.
+#
+# Example: filter_file_conflicts quantum.json '["US-001","US-002","US-003"]'
+filter_file_conflicts() {
+  local json_path="$1"
+  local eligible="$2"
+
+  jq -r --argjson eligible "$eligible" '
+    .stories as $all |
+    .fileConflicts as $fc |
+
+    # Build a map of story_id -> set of file paths (from tasks)
+    (
+      [ $all[] | select(.id as $id | $eligible | index($id)) |
+        {id: .id, priority: (.priority // 999),
+         files: [.tasks[]? | .filePaths[]?]}
+      ] | sort_by(.priority)
+    ) as $eligible_stories |
+
+    # Also include fileConflicts entries
+    (
+      [$fc[]? | {file: .file, stories: .stories}]
+    ) as $conflict_entries |
+
+    # Greedily select stories: for each story in priority order,
+    # include it only if none of its files overlap with already-selected stories.
+    reduce $eligible_stories[] as $story (
+      {selected: [], claimed_files: []};
+      if ([$story.files[] | . as $f | select(
+            [.] | inside([env.claimed_files[]?]) | not
+          )] | length) == ($story.files | length)
+         and
+         # Check fileConflicts: no conflict entry includes both this story
+         # and an already-selected story
+         (
+           [ $conflict_entries[] |
+             select(
+               (.stories | index($story.id)) and
+               ([.stories[] | . as $s | select(
+                 [env.selected[] | .id] | index($s)
+               )] | length > 0)
+             )
+           ] | length == 0
+         )
+      then
+        .selected += [$story] |
+        .claimed_files += $story.files
+      else
+        .
+      end
+    ) |
+    [.selected[].id]
+  ' "$json_path"
+}

--- a/lib/dag-query.sh
+++ b/lib/dag-query.sh
@@ -82,7 +82,7 @@ detect_cycles() {
     if any then "CYCLE_DETECTED" else "NO_CYCLES" end
   ' "$json_path")
 
-  echo "$result"
+  printf "%s\n" "$result"
   if [[ "$result" == *"CYCLE"* ]]; then
     return 1
   fi
@@ -112,6 +112,15 @@ filter_file_conflicts() {
     .stories as $all |
     .fileConflicts as $fc |
 
+    # Collect files already claimed by in_progress stories (from prior waves).
+    # This prevents cross-wave file conflicts when a new wave spawns while
+    # a previous wave is still running.
+    (
+      [ $all[] | select(.status == "in_progress") |
+        .tasks[]? | .filePaths[]?
+      ]
+    ) as $in_progress_files |
+
     # Build a map of story_id -> set of file paths (from tasks)
     (
       [ $all[] | select(.id as $id | $eligible | index($id)) |
@@ -126,11 +135,12 @@ filter_file_conflicts() {
     ) as $conflict_entries |
 
     # Greedily select stories: for each story in priority order,
-    # include it only if none of its files overlap with already-selected stories.
+    # include it only if none of its files overlap with already-selected stories
+    # OR with in_progress stories from prior waves.
     # Note: we bind the accumulator to named variables ($claimed, $sel) inside
     # the reduce body because jq `env` refers to shell $ENV, not the accumulator.
     reduce $eligible_stories[] as $story (
-      {selected: [], claimed_files: []};
+      {selected: [], claimed_files: $in_progress_files};
       .claimed_files as $claimed |
       .selected as $sel |
       if (

--- a/lib/spawn.sh
+++ b/lib/spawn.sh
@@ -27,6 +27,13 @@ Implement story ${story_id} following the instructions in CLAUDE.md.
 IMPORTANT: You are running in a worktree (.ql-wt/). Do NOT write quantum.json.
 The orchestrator manages all state.
 
+IMPORTANT — Python projects: Do NOT run 'pip install -e .' in the worktree.
+Parallel worktrees share one Python environment, so editable installs race.
+Instead, set PYTHONPATH before running tests:
+  export PYTHONPATH="\$(pwd)/src:\$PYTHONPATH"
+Or for inline commands:
+  PYTHONPATH=src python -m pytest tests/ -x -v
+
 Your workflow:
 1. Read quantum.json for story details, PRD path, and codebasePatterns
 2. Implement all tasks in order (TDD if testFirst is true)

--- a/lib/spawn.sh
+++ b/lib/spawn.sh
@@ -29,10 +29,10 @@ The orchestrator manages all state.
 
 IMPORTANT — Python projects: Do NOT run 'pip install -e .' in the worktree.
 Parallel worktrees share one Python environment, so editable installs race.
-Instead, set PYTHONPATH before running tests:
-  export PYTHONPATH="\$(pwd)/src:\$PYTHONPATH"
-Or for inline commands:
-  PYTHONPATH=src python -m pytest tests/ -x -v
+Instead, set PYTHONPATH before running tests (check pyproject.toml for the source root):
+  # For src-layout projects:  export PYTHONPATH="\$(pwd)/src:\$PYTHONPATH"
+  # For flat-layout projects: export PYTHONPATH="\$(pwd):\$PYTHONPATH"
+Verify correct import: python -c "import <module>; print(<module>.__file__)"
 
 Your workflow:
 1. Read quantum.json for story details, PRD path, and codebasePatterns

--- a/lib/worktree.sh
+++ b/lib/worktree.sh
@@ -1,10 +1,55 @@
 #!/usr/bin/env bash
 # lib/worktree.sh -- Git worktree lifecycle functions for quantum-loop
 # Source this file to use create_worktree(), remove_worktree(), list_worktrees()
+# Requires: Git >= 2.20
 
 # Source shared utilities
 WORKTREE_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$WORKTREE_LIB_DIR/common.sh" || { printf "ERROR: common.sh not found\n" >&2; return 1 2>/dev/null || exit 1; }
+
+# _resolve_repo_root(repo_root)
+# Resolves a potentially-nested worktree path to the top-level repository root.
+# Prevents worktree-inside-worktree nesting that causes exponential path growth.
+# Falls back to the input path if resolution fails (e.g., not a git repo).
+_resolve_repo_root() {
+  local repo_root="$1"
+  local real_root
+
+  # Try --path-format=absolute first (Git >= 2.31), fall back without it (Git >= 2.20)
+  real_root=$(git -C "$repo_root" rev-parse --path-format=absolute --git-common-dir 2>/dev/null \
+              || git -C "$repo_root" rev-parse --git-common-dir 2>/dev/null)
+
+  # Normalize relative path (git-common-dir may return relative like "../.git")
+  if [[ -n "$real_root" && "$real_root" != /* ]]; then
+    real_root="$(cd "$repo_root" && cd "$(dirname "$real_root")" && pwd)/$(basename "$real_root")"
+  fi
+
+  # Strip trailing /.git to get the repo root directory
+  real_root=$(printf "%s" "$real_root" | sed 's|[/\\]\.git$||')
+
+  if [[ -n "$real_root" && -d "$real_root" && "$real_root" != "$repo_root" ]]; then
+    printf "%s" "$real_root"
+  else
+    printf "%s" "$repo_root"
+  fi
+}
+
+# _short_path_base(repo_root)
+# Returns the namespaced short-path fallback directory for this repo.
+# Uses a hash of the repo root to prevent cross-repo collisions in /tmp.
+_short_path_base() {
+  local repo_root="$1"
+  local repo_hash
+  # Use md5sum if available, else cksum, else just the basename
+  if command -v md5sum &>/dev/null; then
+    repo_hash=$(printf "%s" "$repo_root" | md5sum | cut -c1-8)
+  elif command -v cksum &>/dev/null; then
+    repo_hash=$(printf "%s" "$repo_root" | cksum | cut -d' ' -f1)
+  else
+    repo_hash=$(basename "$repo_root")
+  fi
+  printf "%s/ql-wt-%s" "${TMPDIR:-/tmp}" "$repo_hash"
+}
 
 # create_worktree(story_id, branch_name, repo_root)
 # Creates a worktree at <repo_root>/.ql-wt/<story_id>/ branched from branch_name HEAD.
@@ -22,24 +67,17 @@ create_worktree() {
   fi
   _validate_story_id "$story_id" || return 1
 
-  local wt_path="$repo_root/.ql-wt/$story_id"
+  # Resolve to top-level repo root to prevent worktree nesting
+  repo_root=$(_resolve_repo_root "$repo_root")
 
-  # Resolve to top-level repo root (not a nested worktree) to prevent worktree nesting.
-  # Without this, agents spawned inside worktrees create .ql-wt/ inside .ql-wt/, leading
-  # to exponentially growing paths that hit OS limits after 2-3 waves.
-  local real_root
-  real_root=$(git -C "$repo_root" rev-parse --path-format=absolute --git-common-dir 2>/dev/null | sed 's|/\.git$||')
-  if [[ -n "$real_root" && "$real_root" != "$repo_root" ]]; then
-    printf "INFO: Resolved nested repo_root to top-level: %s\n" "$real_root" >&2
-    repo_root="$real_root"
-    wt_path="$repo_root/.ql-wt/$story_id"
-  fi
+  local wt_path="$repo_root/.ql-wt/$story_id"
 
   # Windows long-path guard: if the worktree path exceeds 200 chars, use a shorter location.
   # This prevents "fatal: '$GIT_DIR' too big" errors on Windows+OneDrive.
   local orig_len=${#wt_path}
   if [[ $orig_len -gt 200 ]]; then
-    local short_base="${TMPDIR:-/tmp}/ql-wt"
+    local short_base
+    short_base=$(_short_path_base "$repo_root")
     mkdir -p "$short_base"
     wt_path="$short_base/$story_id"
     printf "WARN: Default worktree path too long (%d chars), using %s\n" "$orig_len" "$wt_path" >&2
@@ -69,24 +107,32 @@ remove_worktree() {
   fi
   _validate_story_id "$story_id" || return 1
 
+  # Resolve to top-level repo root (same resolution as create_worktree)
+  repo_root=$(_resolve_repo_root "$repo_root")
+
   local wt_path="$repo_root/.ql-wt/$story_id"
 
   # Also check the short-path fallback location (used when long paths are detected)
-  local short_path="${TMPDIR:-/tmp}/ql-wt/$story_id"
+  local short_base
+  short_base=$(_short_path_base "$repo_root")
+  local short_path="$short_base/$story_id"
 
   for path in "$wt_path" "$short_path"; do
     if [[ -d "$path" ]]; then
       # Retry loop for Windows file locks
+      local removed=false
       local attempt=0
       while [[ $attempt -lt 3 ]]; do
-        git -C "$repo_root" worktree remove --force "$path" 2>/dev/null && break
+        git -C "$repo_root" worktree remove --force "$path" 2>/dev/null && { removed=true; break; }
         attempt=$((attempt + 1))
         if [[ $attempt -lt 3 ]]; then
           sleep 2
         fi
       done
-      # Fallback: force-remove directory if git worktree remove failed
-      rm -rf "$path" 2>/dev/null || true
+      # Fallback: force-remove directory only if git worktree remove failed
+      if [[ "$removed" != "true" && -d "$path" ]]; then
+        rm -rf "$path" 2>/dev/null || true
+      fi
     fi
   done
 
@@ -102,7 +148,8 @@ remove_worktree() {
 
 # list_worktrees(repo_root)
 # Returns newline-separated list of active worktree story IDs.
-# Checks both the default location (.ql-wt/) and the short-path fallback (/tmp/ql-wt/).
+# Checks both the default location (.ql-wt/) and the repo-namespaced
+# short-path fallback (/tmp/ql-wt-<hash>/).
 list_worktrees() {
   local repo_root="$1"
 
@@ -111,10 +158,14 @@ list_worktrees() {
     return 1
   fi
 
-  local wt_dir="$repo_root/.ql-wt"
-  local short_dir="${TMPDIR:-/tmp}/ql-wt"
+  # Resolve to top-level repo root (same resolution as create/remove)
+  repo_root=$(_resolve_repo_root "$repo_root")
 
-  # List directories under both locations that are actual git worktrees
+  local wt_dir="$repo_root/.ql-wt"
+  local short_dir
+  short_dir=$(_short_path_base "$repo_root")
+
+  # List directories under both locations
   for search_dir in "$wt_dir" "$short_dir"; do
     if [[ -d "$search_dir" ]]; then
       for dir in "$search_dir"/*/; do

--- a/lib/worktree.sh
+++ b/lib/worktree.sh
@@ -8,6 +8,8 @@ source "$WORKTREE_LIB_DIR/common.sh" || { printf "ERROR: common.sh not found\n" 
 
 # create_worktree(story_id, branch_name, repo_root)
 # Creates a worktree at <repo_root>/.ql-wt/<story_id>/ branched from branch_name HEAD.
+# On Windows with long paths (OneDrive, deep directories), falls back to a shorter
+# temp-directory location if the default path exceeds 200 characters.
 # Returns 0 on success, 1 on failure.
 create_worktree() {
   local story_id="$1"
@@ -22,8 +24,17 @@ create_worktree() {
 
   local wt_path="$repo_root/.ql-wt/$story_id"
 
-  # Ensure .ql-wt directory exists
-  mkdir -p "$repo_root/.ql-wt"
+  # Windows long-path guard: if the worktree path exceeds 200 chars, use a shorter location.
+  # This prevents "fatal: '$GIT_DIR' too big" errors on Windows+OneDrive.
+  if [[ ${#wt_path} -gt 200 ]]; then
+    local short_base="${TMPDIR:-/tmp}/ql-wt"
+    mkdir -p "$short_base"
+    wt_path="$short_base/$story_id"
+    printf "WARN: Default worktree path too long (%d chars), using %s\n" "${#wt_path}" "$wt_path" >&2
+  fi
+
+  # Ensure parent directory exists
+  mkdir -p "$(dirname "$wt_path")"
 
   # Create worktree with a new branch for this story, based on the feature branch
   local wt_branch="ql-wt/${story_id}"
@@ -34,6 +45,8 @@ create_worktree() {
 # remove_worktree(story_id, repo_root)
 # Removes the worktree at <repo_root>/.ql-wt/<story_id>/.
 # Idempotent: returns 0 even if the worktree doesn't exist.
+# On Windows, retries up to 3 times with a short delay to handle file locks
+# (OneDrive sync, Python __pycache__, etc.).
 remove_worktree() {
   local story_id="$1"
   local repo_root="$2"
@@ -46,16 +59,31 @@ remove_worktree() {
 
   local wt_path="$repo_root/.ql-wt/$story_id"
 
-  if [[ -d "$wt_path" ]]; then
-    git -C "$repo_root" worktree remove --force "$wt_path" 2>/dev/null || true
-  fi
+  # Also check the short-path fallback location (used when long paths are detected)
+  local short_path="${TMPDIR:-/tmp}/ql-wt/$story_id"
+
+  for path in "$wt_path" "$short_path"; do
+    if [[ -d "$path" ]]; then
+      # Retry loop for Windows file locks
+      local attempt=0
+      while [[ $attempt -lt 3 ]]; do
+        git -C "$repo_root" worktree remove --force "$path" 2>/dev/null && break
+        attempt=$((attempt + 1))
+        if [[ $attempt -lt 3 ]]; then
+          sleep 2
+        fi
+      done
+      # Fallback: force-remove directory if git worktree remove failed
+      rm -rf "$path" 2>/dev/null || true
+    fi
+  done
 
   # Clean up the worktree branch
   local wt_branch="ql-wt/${story_id}"
   git -C "$repo_root" branch -D "$wt_branch" 2>/dev/null || true
 
-  # Remove directory if still present (edge case)
-  rm -rf "$wt_path" 2>/dev/null || true
+  # Prune stale worktree references
+  git -C "$repo_root" worktree prune 2>/dev/null || true
 
   return 0
 }

--- a/lib/worktree.sh
+++ b/lib/worktree.sh
@@ -24,13 +24,25 @@ create_worktree() {
 
   local wt_path="$repo_root/.ql-wt/$story_id"
 
+  # Resolve to top-level repo root (not a nested worktree) to prevent worktree nesting.
+  # Without this, agents spawned inside worktrees create .ql-wt/ inside .ql-wt/, leading
+  # to exponentially growing paths that hit OS limits after 2-3 waves.
+  local real_root
+  real_root=$(git -C "$repo_root" rev-parse --path-format=absolute --git-common-dir 2>/dev/null | sed 's|/\.git$||')
+  if [[ -n "$real_root" && "$real_root" != "$repo_root" ]]; then
+    printf "INFO: Resolved nested repo_root to top-level: %s\n" "$real_root" >&2
+    repo_root="$real_root"
+    wt_path="$repo_root/.ql-wt/$story_id"
+  fi
+
   # Windows long-path guard: if the worktree path exceeds 200 chars, use a shorter location.
   # This prevents "fatal: '$GIT_DIR' too big" errors on Windows+OneDrive.
-  if [[ ${#wt_path} -gt 200 ]]; then
+  local orig_len=${#wt_path}
+  if [[ $orig_len -gt 200 ]]; then
     local short_base="${TMPDIR:-/tmp}/ql-wt"
     mkdir -p "$short_base"
     wt_path="$short_base/$story_id"
-    printf "WARN: Default worktree path too long (%d chars), using %s\n" "${#wt_path}" "$wt_path" >&2
+    printf "WARN: Default worktree path too long (%d chars), using %s\n" "$orig_len" "$wt_path" >&2
   fi
 
   # Ensure parent directory exists
@@ -89,7 +101,8 @@ remove_worktree() {
 }
 
 # list_worktrees(repo_root)
-# Returns newline-separated list of active worktree story IDs (those under .ql-wt/).
+# Returns newline-separated list of active worktree story IDs.
+# Checks both the default location (.ql-wt/) and the short-path fallback (/tmp/ql-wt/).
 list_worktrees() {
   local repo_root="$1"
 
@@ -99,14 +112,16 @@ list_worktrees() {
   fi
 
   local wt_dir="$repo_root/.ql-wt"
-  if [[ ! -d "$wt_dir" ]]; then
-    return 0
-  fi
+  local short_dir="${TMPDIR:-/tmp}/ql-wt"
 
-  # List directories under .ql-wt/ that are actual git worktrees
-  for dir in "$wt_dir"/*/; do
-    if [[ -d "$dir" ]]; then
-      basename "$dir"
+  # List directories under both locations that are actual git worktrees
+  for search_dir in "$wt_dir" "$short_dir"; do
+    if [[ -d "$search_dir" ]]; then
+      for dir in "$search_dir"/*/; do
+        if [[ -d "$dir" ]]; then
+          basename "$dir"
+        fi
+      done
     fi
-  done
+  done | sort -u  # Deduplicate in case a story appears in both locations
 }

--- a/lib/worktree.sh
+++ b/lib/worktree.sh
@@ -30,6 +30,13 @@ _resolve_repo_root() {
   if [[ -n "$real_root" && -d "$real_root" && "$real_root" != "$repo_root" ]]; then
     printf "%s" "$real_root"
   else
+    # Warn if the fallback path looks like it is inside a .ql-wt/ directory,
+    # which would indicate we are inside a worktree but git resolution failed.
+    if [[ "$repo_root" == */.ql-wt/* ]]; then
+      printf "WARN: _resolve_repo_root: input path appears to be inside a worktree (%s). " \
+          "$repo_root" >&2
+      printf "Git resolution failed; cannot prevent nesting.\n" >&2
+    fi
     printf "%s" "$repo_root"
   fi
 }
@@ -80,7 +87,15 @@ create_worktree() {
     short_base=$(_short_path_base "$repo_root")
     mkdir -p "$short_base"
     wt_path="$short_base/$story_id"
-    printf "WARN: Default worktree path too long (%d chars), using %s\n" "$orig_len" "$wt_path" >&2
+    local new_len=${#wt_path}
+    printf "WARN: Default worktree path too long (%d chars), using %s (%d chars)\n" \
+        "$orig_len" "$wt_path" "$new_len" >&2
+    # Last resort: if even the short path is too long, use a bare /tmp path
+    if [[ $new_len -gt 200 ]]; then
+      wt_path="/tmp/ql-wt-$(printf "%s" "$story_id" | md5sum 2>/dev/null | cut -c1-6 || echo "$story_id")"
+      printf "WARN: Short-path fallback still too long (%d chars), using emergency path %s\n" \
+          "$new_len" "$wt_path" >&2
+    fi
   fi
 
   # Ensure parent directory exists

--- a/quantum-loop.sh
+++ b/quantum-loop.sh
@@ -413,6 +413,9 @@ if [[ "$PARALLEL_MODE" == "true" ]]; then
       exit 1
     fi
 
+    # Filter out stories that share files with higher-priority stories in this wave
+    EXECUTABLE=$(filter_file_conflicts "$REPO_ROOT/quantum.json" "$EXECUTABLE")
+
     # Count executable stories
     EXEC_COUNT=$(echo "$EXECUTABLE" | jq '. | length')
     WAVE=$((WAVE + 1))
@@ -648,6 +651,7 @@ if [[ "$PARALLEL_MODE" == "true" ]]; then
       if [[ ${#local_completed[@]} -gt 0 && ${#AGENT_PIDS[@]} -lt $MAX_PARALLEL ]]; then
         NEW_EXEC=$(get_executable_stories "$REPO_ROOT/quantum.json")
         if [[ "$NEW_EXEC" != "COMPLETE" && "$NEW_EXEC" != "BLOCKED" && -n "$NEW_EXEC" ]]; then
+          NEW_EXEC=$(filter_file_conflicts "$REPO_ROOT/quantum.json" "$NEW_EXEC")
           NEW_COUNT=$(echo "$NEW_EXEC" | jq '. | length')
           WAVE=$((WAVE + 1))
           for ni in $(seq 0 $((NEW_COUNT - 1))); do

--- a/tests/test_dag_query.sh
+++ b/tests/test_dag_query.sh
@@ -290,7 +290,43 @@ assert_not_contains "US-003 excluded (conflict)" "US-003" "$RESULT"
 rm -f "$TMPJSON"
 
 # =========================================================================
-echo "=== Test 14: filter_file_conflicts — similar but different paths ==="
+echo "=== Test 14: filter_file_conflicts — null fileConflicts ==="
+TMPJSON=$(mktemp)
+cat > "$TMPJSON" << 'EOF'
+{
+  "stories": [
+    {"id": "US-001", "priority": 1, "status": "pending", "dependsOn": [], "tasks": [{"filePaths": ["src/a.ts"]}], "retries": {"attempts": 0, "maxAttempts": 3}},
+    {"id": "US-002", "priority": 2, "status": "pending", "dependsOn": [], "tasks": [{"filePaths": ["src/b.ts"]}], "retries": {"attempts": 0, "maxAttempts": 3}}
+  ],
+  "fileConflicts": null
+}
+EOF
+RESULT=$(filter_file_conflicts "$TMPJSON" '["US-001","US-002"]')
+assert_contains "US-001 with null fileConflicts" "US-001" "$RESULT"
+assert_contains "US-002 with null fileConflicts" "US-002" "$RESULT"
+rm -f "$TMPJSON"
+
+# =========================================================================
+echo "=== Test 15: filter_file_conflicts — transitive conflict chain ==="
+TMPJSON=$(mktemp)
+cat > "$TMPJSON" << 'EOF'
+{
+  "stories": [
+    {"id": "US-001", "priority": 1, "status": "pending", "dependsOn": [], "tasks": [{"filePaths": ["src/a.ts"]}], "retries": {"attempts": 0, "maxAttempts": 3}},
+    {"id": "US-002", "priority": 2, "status": "pending", "dependsOn": [], "tasks": [{"filePaths": ["src/a.ts", "src/b.ts"]}], "retries": {"attempts": 0, "maxAttempts": 3}},
+    {"id": "US-003", "priority": 3, "status": "pending", "dependsOn": [], "tasks": [{"filePaths": ["src/b.ts"]}], "retries": {"attempts": 0, "maxAttempts": 3}}
+  ],
+  "fileConflicts": []
+}
+EOF
+RESULT=$(filter_file_conflicts "$TMPJSON" '["US-001","US-002","US-003"]')
+assert_contains "US-001 included (claims src/a.ts)" "US-001" "$RESULT"
+assert_not_contains "US-002 excluded (src/a.ts conflict with US-001)" "US-002" "$RESULT"
+assert_contains "US-003 included (src/b.ts unclaimed — US-002 was excluded)" "US-003" "$RESULT"
+rm -f "$TMPJSON"
+
+# =========================================================================
+echo "=== Test 16: filter_file_conflicts — similar-but-different paths ==="
 TMPJSON=$(mktemp)
 cat > "$TMPJSON" << 'EOF'
 {

--- a/tests/test_dag_query.sh
+++ b/tests/test_dag_query.sh
@@ -196,6 +196,117 @@ assert_contains "US-003 eligible" "US-003" "$RESULT"
 rm -f "$TMPJSON"
 
 # =========================================================================
+# =========================================================================
+echo "=== Test 9: filter_file_conflicts — filePaths overlap ==="
+TMPJSON=$(mktemp)
+cat > "$TMPJSON" << 'EOF'
+{
+  "stories": [
+    {"id": "US-001", "priority": 1, "status": "pending", "dependsOn": [], "tasks": [{"filePaths": ["src/a.ts", "src/b.ts"]}], "retries": {"attempts": 0, "maxAttempts": 3}},
+    {"id": "US-002", "priority": 2, "status": "pending", "dependsOn": [], "tasks": [{"filePaths": ["src/b.ts", "src/c.ts"]}], "retries": {"attempts": 0, "maxAttempts": 3}},
+    {"id": "US-003", "priority": 3, "status": "pending", "dependsOn": [], "tasks": [{"filePaths": ["src/d.ts"]}], "retries": {"attempts": 0, "maxAttempts": 3}}
+  ],
+  "fileConflicts": []
+}
+EOF
+RESULT=$(filter_file_conflicts "$TMPJSON" '["US-001","US-002","US-003"]')
+assert_contains "US-001 included (highest priority)" "US-001" "$RESULT"
+assert_not_contains "US-002 excluded (shares src/b.ts with US-001)" "US-002" "$RESULT"
+assert_contains "US-003 included (no conflict)" "US-003" "$RESULT"
+rm -f "$TMPJSON"
+
+# =========================================================================
+echo "=== Test 10: filter_file_conflicts — fileConflicts entry ==="
+TMPJSON=$(mktemp)
+cat > "$TMPJSON" << 'EOF'
+{
+  "stories": [
+    {"id": "US-001", "priority": 1, "status": "pending", "dependsOn": [], "tasks": [{"filePaths": ["src/x.ts"]}], "retries": {"attempts": 0, "maxAttempts": 3}},
+    {"id": "US-002", "priority": 2, "status": "pending", "dependsOn": [], "tasks": [{"filePaths": ["src/y.ts"]}], "retries": {"attempts": 0, "maxAttempts": 3}},
+    {"id": "US-003", "priority": 3, "status": "pending", "dependsOn": [], "tasks": [{"filePaths": ["src/z.ts"]}], "retries": {"attempts": 0, "maxAttempts": 3}}
+  ],
+  "fileConflicts": [{"file": "src/shared.ts", "stories": ["US-001", "US-003"]}]
+}
+EOF
+RESULT=$(filter_file_conflicts "$TMPJSON" '["US-001","US-002","US-003"]')
+assert_contains "US-001 included" "US-001" "$RESULT"
+assert_contains "US-002 included (no conflict)" "US-002" "$RESULT"
+assert_not_contains "US-003 excluded (fileConflict with US-001)" "US-003" "$RESULT"
+rm -f "$TMPJSON"
+
+# =========================================================================
+echo "=== Test 11: filter_file_conflicts — empty filePaths ==="
+TMPJSON=$(mktemp)
+cat > "$TMPJSON" << 'EOF'
+{
+  "stories": [
+    {"id": "US-001", "priority": 1, "status": "pending", "dependsOn": [], "tasks": [{"filePaths": []}], "retries": {"attempts": 0, "maxAttempts": 3}},
+    {"id": "US-002", "priority": 2, "status": "pending", "dependsOn": [], "tasks": [], "retries": {"attempts": 0, "maxAttempts": 3}}
+  ],
+  "fileConflicts": []
+}
+EOF
+RESULT=$(filter_file_conflicts "$TMPJSON" '["US-001","US-002"]')
+assert_contains "US-001 included (empty filePaths)" "US-001" "$RESULT"
+assert_contains "US-002 included (no tasks)" "US-002" "$RESULT"
+rm -f "$TMPJSON"
+
+# =========================================================================
+echo "=== Test 12: filter_file_conflicts — no conflicts ==="
+TMPJSON=$(mktemp)
+cat > "$TMPJSON" << 'EOF'
+{
+  "stories": [
+    {"id": "US-001", "priority": 1, "status": "pending", "dependsOn": [], "tasks": [{"filePaths": ["src/a.ts"]}], "retries": {"attempts": 0, "maxAttempts": 3}},
+    {"id": "US-002", "priority": 2, "status": "pending", "dependsOn": [], "tasks": [{"filePaths": ["src/b.ts"]}], "retries": {"attempts": 0, "maxAttempts": 3}},
+    {"id": "US-003", "priority": 3, "status": "pending", "dependsOn": [], "tasks": [{"filePaths": ["src/c.ts"]}], "retries": {"attempts": 0, "maxAttempts": 3}}
+  ],
+  "fileConflicts": []
+}
+EOF
+RESULT=$(filter_file_conflicts "$TMPJSON" '["US-001","US-002","US-003"]')
+assert_contains "US-001 included" "US-001" "$RESULT"
+assert_contains "US-002 included" "US-002" "$RESULT"
+assert_contains "US-003 included" "US-003" "$RESULT"
+rm -f "$TMPJSON"
+
+# =========================================================================
+echo "=== Test 13: filter_file_conflicts — three-way conflict ==="
+TMPJSON=$(mktemp)
+cat > "$TMPJSON" << 'EOF'
+{
+  "stories": [
+    {"id": "US-001", "priority": 1, "status": "pending", "dependsOn": [], "tasks": [{"filePaths": ["src/shared.ts"]}], "retries": {"attempts": 0, "maxAttempts": 3}},
+    {"id": "US-002", "priority": 2, "status": "pending", "dependsOn": [], "tasks": [{"filePaths": ["src/shared.ts"]}], "retries": {"attempts": 0, "maxAttempts": 3}},
+    {"id": "US-003", "priority": 3, "status": "pending", "dependsOn": [], "tasks": [{"filePaths": ["src/shared.ts"]}], "retries": {"attempts": 0, "maxAttempts": 3}}
+  ],
+  "fileConflicts": []
+}
+EOF
+RESULT=$(filter_file_conflicts "$TMPJSON" '["US-001","US-002","US-003"]')
+assert_contains "US-001 included (highest priority)" "US-001" "$RESULT"
+assert_not_contains "US-002 excluded (conflict)" "US-002" "$RESULT"
+assert_not_contains "US-003 excluded (conflict)" "US-003" "$RESULT"
+rm -f "$TMPJSON"
+
+# =========================================================================
+echo "=== Test 14: filter_file_conflicts — similar but different paths ==="
+TMPJSON=$(mktemp)
+cat > "$TMPJSON" << 'EOF'
+{
+  "stories": [
+    {"id": "US-001", "priority": 1, "status": "pending", "dependsOn": [], "tasks": [{"filePaths": ["src/a.ts"]}], "retries": {"attempts": 0, "maxAttempts": 3}},
+    {"id": "US-002", "priority": 2, "status": "pending", "dependsOn": [], "tasks": [{"filePaths": ["src/a.tsx"]}], "retries": {"attempts": 0, "maxAttempts": 3}}
+  ],
+  "fileConflicts": []
+}
+EOF
+RESULT=$(filter_file_conflicts "$TMPJSON" '["US-001","US-002"]')
+assert_contains "US-001 included" "US-001" "$RESULT"
+assert_contains "US-002 included (a.tsx != a.ts, exact match)" "US-002" "$RESULT"
+rm -f "$TMPJSON"
+
+# =========================================================================
 echo ""
 echo "=== Results: $PASS/$TOTAL passed, $FAIL failed ==="
 if [[ $FAIL -eq 0 ]]; then

--- a/tests/test_spawn.sh
+++ b/tests/test_spawn.sh
@@ -67,26 +67,34 @@ PROMPT=$(build_agent_prompt "US-003")
 assert_contains "Prompt warns about quantum.json" "quantum.json" "$PROMPT"
 
 # =========================================================================
-echo "=== Test 3: build_autonomous_command generates correct command ==="
+echo "=== Test 3: build_agent_prompt includes PYTHONPATH instruction ==="
+PROMPT=$(build_agent_prompt "US-003")
+assert_contains "Prompt warns against pip install -e ." "pip install -e ." "$PROMPT"
+assert_contains "Prompt includes PYTHONPATH" "PYTHONPATH" "$PROMPT"
+assert_contains "Prompt covers src-layout" "src-layout" "$PROMPT"
+assert_contains "Prompt covers flat-layout" "flat-layout" "$PROMPT"
+
+# =========================================================================
+echo "=== Test 4: build_autonomous_command generates correct command ==="
 CMD=$(build_autonomous_command "US-003" "/tmp/test-wt")
 assert_contains "Command includes worktree path" "/tmp/test-wt" "$CMD"
 assert_contains "Command includes story ID" "US-003" "$CMD"
 assert_contains "Command uses claude" "claude" "$CMD"
 
 # =========================================================================
-echo "=== Test 4: Input validation - empty story_id ==="
+echo "=== Test 5: Input validation - empty story_id ==="
 RESULT=$(build_agent_prompt "" 2>&1)
 EXIT_CODE=$?
 assert_eq "Empty story_id returns error" "1" "$EXIT_CODE"
 
 # =========================================================================
-echo "=== Test 5: Input validation - invalid story_id format ==="
+echo "=== Test 6: Input validation - invalid story_id format ==="
 RESULT=$(build_agent_prompt "../hack" 2>&1)
 EXIT_CODE=$?
 assert_eq "Invalid story_id returns error" "1" "$EXIT_CODE"
 
 # =========================================================================
-echo "=== Test 6: build_autonomous_command validates inputs ==="
+echo "=== Test 7: build_autonomous_command validates inputs ==="
 RESULT=$(build_autonomous_command "" "/tmp/wt" 2>&1)
 EXIT_CODE=$?
 assert_eq "Empty story_id in command returns error" "1" "$EXIT_CODE"
@@ -96,28 +104,28 @@ EXIT_CODE=$?
 assert_eq "Empty worktree_path in command returns error" "1" "$EXIT_CODE"
 
 # =========================================================================
-echo "=== Test 7: spawn_autonomous rejects empty story_id ==="
+echo "=== Test 8: spawn_autonomous rejects empty story_id ==="
 RESULT=$(spawn_autonomous "" "/tmp/wt" 2>&1)
 EXIT_CODE=$?
 assert_eq "spawn_autonomous empty story_id returns error" "1" "$EXIT_CODE"
 assert_contains "spawn_autonomous empty story_id error message" "story_id is required" "$RESULT"
 
 # =========================================================================
-echo "=== Test 8: spawn_autonomous rejects empty worktree_path ==="
+echo "=== Test 9: spawn_autonomous rejects empty worktree_path ==="
 RESULT=$(spawn_autonomous "US-001" "" 2>&1)
 EXIT_CODE=$?
 assert_eq "spawn_autonomous empty worktree_path returns error" "1" "$EXIT_CODE"
 assert_contains "spawn_autonomous empty worktree_path error message" "worktree_path is required" "$RESULT"
 
 # =========================================================================
-echo "=== Test 9: spawn_autonomous rejects nonexistent worktree_path ==="
+echo "=== Test 10: spawn_autonomous rejects nonexistent worktree_path ==="
 RESULT=$(spawn_autonomous "US-001" "/tmp/nonexistent-path-$$" 2>&1)
 EXIT_CODE=$?
 assert_eq "spawn_autonomous nonexistent worktree_path returns error" "1" "$EXIT_CODE"
 assert_contains "spawn_autonomous nonexistent path error message" "does not exist" "$RESULT"
 
 # =========================================================================
-echo "=== Test 10: spawn_autonomous returns PID with mock claude ==="
+echo "=== Test 11: spawn_autonomous returns PID with mock claude ==="
 # Create a temp directory to act as worktree
 TEST_WT=$(mktemp -d)
 # Create a mock 'claude' that just echoes and exits
@@ -158,11 +166,11 @@ fi
 rm -rf "$TEST_WT" "$MOCK_BIN"
 
 # =========================================================================
-echo "=== Test 11: AGENT_OUTPUT_FILENAME constant is defined ==="
+echo "=== Test 12: AGENT_OUTPUT_FILENAME constant is defined ==="
 assert_eq "AGENT_OUTPUT_FILENAME value" ".ql-agent-output.txt" "$AGENT_OUTPUT_FILENAME"
 
 # =========================================================================
-echo "=== Test 12: Multiple agents run concurrently ==="
+echo "=== Test 13: Multiple agents run concurrently ==="
 # Create 3 temp directories to act as worktrees
 WT1=$(mktemp -d)
 WT2=$(mktemp -d)

--- a/tests/test_worktree.sh
+++ b/tests/test_worktree.sh
@@ -148,6 +148,63 @@ EXIT_CODE=$?
 assert_eq "remove_worktree for nonexistent exits 0" "0" "$EXIT_CODE"
 
 # =========================================================================
+echo "=== Test 7: _resolve_repo_root from main repo returns itself ==="
+RESOLVED=$(_resolve_repo_root "$TMPDIR")
+assert_eq "_resolve_repo_root main repo is identity" "$TMPDIR" "$RESOLVED"
+
+# =========================================================================
+echo "=== Test 8: _resolve_repo_root from inside worktree returns main root ==="
+# Create a worktree to test from
+create_worktree "US-resolve" "ql/test-feature" "$TMPDIR" >/dev/null 2>&1
+WT_RESOLVE="$TMPDIR/.ql-wt/US-resolve"
+if [[ -d "$WT_RESOLVE" ]]; then
+  RESOLVED=$(_resolve_repo_root "$WT_RESOLVE")
+  assert_eq "_resolve_repo_root from worktree returns main root" "$TMPDIR" "$RESOLVED"
+  remove_worktree "US-resolve" "$TMPDIR" >/dev/null 2>&1
+else
+  TOTAL=$((TOTAL + 1))
+  echo "  FAIL: Could not create worktree for _resolve_repo_root test"
+  FAIL=$((FAIL + 1))
+fi
+
+# =========================================================================
+echo "=== Test 9: create_worktree from nested path roots at top level ==="
+create_worktree "US-outer" "ql/test-feature" "$TMPDIR" >/dev/null 2>&1
+NESTED_ROOT="$TMPDIR/.ql-wt/US-outer"
+if [[ -d "$NESTED_ROOT" ]]; then
+  create_worktree "US-inner" "ql/test-feature" "$NESTED_ROOT" >/dev/null 2>&1
+  # Should land under main repo root, NOT double-nested
+  assert_dir_exists "US-inner under main root" "$TMPDIR/.ql-wt/US-inner"
+  assert_dir_not_exists "US-inner NOT nested inside US-outer" "$NESTED_ROOT/.ql-wt/US-inner"
+  remove_worktree "US-inner" "$TMPDIR" >/dev/null 2>&1
+  remove_worktree "US-outer" "$TMPDIR" >/dev/null 2>&1
+else
+  TOTAL=$((TOTAL + 1))
+  echo "  FAIL: Could not create outer worktree for nesting test"
+  FAIL=$((FAIL + 1))
+fi
+
+# =========================================================================
+echo "=== Test 10: _short_path_base is deterministic ==="
+BASE1=$(_short_path_base "$TMPDIR")
+BASE2=$(_short_path_base "$TMPDIR")
+assert_eq "_short_path_base deterministic" "$BASE1" "$BASE2"
+assert_contains "_short_path_base has ql-wt prefix" "ql-wt-" "$BASE1"
+
+# =========================================================================
+echo "=== Test 11: _short_path_base differs per repo root ==="
+BASE_A=$(_short_path_base "/tmp/repo-a")
+BASE_B=$(_short_path_base "/tmp/repo-b")
+TOTAL=$((TOTAL + 1))
+if [[ "$BASE_A" != "$BASE_B" ]]; then
+  echo "  PASS: Different repos get different short paths"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: Same short path for different repos: $BASE_A"
+  FAIL=$((FAIL + 1))
+fi
+
+# =========================================================================
 echo ""
 echo "=== Results: $PASS/$TOTAL passed, $FAIL failed ==="
 if [[ $FAIL -eq 0 ]]; then


### PR DESCRIPTION
## Summary

Fixes 7 issues discovered during field testing of a 14-story parallel execution run (ql/image-mode feature on CI-synthetic-docx). Adds a full-feature code review step and comprehensive test coverage.

Closes #16

### Changes by file

- **agents/orchestrator.md** — File-conflict-aware DAG scheduling (Step 2.1), PYTHONPATH in spawn prompt, quantum.json merge guidance, inline review gate for parallel mode (Step 3B.4), full-feature code review after completion (Step 4B)
- **agents/implementer.md** — New "Environment Setup (Worktree Mode)" section with PYTHONPATH injection for Python projects (src-layout and flat-layout)
- **lib/worktree.sh** — `_resolve_repo_root()` shared helper prevents worktree nesting, Git version fallback (2.31+ → 2.20+), `_short_path_base()` with repo-hash namespace prevents cross-repo /tmp collisions, long-path fallback (>200 chars), retry loop for Windows file locks, `rm -rf` only on failure
- **lib/dag-query.sh** — `filter_file_conflicts()` with input validation, correct jq variable bindings (not `env.`), exact-match `index()` (not substring `inside`)
- **lib/spawn.sh** — PYTHONPATH guidance in autonomous agent prompt (both layout variants)
- **tests/test_dag_query.sh** — 8 new tests for `filter_file_conflicts()` (35 total, all passing): filePaths overlap, fileConflicts entries, empty/null, three-way conflict, transitive chain, similar-but-different paths

### Issues fixed

| # | Issue | Severity |
|---|-------|----------|
| 1 | Worktree nesting (agents create .ql-wt inside .ql-wt) | Critical |
| 2 | Editable install race (pip install -e . across worktrees) | Critical |
| 3 | jq `env.` references shell $ENV instead of accumulator | Critical |
| 4 | jq `inside` does substring matching on file paths | Critical |
| 5 | File-conflict-unaware DAG scheduling causes merge conflicts | High |
| 6 | Worktree cleanup fails on Windows (file locks) | High |
| 7 | No full-feature code review after all stories pass | High |

## Test plan

- [x] `bash tests/test_dag_query.sh` — 35/35 passing
- [x] `bash -n lib/worktree.sh lib/dag-query.sh lib/spawn.sh` — all syntax valid
- [x] Smoke tested `filter_file_conflicts` with overlapping files, fileConflicts, null, transitive chains
- [ ] Field test on next ql-execute run with parallel stories

🤖 Generated with [Claude Code](https://claude.com/claude-code)