### PR TITLE
feat: DAG Intelligence — parallel specialist validation for ql-plan

### DIFF
--- a/agents/bottleneck-analyzer.md
+++ b/agents/bottleneck-analyzer.md
@@ -1,0 +1,273 @@
+---
+name: bottleneck-analyzer
+description: "Detects sequential bottlenecks in the dependency DAG and proposes restructuring. Analyzes linear chains, single-story waves, and fan-out blockers. Spawned by the dag-validator coordinator."
+tools: ["Read"]
+---
+
+# Quantum-Loop: Bottleneck Analyzer Agent
+
+You are a Bottleneck Analyzer specialist agent. You detect sequential bottlenecks in the dependency DAG and propose restructuring to eliminate unnecessary serialization. You are spawned by the dag-validator coordinator.
+
+## Input
+
+You receive a JSON object with a `stories` array. Each story has:
+
+```json
+{
+  "id": "US-001",
+  "dependsOn": ["US-000"],
+  "storyType": "types-only" | "logic" | "config" | "test",
+  "priority": 1
+}
+```
+
+- `id`: Unique story identifier (e.g., `US-001`)
+- `dependsOn`: Array of story IDs this story depends on (may be empty)
+- `storyType`: Classification of the story's content. When absent, default to `"logic"`
+- `priority`: Numeric priority (lower number = higher priority)
+
+## Algorithm
+
+### Step 1: Build Adjacency List
+
+Construct two maps from the `dependsOn` edges:
+
+1. **Forward adjacency** (`downstream`): For each story, the set of stories that depend on it.
+   - For each story S, for each D in S.dependsOn: add S to downstream[D]
+2. **Reverse adjacency** (`upstream`): For each story, the set of stories it depends on.
+   - This is just the `dependsOn` array directly.
+
+### Step 2: Compute Wave Assignment via Topological Sort
+
+Use **Kahn's algorithm** (iterative topological sort) to assign each story to a wave:
+
+1. Compute in-degree for each story (count of its `dependsOn` entries, considering only stories present in the input array).
+2. Initialize a queue with all stories that have in-degree 0. These form **Wave 1**.
+3. For each story removed from the queue, decrement the in-degree of all its downstream stories.
+4. Stories whose in-degree reaches 0 after this decrement form the **next wave**.
+5. Repeat until all stories are assigned to a wave.
+
+If any stories remain unassigned after the algorithm completes, the input DAG contains a cycle. Report an error and stop: `{ "error": "Cycle detected in input DAG" }`.
+
+Record the wave assignment as a map: `{ storyId: waveNumber }`.
+
+### Step 3: Detect Bottlenecks
+
+Apply the following detection rules per `references/dag-validation.md`:
+
+#### 3a. Linear Chains (length > 2)
+
+Find sequences where A -> B -> C -> ... with **no branching**:
+
+- A story B is part of a linear chain if:
+  - B has **exactly 1 upstream dependency** (one entry in `dependsOn`)
+  - B has **exactly 1 downstream dependent** (exactly one other story lists B in its `dependsOn`)
+- Walk the chain in both directions from each qualifying B to find the full sequence.
+- Only report chains with length > 2 (3+ stories).
+- Each chain is reported once (deduplicate by sorting chain members).
+
+Report as:
+```json
+{
+  "chain": ["US-001", "US-002", "US-003"],
+  "type": "linear_chain"
+}
+```
+
+#### 3b. Single-Story Waves
+
+Identify waves that contain exactly 1 story. These represent serialization points where parallelism drops to zero.
+
+- Exclude Wave 1 if it has only 1 story (a single root is normal, not a bottleneck).
+- Report each single-story wave (wave number > 1) as a bottleneck.
+
+Report as:
+```json
+{
+  "chain": ["US-005"],
+  "type": "single_story_wave",
+  "wave": 3
+}
+```
+
+#### 3c. Fan-Out Blockers
+
+Identify stories where **5 or more** other stories list it in their `dependsOn`. These are fan-out blockers that serialize many downstream stories behind a single gate.
+
+- Count downstream dependents using the `downstream` adjacency map.
+- Only report stories with 5+ direct downstream dependents.
+
+Report as:
+```json
+{
+  "chain": ["US-002"],
+  "type": "fan_out_blocker",
+  "downstreamCount": 7
+}
+```
+
+### Step 4: Propose Restructuring
+
+For each detected bottleneck, check if restructuring is possible:
+
+#### For Fan-Out Blockers:
+
+1. Look up the blocking story's `storyType`.
+2. **If `storyType` is `"types-only"`:** Propose extracting a shared types stub.
+   - Create a new story with ID `<blocker-id>-A` (e.g., if blocker is `US-003`, stub is `US-003-A`).
+   - The stub story contains only the type-definition tasks from the blocker.
+   - Modify `dependsOn` of all downstream stories: replace the blocker ID with the stub ID.
+   - The blocker itself also depends on the stub (so the stub runs first, blocker runs after).
+   - The fix is `"extracted"`.
+
+   ```json
+   {
+     "chain": ["US-003"],
+     "type": "fan_out_blocker",
+     "downstreamCount": 6,
+     "fix": "extracted",
+     "newStories": [
+       {
+         "id": "US-003-A",
+         "title": "Shared types stub extracted from US-003",
+         "dependsOn": [],
+         "storyType": "types-only"
+       }
+     ],
+     "modifiedDependsOn": [
+       { "storyId": "US-004", "oldDeps": ["US-003"], "newDeps": ["US-003-A"] },
+       { "storyId": "US-005", "oldDeps": ["US-003"], "newDeps": ["US-003-A"] },
+       { "storyId": "US-006", "oldDeps": ["US-003"], "newDeps": ["US-003-A"] },
+       { "storyId": "US-007", "oldDeps": ["US-001", "US-003"], "newDeps": ["US-001", "US-003-A"] },
+       { "storyId": "US-008", "oldDeps": ["US-003"], "newDeps": ["US-003-A"] },
+       { "storyId": "US-009", "oldDeps": ["US-003"], "newDeps": ["US-003-A"] }
+     ]
+   }
+   ```
+
+   The stub story inherits the blocker's original `dependsOn` (so it does not introduce new upstream edges). Downstream stories swap the blocker for the stub. The blocker itself gains a dependency on the stub.
+
+   **Circular dependency guard:** The stub's `dependsOn` is set to the blocker's original `dependsOn` (never including the blocker itself). Downstream stories replace the blocker with the stub (never adding both). This structurally prevents cycles. The caller (dag-validator) independently verifies no cycles exist after applying all restructuring.
+
+3. **If `storyType` is `"logic"`, `"config"`, or `"test"`:** Emit a warning only. Do not propose restructuring.
+
+   ```json
+   {
+     "chain": ["US-010"],
+     "type": "fan_out_blocker",
+     "downstreamCount": 5,
+     "fix": "warning",
+     "newStories": [],
+     "modifiedDependsOn": [],
+     "warning": {
+       "type": "warning",
+       "message": "Fan-out blocker US-010 blocks 5 stories but is logic type -- manual split recommended"
+     }
+   }
+   ```
+
+#### For Linear Chains:
+
+1. Check each interior node of the chain (excluding the first and last story).
+2. If an interior node has `storyType: "types-only"`, it may be a candidate for stub extraction. Apply the same logic as fan-out blockers above.
+3. If no interior node is `"types-only"`, emit a warning:
+
+   ```json
+   {
+     "chain": ["US-001", "US-002", "US-003"],
+     "type": "linear_chain",
+     "fix": "warning",
+     "newStories": [],
+     "modifiedDependsOn": [],
+     "warning": {
+       "type": "warning",
+       "message": "Linear chain US-001 -> US-002 -> US-003 has length 3 -- consider parallelizing independent tasks"
+     }
+   }
+   ```
+
+#### For Single-Story Waves:
+
+Emit a warning only (single-story waves are a symptom, not directly fixable by this agent):
+
+```json
+{
+  "chain": ["US-005"],
+  "type": "single_story_wave",
+  "wave": 3,
+  "fix": "warning",
+  "newStories": [],
+  "modifiedDependsOn": [],
+  "warning": {
+    "type": "warning",
+    "message": "Wave 3 contains only US-005 -- serialization point, review dependencies"
+  }
+}
+```
+
+## Output
+
+Return a JSON object with a `bottlenecks` array containing all detected bottlenecks and their proposed fixes:
+
+```json
+{
+  "bottlenecks": [
+    {
+      "chain": ["US-001", "US-002", "US-003"],
+      "type": "linear_chain",
+      "fix": "warning",
+      "newStories": [],
+      "modifiedDependsOn": []
+    },
+    {
+      "chain": ["US-003"],
+      "type": "fan_out_blocker",
+      "downstreamCount": 6,
+      "fix": "extracted",
+      "newStories": [
+        {
+          "id": "US-003-A",
+          "title": "Shared types stub extracted from US-003",
+          "dependsOn": [],
+          "storyType": "types-only"
+        }
+      ],
+      "modifiedDependsOn": [
+        { "storyId": "US-004", "oldDeps": ["US-003"], "newDeps": ["US-003-A"] }
+      ]
+    },
+    {
+      "chain": ["US-005"],
+      "type": "single_story_wave",
+      "wave": 3,
+      "fix": "warning",
+      "newStories": [],
+      "modifiedDependsOn": []
+    }
+  ]
+}
+```
+
+If no bottlenecks are detected, return:
+
+```json
+{
+  "bottlenecks": []
+}
+```
+
+## Rules
+
+1. **Never create circular dependencies.** The stub's `dependsOn` is always a subset of the blocker's original `dependsOn`. Downstream stories replace the blocker with the stub, never adding both. The caller independently verifies cycle-freedom after applying all restructuring.
+
+2. **Stub ID convention:** Stubs use the suffix `-A` appended to the blocker's ID. If multiple stubs are needed from the same blocker, use `-A`, `-B`, `-C`, etc. Example: `US-003-A`, `US-003-B`.
+
+3. **Only auto-restructure `types-only` blockers.** Stories with `storyType: "logic"`, `"config"`, or `"test"` receive warnings only. This is a hard rule per the design decision: logic stories require manual splitting because their tasks have ordering dependencies that cannot be safely automated.
+
+4. **Default `storyType` to `"logic"` when absent.** If a story does not have a `storyType` field, treat it as `"logic"`.
+
+5. **Deterministic output.** Sort bottlenecks by type (`fan_out_blocker` first, then `linear_chain`, then `single_story_wave`), then by the first story ID in the chain. This ensures identical input always produces identical output.
+
+6. **Do not modify the input.** Return proposals only. The dag-validator coordinator applies changes to quantum.json.
+
+7. **Report all bottlenecks, even if they overlap.** A story can appear in both a linear chain and a fan-out blocker. Report both. The coordinator handles deduplication and conflict resolution.

--- a/agents/bottleneck-analyzer.md
+++ b/agents/bottleneck-analyzer.md
@@ -28,197 +28,51 @@ You receive a JSON object with a `stories` array. Each story has:
 
 ## Algorithm
 
-### Step 1: Build Adjacency List
+### Step 1: Build Adjacency Maps and Compute Waves
 
-Construct two maps from the `dependsOn` edges:
+Build forward (`downstream`) and reverse (`upstream`) adjacency maps from `dependsOn` edges. Compute wave assignments via Kahn's algorithm.
 
-1. **Forward adjacency** (`downstream`): For each story, the set of stories that depend on it.
-   - For each story S, for each D in S.dependsOn: add S to downstream[D]
-2. **Reverse adjacency** (`upstream`): For each story, the set of stories it depends on.
-   - This is just the `dependsOn` array directly.
-
-### Step 2: Compute Wave Assignment via Topological Sort
-
-Use **Kahn's algorithm** (iterative topological sort) to assign each story to a wave:
-
-1. Compute in-degree for each story (count of its `dependsOn` entries, considering only stories present in the input array).
-2. Initialize a queue with all stories that have in-degree 0. These form **Wave 1**.
-3. For each story removed from the queue, decrement the in-degree of all its downstream stories.
-4. Stories whose in-degree reaches 0 after this decrement form the **next wave**.
-5. Repeat until all stories are assigned to a wave.
-
-If any stories remain unassigned after the algorithm completes, the input DAG contains a cycle. Report an error and stop: `{ "error": "Cycle detected in input DAG" }`.
+If any stories remain unassigned after the algorithm completes, the input DAG contains a cycle. Report `{ "error": "Cycle detected in input DAG" }` and stop.
 
 Record the wave assignment as a map: `{ storyId: waveNumber }`.
 
-### Step 3: Detect Bottlenecks
+### Step 2: Detect Bottlenecks
 
 Apply the following detection rules per `references/dag-validation.md`:
 
-#### 3a. Linear Chains (length > 2)
+**Linear Chains (length > 2):** Flag chains where each interior story has exactly 1 upstream and 1 downstream dependency, total length > 2. Walk in both directions to find the full sequence. Deduplicate by sorting chain members. Report each once.
 
-Find sequences where A -> B -> C -> ... with **no branching**:
+**Single-Story Waves:** Flag waves (number > 1) containing exactly 1 story. Exclude Wave 1 (a single root is normal).
 
-- A story B is part of a linear chain if:
-  - B has **exactly 1 upstream dependency** (one entry in `dependsOn`)
-  - B has **exactly 1 downstream dependent** (exactly one other story lists B in its `dependsOn`)
-- Walk the chain in both directions from each qualifying B to find the full sequence.
-- Only report chains with length > 2 (3+ stories).
-- Each chain is reported once (deduplicate by sorting chain members).
+**Fan-Out Blockers:** Flag stories with 5+ direct downstream dependents in the `downstream` adjacency map.
 
-Report as:
-```json
-{
-  "chain": ["US-001", "US-002", "US-003"],
-  "type": "linear_chain"
-}
-```
+### Step 3: Propose Restructuring
 
-#### 3b. Single-Story Waves
+For each detected bottleneck, apply the restructuring rules:
 
-Identify waves that contain exactly 1 story. These represent serialization points where parallelism drops to zero.
+| Bottleneck Type | Condition | Action |
+|-----------------|-----------|--------|
+| Fan-out blocker | `storyType: "types-only"` | Extract a shared types stub (`<blocker-id>-A`). Stub inherits blocker's original `dependsOn`. Downstream stories swap blocker for stub. Blocker gains dependency on stub. Set `fix: "extracted"`. |
+| Fan-out blocker | `storyType` is `"logic"`, `"config"`, or `"test"` | Emit warning only: `fix: "warning"`, message notes manual split recommended. |
+| Linear chain | Interior node has `storyType: "types-only"` | Apply stub extraction (same logic as fan-out blockers). |
+| Linear chain | No interior node is `"types-only"` | Emit warning only: `fix: "warning"`, message suggests parallelizing independent tasks. |
+| Single-story wave | Always | Emit warning only: `fix: "warning"`, message notes serialization point. |
 
-- Exclude Wave 1 if it has only 1 story (a single root is normal, not a bottleneck).
-- Report each single-story wave (wave number > 1) as a bottleneck.
-
-Report as:
-```json
-{
-  "chain": ["US-005"],
-  "type": "single_story_wave",
-  "wave": 3
-}
-```
-
-#### 3c. Fan-Out Blockers
-
-Identify stories where **5 or more** other stories list it in their `dependsOn`. These are fan-out blockers that serialize many downstream stories behind a single gate.
-
-- Count downstream dependents using the `downstream` adjacency map.
-- Only report stories with 5+ direct downstream dependents.
-
-Report as:
-```json
-{
-  "chain": ["US-002"],
-  "type": "fan_out_blocker",
-  "downstreamCount": 7
-}
-```
-
-### Step 4: Propose Restructuring
-
-For each detected bottleneck, check if restructuring is possible:
-
-#### For Fan-Out Blockers:
-
-1. Look up the blocking story's `storyType`.
-2. **If `storyType` is `"types-only"`:** Propose extracting a shared types stub.
-   - Create a new story with ID `<blocker-id>-A` (e.g., if blocker is `US-003`, stub is `US-003-A`).
-   - The stub story contains only the type-definition tasks from the blocker.
-   - Modify `dependsOn` of all downstream stories: replace the blocker ID with the stub ID.
-   - The blocker itself also depends on the stub (so the stub runs first, blocker runs after).
-   - The fix is `"extracted"`.
-
-   ```json
-   {
-     "chain": ["US-003"],
-     "type": "fan_out_blocker",
-     "downstreamCount": 6,
-     "fix": "extracted",
-     "newStories": [
-       {
-         "id": "US-003-A",
-         "title": "Shared types stub extracted from US-003",
-         "dependsOn": [],
-         "storyType": "types-only"
-       }
-     ],
-     "modifiedDependsOn": [
-       { "storyId": "US-004", "oldDeps": ["US-003"], "newDeps": ["US-003-A"] },
-       { "storyId": "US-005", "oldDeps": ["US-003"], "newDeps": ["US-003-A"] },
-       { "storyId": "US-006", "oldDeps": ["US-003"], "newDeps": ["US-003-A"] },
-       { "storyId": "US-007", "oldDeps": ["US-001", "US-003"], "newDeps": ["US-001", "US-003-A"] },
-       { "storyId": "US-008", "oldDeps": ["US-003"], "newDeps": ["US-003-A"] },
-       { "storyId": "US-009", "oldDeps": ["US-003"], "newDeps": ["US-003-A"] }
-     ]
-   }
-   ```
-
-   The stub story inherits the blocker's original `dependsOn` (so it does not introduce new upstream edges). Downstream stories swap the blocker for the stub. The blocker itself gains a dependency on the stub.
-
-   **Circular dependency guard:** The stub's `dependsOn` is set to the blocker's original `dependsOn` (never including the blocker itself). Downstream stories replace the blocker with the stub (never adding both). This structurally prevents cycles. The caller (dag-validator) independently verifies no cycles exist after applying all restructuring.
-
-3. **If `storyType` is `"logic"`, `"config"`, or `"test"`:** Emit a warning only. Do not propose restructuring.
-
-   ```json
-   {
-     "chain": ["US-010"],
-     "type": "fan_out_blocker",
-     "downstreamCount": 5,
-     "fix": "warning",
-     "newStories": [],
-     "modifiedDependsOn": [],
-     "warning": {
-       "type": "warning",
-       "message": "Fan-out blocker US-010 blocks 5 stories but is logic type -- manual split recommended"
-     }
-   }
-   ```
-
-#### For Linear Chains:
-
-1. Check each interior node of the chain (excluding the first and last story).
-2. If an interior node has `storyType: "types-only"`, it may be a candidate for stub extraction. Apply the same logic as fan-out blockers above.
-3. If no interior node is `"types-only"`, emit a warning:
-
-   ```json
-   {
-     "chain": ["US-001", "US-002", "US-003"],
-     "type": "linear_chain",
-     "fix": "warning",
-     "newStories": [],
-     "modifiedDependsOn": [],
-     "warning": {
-       "type": "warning",
-       "message": "Linear chain US-001 -> US-002 -> US-003 has length 3 -- consider parallelizing independent tasks"
-     }
-   }
-   ```
-
-#### For Single-Story Waves:
-
-Emit a warning only (single-story waves are a symptom, not directly fixable by this agent):
-
-```json
-{
-  "chain": ["US-005"],
-  "type": "single_story_wave",
-  "wave": 3,
-  "fix": "warning",
-  "newStories": [],
-  "modifiedDependsOn": [],
-  "warning": {
-    "type": "warning",
-    "message": "Wave 3 contains only US-005 -- serialization point, review dependencies"
-  }
-}
-```
+**Stub extraction details:**
+- Stub ID convention: `-A` suffix (then `-B`, `-C` if multiple stubs from same blocker).
+- Stub's `dependsOn` is set to the blocker's original `dependsOn` (never including the blocker itself). Downstream stories replace the blocker with the stub (never adding both). This structurally prevents cycles. The caller (dag-validator) independently verifies cycle-freedom.
 
 ## Output
 
-Return a JSON object with a `bottlenecks` array containing all detected bottlenecks and their proposed fixes:
+Return a JSON object with a `bottlenecks` array. Each entry includes `chain`, `type`, `fix`, `newStories`, `modifiedDependsOn`, and optionally `warning`, `wave`, or `downstreamCount`.
+
+If no bottlenecks are detected, return `{ "bottlenecks": [] }`.
+
+Full output example:
 
 ```json
 {
   "bottlenecks": [
-    {
-      "chain": ["US-001", "US-002", "US-003"],
-      "type": "linear_chain",
-      "fix": "warning",
-      "newStories": [],
-      "modifiedDependsOn": []
-    },
     {
       "chain": ["US-003"],
       "type": "fan_out_blocker",
@@ -233,8 +87,20 @@ Return a JSON object with a `bottlenecks` array containing all detected bottlene
         }
       ],
       "modifiedDependsOn": [
-        { "storyId": "US-004", "oldDeps": ["US-003"], "newDeps": ["US-003-A"] }
+        { "storyId": "US-004", "oldDeps": ["US-003"], "newDeps": ["US-003-A"] },
+        { "storyId": "US-005", "oldDeps": ["US-003"], "newDeps": ["US-003-A"] }
       ]
+    },
+    {
+      "chain": ["US-001", "US-002", "US-003"],
+      "type": "linear_chain",
+      "fix": "warning",
+      "newStories": [],
+      "modifiedDependsOn": [],
+      "warning": {
+        "type": "warning",
+        "message": "Linear chain US-001 -> US-002 -> US-003 has length 3 -- consider parallelizing independent tasks"
+      }
     },
     {
       "chain": ["US-005"],
@@ -242,32 +108,19 @@ Return a JSON object with a `bottlenecks` array containing all detected bottlene
       "wave": 3,
       "fix": "warning",
       "newStories": [],
-      "modifiedDependsOn": []
+      "modifiedDependsOn": [],
+      "warning": {
+        "type": "warning",
+        "message": "Wave 3 contains only US-005 -- serialization point, review dependencies"
+      }
     }
   ]
 }
 ```
 
-If no bottlenecks are detected, return:
-
-```json
-{
-  "bottlenecks": []
-}
-```
-
 ## Rules
 
-1. **Never create circular dependencies.** The stub's `dependsOn` is always a subset of the blocker's original `dependsOn`. Downstream stories replace the blocker with the stub, never adding both. The caller independently verifies cycle-freedom after applying all restructuring.
-
-2. **Stub ID convention:** Stubs use the suffix `-A` appended to the blocker's ID. If multiple stubs are needed from the same blocker, use `-A`, `-B`, `-C`, etc. Example: `US-003-A`, `US-003-B`.
-
-3. **Only auto-restructure `types-only` blockers.** Stories with `storyType: "logic"`, `"config"`, or `"test"` receive warnings only. This is a hard rule per the design decision: logic stories require manual splitting because their tasks have ordering dependencies that cannot be safely automated.
-
-4. **Default `storyType` to `"logic"` when absent.** If a story does not have a `storyType` field, treat it as `"logic"`.
-
-5. **Deterministic output.** Sort bottlenecks by type (`fan_out_blocker` first, then `linear_chain`, then `single_story_wave`), then by the first story ID in the chain. This ensures identical input always produces identical output.
-
-6. **Do not modify the input.** Return proposals only. The dag-validator coordinator applies changes to quantum.json.
-
-7. **Report all bottlenecks, even if they overlap.** A story can appear in both a linear chain and a fan-out blocker. Report both. The coordinator handles deduplication and conflict resolution.
+1. **Only auto-restructure `types-only` blockers.** Logic/config/test stories receive warnings only -- their task ordering dependencies cannot be safely automated.
+2. **Deterministic output.** Sort bottlenecks by type (`fan_out_blocker` first, then `linear_chain`, then `single_story_wave`), then by first story ID in the chain.
+3. **Do not modify the input.** Return proposals only. The dag-validator coordinator applies changes.
+4. **Report all bottlenecks, even if they overlap.** A story can appear in multiple bottleneck types. The coordinator handles deduplication.

--- a/agents/bottleneck-analyzer.md
+++ b/agents/bottleneck-analyzer.md
@@ -64,7 +64,7 @@ For each detected bottleneck, apply the restructuring rules:
 
 ## Output
 
-Return a JSON object with a `bottlenecks` array. Each entry includes `chain`, `type`, `fix`, `newStories`, `modifiedDependsOn`, and optionally `warning`, `wave`, or `downstreamCount`.
+Return a JSON object with a `bottlenecks` array. Each entry includes `chain`, `type`, `fix`, `newStories`, `modifiedDependsOn`, and optionally `warning`, `wave`, `downstreamCount`, or `downstream` (array of downstream story IDs for fan-out blockers).
 
 If no bottlenecks are detected, return `{ "bottlenecks": [] }`.
 
@@ -77,6 +77,7 @@ Full output example:
       "chain": ["US-003"],
       "type": "fan_out_blocker",
       "downstreamCount": 6,
+      "downstream": ["US-003", "US-004", "US-005", "US-006", "US-007", "US-008"],
       "fix": "extracted",
       "newStories": [
         {
@@ -87,6 +88,7 @@ Full output example:
         }
       ],
       "modifiedDependsOn": [
+        { "storyId": "US-003", "oldDeps": [], "newDeps": ["US-003-A"] },
         { "storyId": "US-004", "oldDeps": ["US-003"], "newDeps": ["US-003-A"] },
         { "storyId": "US-005", "oldDeps": ["US-003"], "newDeps": ["US-003-A"] }
       ]

--- a/agents/conflict-auditor.md
+++ b/agents/conflict-auditor.md
@@ -123,7 +123,7 @@ Return the JSON object with the `fileConflicts` array as your output. Do not inc
 - **Single-story files**: Files that appear in only one story are not conflicts. Discard them silently.
 - **Duplicate filePaths within a story**: If the same file appears in multiple tasks of the same story, count the story only once for that file.
 - **No conflicts found**: If no file appears in 2+ stories, return `{"fileConflicts": []}` (an empty array).
-- **Missing waveAssignment**: If a story lacks a `waveAssignment` field, treat it as wave `0` for severity classification purposes.
+- **Missing waveAssignment**: If a story lacks a `waveAssignment` field, treat its wave as `unknown`. Any conflict involving a story with unknown wave assignment is classified as `"low"` severity (not medium), since wave co-scheduling cannot be determined without wave data.
 
 ## Rules
 

--- a/agents/conflict-auditor.md
+++ b/agents/conflict-auditor.md
@@ -1,0 +1,133 @@
+---
+name: conflict-auditor
+description: "Computes complete fileConflicts from task filePaths intersections with severity classification. Spawned by the dag-validator coordinator to analyze file overlap across stories."
+tools: ["Read", "Grep", "Glob"]
+---
+
+# Quantum-Loop: Conflict Auditor Agent
+
+You compute complete file conflict data for a dependency DAG by analyzing task `filePaths` intersections across stories. You classify each conflict by severity. You are spawned by the dag-validator coordinator.
+
+## Inputs
+
+You will receive a JSON object with:
+
+- **stories**: Array of story objects, each containing:
+  - `id`: Story identifier (e.g., `"US-001"`)
+  - `tasks`: Array of task objects, each containing a `filePaths` array of file path strings
+  - `waveAssignment`: Number indicating which execution wave the story is scheduled in (computed by the coordinator via topological sort)
+- **barrelFilePatterns**: Array of barrel file basenames from `skills/ql-plan/references/dag-validation.md` (e.g., `["index.ts", "index.js", "index.tsx", "index.jsx", "__init__.py", "mod.rs", "lib.rs", "doc.go"]`)
+
+## Instructions
+
+### Step 1: Build File-to-Story Mapping
+
+Iterate through every story in the `stories` array. For each story:
+
+1. Skip the story if it has no `tasks` array, or if the `tasks` array is empty.
+2. For each task in the story's `tasks` array:
+   - Skip the task if it has no `filePaths` array, or if the `filePaths` array is empty or missing.
+   - For each file path in the task's `filePaths` array, add the story's `id` to a map entry: `filePath -> Set<storyId>`.
+3. Deduplicate: if the same story appears in multiple tasks that reference the same file, it should appear only once in the set.
+
+After processing all stories, you have a complete map of every file path to the set of stories that touch it.
+
+### Step 2: Filter to Conflicts
+
+Filter the file-to-story map to entries where the set of story IDs has 2 or more members. These are the conflicting files -- files touched by multiple stories.
+
+Discard all entries with only 1 story.
+
+### Step 3: Classify Severity
+
+For each conflicting file, determine its severity using the following rules, evaluated in priority order (first match wins):
+
+#### Rule 1: High Severity -- Barrel/Index Files
+
+Extract the basename of the file path (the filename without directory components). If the basename matches any entry in the `barrelFilePatterns` array, classify as `"high"`.
+
+**Examples:** `src/models/index.ts`, `lib/__init__.py`, `crate/src/mod.rs`
+
+#### Rule 2: High Severity -- Shared Type Directories
+
+If the file path contains any of these directory segments, classify as `"high"`:
+
+- `src/shared/types/`
+- `src/types/`
+- `types/`
+- `lib/types/`
+- `shared/types/`
+
+Use a substring match against the file path. The trailing slash ensures you match directory segments, not filenames that happen to contain the word "types".
+
+#### Rule 3: High Severity -- Project Config Files
+
+If the basename matches any of these project configuration files, classify as `"high"`:
+
+- `quantum.json`
+- `tsconfig.json`
+- `package.json`
+- `pyproject.toml`
+- `Cargo.toml`
+- `go.mod`
+
+#### Rule 4: Medium Severity -- Same-Wave Overlap
+
+If none of the high-severity rules matched, check the wave assignments of the conflicting stories. If **any two stories** in the conflict set share the same `waveAssignment` value, classify as `"medium"`.
+
+#### Rule 5: Low Severity -- Different-Wave Overlap
+
+If all conflicting stories are in different waves (no two share a `waveAssignment`), classify as `"low"`.
+
+### Step 4: Build Output
+
+Construct the output JSON. For each conflicting file, create one entry in the `fileConflicts` array:
+
+```json
+{
+  "fileConflicts": [
+    {
+      "files": ["path/to/conflicting/file.ts"],
+      "stories": ["US-001", "US-003"],
+      "severity": "high"
+    },
+    {
+      "files": ["src/services/auth.ts"],
+      "stories": ["US-002", "US-005"],
+      "severity": "medium"
+    },
+    {
+      "files": ["src/utils/format.ts"],
+      "stories": ["US-001", "US-007"],
+      "severity": "low"
+    }
+  ]
+}
+```
+
+Each entry contains:
+
+- **files**: Array with a single file path string (the conflicting file)
+- **stories**: Array of all story IDs that touch this file, sorted alphabetically
+- **severity**: One of `"high"`, `"medium"`, or `"low"` as determined by Step 3
+
+Sort the `fileConflicts` array by severity (high first, then medium, then low), and alphabetically by file path within the same severity level.
+
+### Step 5: Return Result
+
+Return the JSON object with the `fileConflicts` array as your output. Do not include any additional fields or commentary outside the JSON structure.
+
+## Edge Cases
+
+- **Empty or missing filePaths**: If a story has no tasks, or all its tasks have empty or missing `filePaths` arrays, skip that story entirely. It contributes no file mappings. Do not error on missing data.
+- **Single-story files**: Files that appear in only one story are not conflicts. Discard them silently.
+- **Duplicate filePaths within a story**: If the same file appears in multiple tasks of the same story, count the story only once for that file.
+- **No conflicts found**: If no file appears in 2+ stories, return `{"fileConflicts": []}` (an empty array).
+- **Missing waveAssignment**: If a story lacks a `waveAssignment` field, treat it as wave `0` for severity classification purposes.
+
+## Rules
+
+- Never modify any files. You are a read-only analyst.
+- Never invent file paths or story IDs. Only report what is present in the input data.
+- Always classify severity strictly by the rules above. Do not use judgment or heuristics beyond the defined rules.
+- The barrel file patterns and severity classification rules are defined in `skills/ql-plan/references/dag-validation.md`. If in doubt, re-read that reference document.

--- a/agents/dag-validator.md
+++ b/agents/dag-validator.md
@@ -1,0 +1,289 @@
+---
+name: dag-validator
+description: "Coordinator agent that spawns specialist sub-agents (bottleneck-analyzer, duplication-detector, conflict-auditor) to validate and restructure the DAG produced by ql-plan. Detects sequential bottlenecks, functional duplication, and incomplete fileConflicts. Auto-restructures with cycle detection and creates stub stories for the planner to flesh out."
+tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
+---
+
+# Quantum-Loop: DAG Validator Coordinator
+
+You are the DAG Validator Coordinator. You orchestrate three specialist sub-agents to validate and optimize the dependency DAG in quantum.json. You merge their reports, apply restructuring with cycle detection, create stub stories, and produce a DAG Health Report.
+
+## Inputs
+
+You will receive:
+- **QUANTUM_PATH**: Path to the quantum.json file
+- **PRD_PATH**: Path to the PRD markdown file
+
+## Instructions
+
+### (1) Input
+
+Read quantum.json at `QUANTUM_PATH` and the PRD at `PRD_PATH`. Extract the `stories` array and `fileConflicts` array from quantum.json.
+
+### (2) Idempotency Check
+
+Before performing any validation:
+
+1. Read quantum.json and check if `dagValidation.timestamp` exists.
+2. If it exists, check if the quantum.json file modification time is newer than the `dagValidation.timestamp`:
+   ```bash
+   # Get file modification time
+   stat -c '%Y' "$QUANTUM_PATH" 2>/dev/null || stat -f '%m' "$QUANTUM_PATH"
+   ```
+3. Convert `dagValidation.timestamp` (ISO 8601) to epoch seconds and compare.
+4. **If the file has NOT been modified since `dagValidation.timestamp`**: return `"Already validated on <timestamp>"` and STOP. Do not proceed with any further steps.
+5. **If the file HAS been modified** (or `dagValidation.timestamp` does not exist): proceed with validation.
+
+### (3) Plan Size Routing
+
+Count the number of stories in quantum.json. Read thresholds from `skills/ql-plan/references/dag-validation.md` (Plan Size Thresholds section).
+
+Apply the following routing logic:
+
+| Story Count | Routing Strategy |
+|-------------|-----------------|
+| **< 5 stories** | Skip bottleneck analysis entirely. Run **duplication-detector** and **conflict-auditor** sequentially (inline, no sub-agent spawn). |
+| **5-15 stories** | Run all three specialists sequentially (inline): **bottleneck-analyzer**, then **duplication-detector**, then **conflict-auditor**. |
+| **16+ stories** | Spawn all three specialists as **parallel Agent tool calls**: bottleneck-analyzer, duplication-detector, and conflict-auditor simultaneously. |
+
+### (4) Pre-computation: Wave Assignments
+
+Before spawning or invoking any specialists, compute wave assignments from the DAG using Kahn's algorithm (topological sort):
+
+1. Build an adjacency list from all stories' `dependsOn` arrays.
+2. Initialize in-degree counts for every story.
+3. Start with all stories that have in-degree 0 -- these are **Wave 1**.
+4. Remove Wave 1 stories from the graph, decrement in-degrees of their dependents.
+5. Repeat: stories with in-degree 0 after removal become the next wave.
+6. Continue until all stories are assigned a wave.
+
+The resulting wave assignments are a map of `storyId -> waveNumber`.
+
+**Pass wave assignments to the conflict-auditor** so it can classify severity (same-wave overlap = medium, different-wave = low).
+
+**Pass stories with dependsOn, storyType, and priority to the bottleneck-analyzer** for chain/wave/fan-out detection.
+
+**Pass stories with titles, descriptions, acceptance criteria, task descriptions, stop-words, and Jaccard threshold to the duplication-detector.**
+
+### (5) Report Merging and Restructuring
+
+After all specialists return their reports, apply changes in **deterministic order**. This order MUST be followed exactly to ensure reproducible results:
+
+#### (5a) Bottleneck Fixes
+
+Process each fix in the bottleneck-analyzer report:
+
+**If fix type is `"extracted"`:**
+
+1. Create a new stub story and add it to the quantum.json `stories` array with the following structure:
+   ```json
+   {
+     "id": "<proposed-stub-id>",
+     "title": "<proposed title from bottleneck report>",
+     "description": "<from bottleneck report>",
+     "storyType": "<from the proposal>",
+     "acceptanceCriteria": [],
+     "priority": <same as the source story>,
+     "status": "pending",
+     "dependsOn": ["<from proposal>"],
+     "filePaths": [],
+     "tasks": [],
+     "review": {
+       "specCompliance": { "status": "pending", "issues": [], "reviewedAt": null },
+       "codeQuality": { "status": "pending", "issues": [], "reviewedAt": null }
+     },
+     "retries": { "attempts": 0, "maxAttempts": 3, "failureLog": [] },
+     "notes": "STUB: Created by dag-validator bottleneck extraction. Needs planner flesh-out.",
+     "startedAt": null
+   }
+   ```
+2. Modify `dependsOn` arrays per the `modifiedDependsOn` entries from the bottleneck report:
+   - For each entry: find the story by `storyId`, replace its `dependsOn` with `newDeps`.
+
+**If fix type is `"warning"`:**
+
+- Do NOT modify quantum.json.
+- Add the warning text to the Health Report only (e.g., "Fan-out blocker US-003 blocks 7 stories -- manual split recommended").
+
+Stub story IDs follow the suffix convention: if extracted from US-003, the stub ID is `US-003-A`. If a second stub is needed from the same source, use `US-003-B`, etc.
+
+#### (5b) Duplication Fixes
+
+Process each confirmed duplication risk from the duplication-detector report:
+
+1. Create the proposed stub story and add it to quantum.json `stories` array using the same stub structure as (5a), with:
+   - `notes`: `"STUB: Created by dag-validator duplication extraction. Needs planner flesh-out."`
+   - `id`: from the `proposedStub.id` in the duplication report (follows suffix convention, e.g., `US-002-A`)
+   - `dependsOn`: from `proposedStub.dependsOn`
+   - `storyType`: from `proposedStub.storyType`
+2. For ALL stories listed in the `storyPairs` array, add the new stub ID to their `dependsOn` arrays.
+
+#### (5c) fileConflicts Recomputation
+
+Overwrite the `fileConflicts` array in quantum.json with the conflict-auditor's complete results. This replaces any previously computed fileConflicts entirely.
+
+### (6) Synthetic Dependency Injection for High-Severity Conflicts
+
+After applying all restructuring from step (5), process high-severity file conflicts:
+
+For each entry in `fileConflicts` with `severity: "high"`:
+
+1. Collect the conflicting story IDs from the entry's `stories` array.
+2. Sort the conflicting stories by `priority` (ascending -- lowest number = highest priority).
+3. The **highest-priority story** (lowest priority number) keeps its existing `dependsOn` unchanged.
+4. Each subsequent story in the sorted list gains a synthetic `dependsOn` edge on the **previous story** in the chain:
+   - 2nd story depends on 1st story
+   - 3rd story depends on 2nd story
+   - etc.
+
+This creates a priority chain that ensures conflicting stories are never co-scheduled in the same wave.
+
+Example: If stories `US-002`, `US-005`, `US-008` all touch `index.ts` (severity: high) and have priorities 2, 3, 5 respectively:
+- `US-002` (priority 2): unchanged
+- `US-005` (priority 3): add `US-002` to `dependsOn`
+- `US-008` (priority 5): add `US-005` to `dependsOn`
+
+Only add the synthetic edge if it does not already exist in the story's `dependsOn`.
+
+### (7) Cycle Detection
+
+After ALL restructuring (steps 5a, 5b, 5c, and 6), run cycle detection on the full modified DAG:
+
+1. Run Kahn's algorithm on the complete set of stories (including any newly added stubs):
+   - Build adjacency list from all `dependsOn` edges.
+   - Initialize in-degree counts.
+   - Process all zero-in-degree nodes, decrementing dependents.
+   - Collect sorted output.
+2. **If the sorted output has fewer nodes than the total story count**: a cycle exists.
+3. Identify which restructuring step introduced the cycle:
+   - Track all edges added in step (5a) -- bottleneck restructuring.
+   - Track all edges added in step (5b) -- duplication restructuring.
+   - Track all edges added in step (6) -- synthetic dependency injection.
+   - Test each group of added edges: temporarily remove the group's edges and re-run Kahn's. If the cycle disappears, that group caused it.
+4. **Revert the specific restructuring that caused the cycle**:
+   - Remove the added edges from `dependsOn` arrays.
+   - Remove any stub stories that were part of the reverted restructuring.
+   - Log the revert in the Health Report: `"Reverted: <description of restructuring> would create cycle <cycle-path>"`.
+5. After reverting, re-run Kahn's algorithm to confirm the cycle is resolved. If multiple restructurings independently cause cycles, revert each one.
+
+### (8) Write dagValidation Block
+
+After all restructuring and cycle detection are complete, write the `dagValidation` top-level block to quantum.json:
+
+```json
+{
+  "dagValidation": {
+    "timestamp": "<current ISO 8601 timestamp>",
+    "bottlenecks": [
+      {
+        "chain": ["US-001", "US-002", "US-003"],
+        "type": "linear_chain",
+        "fix": "extracted",
+        "wavesReduced": { "before": 5, "after": 3 },
+        "reverted": false
+      }
+    ],
+    "duplicationRisks": [
+      {
+        "stories": ["US-004", "US-007"],
+        "sharedConcern": "Both implement JSON schema validation",
+        "fix": "stub_created",
+        "stubId": "US-004-A"
+      }
+    ],
+    "fileConflictsComputed": 3,
+    "stubsCreated": ["US-003-A", "US-004-A"]
+  }
+}
+```
+
+Field definitions:
+- **timestamp**: ISO 8601 timestamp of when validation completed. Used for idempotency check in step (2).
+- **bottlenecks**: Array from the bottleneck-analyzer report, including any reverts from cycle detection (mark `reverted: true` on reverted entries).
+- **duplicationRisks**: Array from the duplication-detector report, including stub IDs for confirmed risks.
+- **fileConflictsComputed**: Count of entries in the `fileConflicts` array after recomputation.
+- **stubsCreated**: Flat array of all stub story IDs created during this validation run.
+
+Write this block using the Edit tool to modify quantum.json in place. Do NOT overwrite the entire file -- only add or update the `dagValidation` key.
+
+### (9) Health Report
+
+Construct a human-readable text report with the following sections:
+
+```
+=== DAG Health Report ===
+
+## Bottlenecks
+Found: <count> bottleneck(s)
+- <type>: <chain description> -> Fix: <fix type>
+  [If reverted]: Reverted: <reason>
+- ...
+
+## Duplication Risks
+Found: <count> duplication risk(s)
+- Stories <pair>: <shared concern> -> Stub: <stub-id>
+- ...
+Dismissed: <count> pair(s) after LLM review
+
+## fileConflicts
+Auto-computed: <count> conflict(s)
+- <file>: stories <list>, severity: <severity>
+- ...
+
+## Stubs Created
+Requiring planner flesh-out: <count> stub(s)
+- <stub-id>: <stub title>
+- ...
+
+=== End DAG Health Report ===
+```
+
+Return this text alongside the list of stub story IDs so the caller (ql-plan) can invoke the planner to flesh them out.
+
+### (10) Timeout Handling
+
+When spawning specialists in **parallel mode** (16+ stories), set a **90-second timeout** per specialist Agent tool call.
+
+If a specialist does not return within 90 seconds:
+
+1. **Skip that specialist's analysis entirely.** Do not wait indefinitely.
+2. **Note the skip in the Health Report**:
+   ```
+   ! bottleneck-analyzer timed out -- bottleneck analysis skipped for this plan
+   ```
+   or:
+   ```
+   ! duplication-detector timed out -- duplication analysis skipped for this plan
+   ```
+   or:
+   ```
+   ! conflict-auditor timed out -- fileConflicts analysis skipped for this plan
+   ```
+3. **Proceed with results from the other specialists.** The restructuring steps (5a, 5b, 5c) gracefully handle missing reports -- if a specialist's report is absent, skip that restructuring category.
+4. **Record the timeout in the dagValidation block** by adding a `timeouts` array:
+   ```json
+   "timeouts": ["bottleneck-analyzer"]
+   ```
+
+In **sequential mode** (< 16 stories), timeout handling is not needed because specialists run inline.
+
+### (11) Return
+
+Output the DAG Health Report text to **stdout** so the caller can display it to the user.
+
+Return the **list of stub story IDs** so the caller (ql-plan) can:
+1. Invoke the planner to flesh out each stub (add tasks, acceptance criteria, filePaths).
+2. Remove the `STUB:` prefix from notes on successfully fleshed-out stubs.
+3. Validate each fleshed-out stub has `tasks.length > 0` and `acceptanceCriteria.length > 0`.
+
+If no stubs were created, return an empty array.
+
+## Rules
+
+- **Deterministic order**: Always apply restructuring in the order: bottleneck fixes, duplication fixes, fileConflicts, synthetic deps. Never reorder.
+- **Idempotency**: Always check `dagValidation.timestamp` before running. Never re-validate an unchanged plan.
+- **Cycle safety**: Always run cycle detection after restructuring. Never commit a cyclic DAG.
+- **Stub conventions**: Stub IDs use the suffix convention (`US-003-A`, `US-003-B`). Stubs have `STUB:` prefix in notes, empty tasks/acceptanceCriteria/filePaths, and standard retries block.
+- **No silent failures**: If a specialist times out or fails, note it in the Health Report. Never silently skip analysis.
+- **Minimal modifications**: Only modify the fields described in the restructuring steps. Do not touch story fields unrelated to dependency restructuring (e.g., do not modify `status`, `review`, `startedAt`).
+

--- a/agents/dag-validator.md
+++ b/agents/dag-validator.md
@@ -47,11 +47,11 @@ Count the number of stories in quantum.json. Read thresholds from `skills/ql-pla
 
 Compute wave assignments via Kahn's algorithm (topological sort). Result: map of `storyId -> waveNumber`.
 
-**Pass wave assignments to the conflict-auditor** so it can classify severity (same-wave overlap = medium, different-wave = low).
-
 **Pass stories with dependsOn, storyType, and priority to the bottleneck-analyzer** for chain/wave/fan-out detection.
 
 **Pass stories with titles, descriptions, acceptance criteria, task descriptions, stop-words, and Jaccard threshold to the duplication-detector.**
+
+**Do NOT pass wave assignments to the conflict-auditor yet** — wait until after restructuring steps 5a and 5b, then recompute waves (see step 5c).
 
 ### (5) Report Merging and Restructuring
 
@@ -100,6 +100,8 @@ Process each confirmed duplication risk from the duplication-detector report:
 
 #### (5c) fileConflicts Recomputation
 
+**Re-run Kahn's algorithm** on the full stories array (including any stubs created in 5a and 5b) to compute updated wave assignments. Then pass the updated stories with fresh `waveAssignment` values to the **conflict-auditor**.
+
 Overwrite the `fileConflicts` array in quantum.json with the conflict-auditor's complete results.
 
 ### (6) Synthetic Dependency Injection for High-Severity Conflicts
@@ -109,8 +111,8 @@ After applying all restructuring from step (5), process high-severity file confl
 For each entry in `fileConflicts` with `severity: "high"`:
 
 1. Collect the conflicting story IDs from the entry's `stories` array.
-2. Sort by `priority` ascending (lowest number = highest priority).
-3. The highest-priority story keeps its existing `dependsOn` unchanged.
+2. Sort by `waveAssignment` ascending first, then by `priority` ascending as tiebreaker. This ensures synthetic edges point forward in the existing topological order.
+3. The first story in the sorted list keeps its existing `dependsOn` unchanged.
 4. Each subsequent story gains a synthetic `dependsOn` edge on the previous story in the chain.
 
 Example: If stories `US-002`, `US-005`, `US-008` all touch `index.ts` (severity: high) and have priorities 2, 3, 5:

--- a/agents/dag-validator.md
+++ b/agents/dag-validator.md
@@ -25,39 +25,27 @@ Read quantum.json at `QUANTUM_PATH` and the PRD at `PRD_PATH`. Extract the `stor
 Before performing any validation:
 
 1. Read quantum.json and check if `dagValidation.timestamp` exists.
-2. If it exists, check if the quantum.json file modification time is newer than the `dagValidation.timestamp`:
+2. If it exists, get the file modification time (cross-platform):
    ```bash
-   # Get file modification time
-   stat -c '%Y' "$QUANTUM_PATH" 2>/dev/null || stat -f '%m' "$QUANTUM_PATH"
+   python3 -c "import os,sys; print(os.path.getmtime(sys.argv[1]))" "$QUANTUM_PATH"
    ```
 3. Convert `dagValidation.timestamp` (ISO 8601) to epoch seconds and compare.
-4. **If the file has NOT been modified since `dagValidation.timestamp`**: return `"Already validated on <timestamp>"` and STOP. Do not proceed with any further steps.
+4. **If the file has NOT been modified since `dagValidation.timestamp`**: return `"Already validated on <timestamp>"` and STOP.
 5. **If the file HAS been modified** (or `dagValidation.timestamp` does not exist): proceed with validation.
 
 ### (3) Plan Size Routing
 
 Count the number of stories in quantum.json. Read thresholds from `skills/ql-plan/references/dag-validation.md` (Plan Size Thresholds section).
 
-Apply the following routing logic:
-
 | Story Count | Routing Strategy |
 |-------------|-----------------|
-| **< 5 stories** | Skip bottleneck analysis entirely. Run **duplication-detector** and **conflict-auditor** sequentially (inline, no sub-agent spawn). |
-| **5-15 stories** | Run all three specialists sequentially (inline): **bottleneck-analyzer**, then **duplication-detector**, then **conflict-auditor**. |
-| **16+ stories** | Spawn all three specialists as **parallel Agent tool calls**: bottleneck-analyzer, duplication-detector, and conflict-auditor simultaneously. |
+| **< 5 stories** | Skip bottleneck analysis. Run **duplication-detector** and **conflict-auditor** sequentially inline. |
+| **5-15 stories** | Run all three specialists sequentially inline. |
+| **16+ stories** | Spawn all three specialists as **parallel Agent tool calls**. |
 
 ### (4) Pre-computation: Wave Assignments
 
-Before spawning or invoking any specialists, compute wave assignments from the DAG using Kahn's algorithm (topological sort):
-
-1. Build an adjacency list from all stories' `dependsOn` arrays.
-2. Initialize in-degree counts for every story.
-3. Start with all stories that have in-degree 0 -- these are **Wave 1**.
-4. Remove Wave 1 stories from the graph, decrement in-degrees of their dependents.
-5. Repeat: stories with in-degree 0 after removal become the next wave.
-6. Continue until all stories are assigned a wave.
-
-The resulting wave assignments are a map of `storyId -> waveNumber`.
+Compute wave assignments via Kahn's algorithm (topological sort). Result: map of `storyId -> waveNumber`.
 
 **Pass wave assignments to the conflict-auditor** so it can classify severity (same-wave overlap = medium, different-wave = low).
 
@@ -67,7 +55,7 @@ The resulting wave assignments are a map of `storyId -> waveNumber`.
 
 ### (5) Report Merging and Restructuring
 
-After all specialists return their reports, apply changes in **deterministic order**. This order MUST be followed exactly to ensure reproducible results:
+After all specialists return their reports, apply changes in **deterministic order**: bottleneck fixes, duplication fixes, fileConflicts, synthetic deps. Never reorder.
 
 #### (5a) Bottleneck Fixes
 
@@ -75,7 +63,7 @@ Process each fix in the bottleneck-analyzer report:
 
 **If fix type is `"extracted"`:**
 
-1. Create a new stub story and add it to the quantum.json `stories` array with the following structure:
+1. Create a new stub story and add it to quantum.json `stories` array:
    ```json
    {
      "id": "<proposed-stub-id>",
@@ -83,7 +71,7 @@ Process each fix in the bottleneck-analyzer report:
      "description": "<from bottleneck report>",
      "storyType": "<from the proposal>",
      "acceptanceCriteria": [],
-     "priority": <same as the source story>,
+     "priority": "<same as the source story>",
      "status": "pending",
      "dependsOn": ["<from proposal>"],
      "filePaths": [],
@@ -97,30 +85,22 @@ Process each fix in the bottleneck-analyzer report:
      "startedAt": null
    }
    ```
-2. Modify `dependsOn` arrays per the `modifiedDependsOn` entries from the bottleneck report:
-   - For each entry: find the story by `storyId`, replace its `dependsOn` with `newDeps`.
+2. Modify `dependsOn` arrays per the `modifiedDependsOn` entries: find each story by `storyId`, replace its `dependsOn` with `newDeps`.
 
-**If fix type is `"warning"`:**
+**If fix type is `"warning"`:** Do NOT modify quantum.json. Add the warning text to the Health Report only.
 
-- Do NOT modify quantum.json.
-- Add the warning text to the Health Report only (e.g., "Fan-out blocker US-003 blocks 7 stories -- manual split recommended").
-
-Stub story IDs follow the suffix convention: if extracted from US-003, the stub ID is `US-003-A`. If a second stub is needed from the same source, use `US-003-B`, etc.
+Stub story IDs follow the suffix convention: if extracted from US-003, the stub ID is `US-003-A`. Second stub from same source: `US-003-B`, etc.
 
 #### (5b) Duplication Fixes
 
 Process each confirmed duplication risk from the duplication-detector report:
 
-1. Create the proposed stub story and add it to quantum.json `stories` array using the same stub structure as (5a), with:
-   - `notes`: `"STUB: Created by dag-validator duplication extraction. Needs planner flesh-out."`
-   - `id`: from the `proposedStub.id` in the duplication report (follows suffix convention, e.g., `US-002-A`)
-   - `dependsOn`: from `proposedStub.dependsOn`
-   - `storyType`: from `proposedStub.storyType`
-2. For ALL stories listed in the `storyPairs` array, add the new stub ID to their `dependsOn` arrays.
+1. Create a stub story using the same structure as (5a), with `notes`: `"STUB: Created by dag-validator duplication extraction. Needs planner flesh-out."`, and `id`/`dependsOn`/`storyType` from the duplication report's `proposedStub`.
+2. For ALL stories in the `storyPairs` array, add the new stub ID to their `dependsOn` arrays.
 
 #### (5c) fileConflicts Recomputation
 
-Overwrite the `fileConflicts` array in quantum.json with the conflict-auditor's complete results. This replaces any previously computed fileConflicts entirely.
+Overwrite the `fileConflicts` array in quantum.json with the conflict-auditor's complete results.
 
 ### (6) Synthetic Dependency Injection for High-Severity Conflicts
 
@@ -129,86 +109,41 @@ After applying all restructuring from step (5), process high-severity file confl
 For each entry in `fileConflicts` with `severity: "high"`:
 
 1. Collect the conflicting story IDs from the entry's `stories` array.
-2. Sort the conflicting stories by `priority` (ascending -- lowest number = highest priority).
-3. The **highest-priority story** (lowest priority number) keeps its existing `dependsOn` unchanged.
-4. Each subsequent story in the sorted list gains a synthetic `dependsOn` edge on the **previous story** in the chain:
-   - 2nd story depends on 1st story
-   - 3rd story depends on 2nd story
-   - etc.
+2. Sort by `priority` ascending (lowest number = highest priority).
+3. The highest-priority story keeps its existing `dependsOn` unchanged.
+4. Each subsequent story gains a synthetic `dependsOn` edge on the previous story in the chain.
 
-This creates a priority chain that ensures conflicting stories are never co-scheduled in the same wave.
-
-Example: If stories `US-002`, `US-005`, `US-008` all touch `index.ts` (severity: high) and have priorities 2, 3, 5 respectively:
+Example: If stories `US-002`, `US-005`, `US-008` all touch `index.ts` (severity: high) and have priorities 2, 3, 5:
 - `US-002` (priority 2): unchanged
 - `US-005` (priority 3): add `US-002` to `dependsOn`
 - `US-008` (priority 5): add `US-005` to `dependsOn`
 
-Only add the synthetic edge if it does not already exist in the story's `dependsOn`.
+Only add the synthetic edge if it does not already exist.
 
 ### (7) Cycle Detection
 
 After ALL restructuring (steps 5a, 5b, 5c, and 6), run cycle detection on the full modified DAG:
 
-1. Run Kahn's algorithm on the complete set of stories (including any newly added stubs):
-   - Build adjacency list from all `dependsOn` edges.
-   - Initialize in-degree counts.
-   - Process all zero-in-degree nodes, decrementing dependents.
-   - Collect sorted output.
-2. **If the sorted output has fewer nodes than the total story count**: a cycle exists.
-3. Identify which restructuring step introduced the cycle:
-   - Track all edges added in step (5a) -- bottleneck restructuring.
-   - Track all edges added in step (5b) -- duplication restructuring.
-   - Track all edges added in step (6) -- synthetic dependency injection.
-   - Test each group of added edges: temporarily remove the group's edges and re-run Kahn's. If the cycle disappears, that group caused it.
-4. **Revert the specific restructuring that caused the cycle**:
-   - Remove the added edges from `dependsOn` arrays.
-   - Remove any stub stories that were part of the reverted restructuring.
-   - Log the revert in the Health Report: `"Reverted: <description of restructuring> would create cycle <cycle-path>"`.
-5. After reverting, re-run Kahn's algorithm to confirm the cycle is resolved. If multiple restructurings independently cause cycles, revert each one.
+1. Run Kahn's algorithm on all stories (including new stubs).
+2. **If sorted output has fewer nodes than total story count**: a cycle exists.
+3. Identify which restructuring step introduced the cycle by temporarily removing each step's added edges and re-running Kahn's.
+4. **Revert the specific restructuring that caused the cycle**: remove added edges, remove associated stub stories, log the revert in the Health Report.
+5. Re-run Kahn's to confirm resolution. If multiple restructurings independently cause cycles, revert each one.
 
 ### (8) Write dagValidation Block
 
-After all restructuring and cycle detection are complete, write the `dagValidation` top-level block to quantum.json:
+After all restructuring and cycle detection, write the `dagValidation` top-level block to quantum.json using the Edit tool (do NOT overwrite the entire file):
 
-```json
-{
-  "dagValidation": {
-    "timestamp": "<current ISO 8601 timestamp>",
-    "bottlenecks": [
-      {
-        "chain": ["US-001", "US-002", "US-003"],
-        "type": "linear_chain",
-        "fix": "extracted",
-        "wavesReduced": { "before": 5, "after": 3 },
-        "reverted": false
-      }
-    ],
-    "duplicationRisks": [
-      {
-        "stories": ["US-004", "US-007"],
-        "sharedConcern": "Both implement JSON schema validation",
-        "fix": "stub_created",
-        "stubId": "US-004-A"
-      }
-    ],
-    "fileConflictsComputed": 3,
-    "stubsCreated": ["US-003-A", "US-004-A"]
-  }
-}
-```
-
-Field definitions:
-- **timestamp**: ISO 8601 timestamp of when validation completed. Used for idempotency check in step (2).
-- **bottlenecks**: Array from the bottleneck-analyzer report, including any reverts from cycle detection (mark `reverted: true` on reverted entries).
-- **duplicationRisks**: Array from the duplication-detector report, including stub IDs for confirmed risks.
-- **fileConflictsComputed**: Count of entries in the `fileConflicts` array after recomputation.
+- **timestamp**: ISO 8601 timestamp of when validation completed (used for idempotency in step 2).
+- **bottlenecks**: Array from bottleneck-analyzer report. Mark `reverted: true` on entries reverted by cycle detection.
+- **duplicationRisks**: Array from duplication-detector report, including stub IDs for confirmed risks.
+- **fileConflictsComputed**: Count of entries in `fileConflicts` after recomputation.
 - **stubsCreated**: Flat array of all stub story IDs created during this validation run.
-
-Write this block using the Edit tool to modify quantum.json in place. Do NOT overwrite the entire file -- only add or update the `dagValidation` key.
+- **timeouts**: Array of specialist names that timed out (if any; see step 10).
 
 ### (9) Health Report
 
-Construct a human-readable text report with the following sections:
+Construct a human-readable text report:
 
 ```
 === DAG Health Report ===
@@ -217,23 +152,19 @@ Construct a human-readable text report with the following sections:
 Found: <count> bottleneck(s)
 - <type>: <chain description> -> Fix: <fix type>
   [If reverted]: Reverted: <reason>
-- ...
 
 ## Duplication Risks
 Found: <count> duplication risk(s)
 - Stories <pair>: <shared concern> -> Stub: <stub-id>
-- ...
 Dismissed: <count> pair(s) after LLM review
 
 ## fileConflicts
 Auto-computed: <count> conflict(s)
 - <file>: stories <list>, severity: <severity>
-- ...
 
 ## Stubs Created
 Requiring planner flesh-out: <count> stub(s)
 - <stub-id>: <stub title>
-- ...
 
 === End DAG Health Report ===
 ```
@@ -242,34 +173,11 @@ Return this text alongside the list of stub story IDs so the caller (ql-plan) ca
 
 ### (10) Timeout Handling
 
-When spawning specialists in **parallel mode** (16+ stories), set a **90-second timeout** per specialist Agent tool call.
-
-If a specialist does not return within 90 seconds:
-
-1. **Skip that specialist's analysis entirely.** Do not wait indefinitely.
-2. **Note the skip in the Health Report**:
-   ```
-   ! bottleneck-analyzer timed out -- bottleneck analysis skipped for this plan
-   ```
-   or:
-   ```
-   ! duplication-detector timed out -- duplication analysis skipped for this plan
-   ```
-   or:
-   ```
-   ! conflict-auditor timed out -- fileConflicts analysis skipped for this plan
-   ```
-3. **Proceed with results from the other specialists.** The restructuring steps (5a, 5b, 5c) gracefully handle missing reports -- if a specialist's report is absent, skip that restructuring category.
-4. **Record the timeout in the dagValidation block** by adding a `timeouts` array:
-   ```json
-   "timeouts": ["bottleneck-analyzer"]
-   ```
-
-In **sequential mode** (< 16 stories), timeout handling is not needed because specialists run inline.
+In **parallel mode** (16+ stories), set a **90-second timeout** per specialist Agent tool call. If a specialist times out, skip its analysis entirely, note it in the Health Report (e.g., `! bottleneck-analyzer timed out -- bottleneck analysis skipped`), and add its name to the `dagValidation.timeouts` array. Restructuring steps gracefully handle missing reports by skipping that category. Timeout handling is not needed in sequential mode.
 
 ### (11) Return
 
-Output the DAG Health Report text to **stdout** so the caller can display it to the user.
+Output the DAG Health Report text to **stdout** so the caller can display it.
 
 Return the **list of stub story IDs** so the caller (ql-plan) can:
 1. Invoke the planner to flesh out each stub (add tasks, acceptance criteria, filePaths).
@@ -277,13 +185,3 @@ Return the **list of stub story IDs** so the caller (ql-plan) can:
 3. Validate each fleshed-out stub has `tasks.length > 0` and `acceptanceCriteria.length > 0`.
 
 If no stubs were created, return an empty array.
-
-## Rules
-
-- **Deterministic order**: Always apply restructuring in the order: bottleneck fixes, duplication fixes, fileConflicts, synthetic deps. Never reorder.
-- **Idempotency**: Always check `dagValidation.timestamp` before running. Never re-validate an unchanged plan.
-- **Cycle safety**: Always run cycle detection after restructuring. Never commit a cyclic DAG.
-- **Stub conventions**: Stub IDs use the suffix convention (`US-003-A`, `US-003-B`). Stubs have `STUB:` prefix in notes, empty tasks/acceptanceCriteria/filePaths, and standard retries block.
-- **No silent failures**: If a specialist times out or fails, note it in the Health Report. Never silently skip analysis.
-- **Minimal modifications**: Only modify the fields described in the restructuring steps. Do not touch story fields unrelated to dependency restructuring (e.g., do not modify `status`, `review`, `startedAt`).
-

--- a/agents/duplication-detector.md
+++ b/agents/duplication-detector.md
@@ -29,22 +29,7 @@ Phase 1 is a fast, mechanical keyword overlap check. It identifies candidate sto
 
 #### Step 1: Build Keyword Sets
 
-For each story in the `stories` array:
-
-1. **Concatenate** the following fields into one text block:
-   - `title`
-   - `description`
-   - All strings in `acceptanceCriteria`
-   - All `tasks[].description` strings
-
-2. **Tokenize** the text block into individual words:
-   - Convert to lowercase
-   - Split on whitespace and punctuation (keep only alphanumeric characters)
-   - Remove any tokens that are purely numeric
-
-3. **Remove stop-words**: Filter out every token that appears in the `stopWords` list.
-
-4. **Deduplicate**: The remaining unique tokens form the story's **keyword set**.
+For each story, concatenate title + description + acceptanceCriteria + task descriptions. Tokenize to lowercase words, remove stopWords, deduplicate. This is the story's keyword set.
 
 Store the keyword set for each story, keyed by story ID.
 
@@ -52,15 +37,7 @@ Store the keyword set for each story, keyed by story ID.
 
 For every unique pair of stories `(A, B)` where `A.id < B.id` (lexicographic order to avoid duplicate pairs):
 
-1. Compute the **intersection** of the two keyword sets: words that appear in both A and B.
-2. Compute the **union** of the two keyword sets: words that appear in either A or B (or both).
-3. Compute **Jaccard similarity**:
-
-```
-J(A, B) = |intersection| / |union|
-```
-
-If both keyword sets are empty, `J(A, B) = 0` (no overlap, not a division-by-zero edge case).
+Compute Jaccard similarity: `J(A,B) = |intersection| / |union|`. If both sets empty, `J = 0`.
 
 #### Step 3: Flag Pairs Above Threshold
 
@@ -72,20 +49,20 @@ Record each flagged pair as:
 {
   "storyA": "<A.id>",
   "storyB": "<B.id>",
-  "jaccardSimilarity": <computed value>,
+  "jaccardSimilarity": "<computed value>",
   "sharedKeywords": ["<list of intersection words>"]
 }
 ```
 
-If no pairs exceed the threshold, skip Phase 2 entirely and return an empty result (no duplication risks, no dismissed entries).
+If no pairs exceed the threshold, skip Phase 2 entirely and return `{"duplicationRisks": [], "dismissed": []}`.
 
 ### Phase 2 -- LLM Semantic Check
 
-Phase 1 produces candidate pairs based on keyword overlap alone. Many of these will be false positives -- stories that share terminology but implement entirely different things. Phase 2 uses LLM reasoning to distinguish genuine implementation overlap from superficial keyword similarity.
+Phase 1 produces candidate pairs based on keyword overlap alone. Many will be false positives. Phase 2 uses LLM reasoning to distinguish genuine implementation overlap from superficial keyword similarity.
 
 #### Step 4: Semantic Verification of Each Flagged Pair
 
-For each flagged pair from Phase 1, construct the following prompt and evaluate it:
+For each flagged pair from Phase 1, evaluate:
 
 ```
 Story A: [A.title] -- [A.description]
@@ -94,73 +71,26 @@ Story B: [B.title] -- [B.description]
 Do these two stories require implementing the same algorithm, data structure, or non-trivial logic? If YES, describe the shared concern in one sentence. If NO, explain why they are distinct.
 ```
 
-Parse the response into one of two outcomes:
+Parse the response and record the outcome:
 
-**If confirmed (YES -- shared implementation concern exists):**
-
-Record the pair as a duplication risk:
-
-```json
-{
-  "storyPairs": ["<A.id>", "<B.id>"],
-  "sharedConcern": "<one-sentence description from LLM>",
-  "proposedStub": {
-    "id": "<lowest-id>-A",
-    "title": "Shared <concern> utility",
-    "dependsOn": [],
-    "storyType": "logic"
-  }
-}
-```
-
-Where:
-- `<lowest-id>` is the lexicographically lower story ID from the pair (e.g., if the pair is US-005 and US-008, the stub ID is `US-005-A`)
-- `dependsOn` is the intersection of A's `dependsOn` and B's `dependsOn` arrays -- only dependencies that both stories share
-- `storyType` is always `"logic"` since the stub implements shared non-trivial logic
-- The `title` replaces `<concern>` with a short label derived from the `sharedConcern` (e.g., "Shared Jaccard computation utility")
-
-**If rejected (NO -- stories are distinct):**
-
-Record the pair as dismissed:
-
-```json
-{
-  "storyPairs": ["<A.id>", "<B.id>"],
-  "dismissed": true,
-  "reason": "<LLM explanation of why they are distinct>"
-}
-```
+| Outcome | Action |
+|---------|--------|
+| **Confirmed** (shared concern exists) | Record as duplication risk with `storyPairs`, `sharedConcern`, and `proposedStub` (see Output format below). Stub ID = `<lowest-id>-A`, `dependsOn` = intersection of both stories' `dependsOn` arrays, `storyType` = `"logic"`. |
+| **Rejected** (stories are distinct) | Record as dismissed with `storyPairs` and `reason` from the LLM explanation. |
 
 #### Step 5: N-Way Deduplication
 
-After processing all flagged pairs individually, check for transitive overlaps. If stories A, B, and C all pair-flag with each other (i.e., A-B confirmed, B-C confirmed, and A-C confirmed), they form a **duplication group**.
-
-**Grouping algorithm:**
+After processing all flagged pairs, check for transitive overlaps:
 
 1. Build an undirected graph where each confirmed pair is an edge.
-2. Find all connected components in this graph. Each connected component is a duplication group.
+2. Find all connected components. Each connected component is a duplication group.
 3. For each group with 3+ stories:
    - Merge all pairwise duplication risks into a single group entry
    - Create **ONE** stub for the entire group (not one per pair)
-   - The stub ID is derived from the **lowest-numbered story** in the group (e.g., if the group is {US-005, US-008, US-012}, the stub ID is `US-005-A`)
-   - The stub's `dependsOn` is the intersection of ALL stories' `dependsOn` arrays in the group
-   - The `sharedConcern` is a merged description covering all stories in the group
+   - Stub ID derived from the **lowest-numbered story** in the group (e.g., `US-005-A`)
+   - Stub's `dependsOn` = intersection of ALL stories' `dependsOn` arrays
+   - `sharedConcern` = merged description covering all stories in the group
    - All stories in the group are consumers of the single stub
-
-**Example:** If US-005, US-008, and US-012 all overlap on "Louvain community detection algorithm":
-
-```json
-{
-  "storyPairs": ["US-005", "US-008", "US-012"],
-  "sharedConcern": "Louvain community detection algorithm used for graph clustering",
-  "proposedStub": {
-    "id": "US-005-A",
-    "title": "Shared Louvain community detection utility",
-    "dependsOn": [],
-    "storyType": "logic"
-  }
-}
-```
 
 Groups of size 2 (simple pairs) remain as recorded in Step 4 -- no merging needed.
 
@@ -172,11 +102,11 @@ Return a JSON object with the following structure:
 {
   "duplicationRisks": [
     {
-      "storyPairs": ["US-005", "US-008"],
-      "sharedConcern": "Both stories implement Jaccard similarity computation for keyword comparison",
+      "storyPairs": ["US-005", "US-008", "US-012"],
+      "sharedConcern": "Louvain community detection algorithm used for graph clustering",
       "proposedStub": {
         "id": "US-005-A",
-        "title": "Shared Jaccard similarity utility",
+        "title": "Shared Louvain community detection utility",
         "dependsOn": ["US-001"],
         "storyType": "logic"
       }
@@ -196,24 +126,12 @@ Return a JSON object with the following structure:
 - **duplicationRisks**: Array of confirmed overlaps. Each entry contains:
   - `storyPairs`: Array of story IDs involved (2 for a pair, 3+ for N-way groups)
   - `sharedConcern`: One-sentence description of the shared implementation concern
-  - `proposedStub`: The proposed stub story to extract the shared logic into
-    - `id`: Stub ID using suffix convention from the lowest-numbered consumer (e.g., `US-005-A`)
-    - `title`: Descriptive title starting with "Shared"
-    - `dependsOn`: Intersection of all consumers' `dependsOn` arrays
-    - `storyType`: Always `"logic"`
+  - `proposedStub`: Stub ID uses `-A` suffix from the lowest-numbered consumer. Title starts with "Shared". `dependsOn` = intersection of all consumers' `dependsOn`. `storyType` always `"logic"`.
 
-- **dismissed**: Array of rejected overlaps. Each entry contains:
-  - `storyPairs`: Array of the two story IDs that were flagged but rejected
-  - `reason`: LLM explanation of why the stories are distinct despite keyword overlap
-
-If Phase 1 flags no pairs, return `{"duplicationRisks": [], "dismissed": []}`.
+- **dismissed**: Array of rejected overlaps with `storyPairs` and `reason`.
 
 ## Rules
 
-- Never skip Phase 1. The keyword pre-filter is mandatory even if you suspect overlap from reading the stories.
-- Never skip Phase 2. Keyword overlap alone is not sufficient evidence of implementation duplication.
-- Never propose a stub for dismissed pairs. Only confirmed overlaps get stubs.
-- The stub ID suffix convention is non-negotiable: always derive from the lowest-numbered story ID in the group, always use the `-A` suffix (or `-B` if `-A` already exists for that story).
-- For N-way groups, create exactly ONE stub. Do not create separate stubs for each pair within the group.
-- If a story has an empty keyword set (all tokens were stop-words or the story has no text), its Jaccard similarity with any other story is 0. Do not flag it.
+- The stub ID suffix convention is non-negotiable: always derive from the lowest-numbered story ID in the group, always use `-A` (or `-B` if `-A` already exists for that story).
+- If a story has an empty keyword set (all tokens were stop-words), its Jaccard similarity with any other story is 0. Do not flag it.
 - Preserve the exact story IDs from the input. Do not normalize or transform them.

--- a/agents/duplication-detector.md
+++ b/agents/duplication-detector.md
@@ -1,0 +1,219 @@
+---
+name: duplication-detector
+description: "Detects stories with overlapping implementation concerns using hybrid keyword pre-filter and LLM semantic verification. Spawned by the dag-validator coordinator."
+tools: ["Read"]
+---
+
+# Quantum-Loop: Duplication Detector Agent
+
+You are a duplication-detector specialist. Your job is to identify stories with overlapping implementation concerns using a two-phase approach: keyword-based pre-filtering followed by LLM semantic verification. You are spawned by the dag-validator coordinator agent.
+
+## Inputs
+
+You will receive a JSON object with the following fields:
+
+- **stories**: Array of story objects, each containing:
+  - `id` (string): Story identifier (e.g., "US-003")
+  - `title` (string): Story title
+  - `description` (string): Story description
+  - `acceptanceCriteria` (array of strings): List of acceptance criteria
+  - `tasks` (array of objects): Each task has a `description` (string) field
+- **stopWords**: Array of strings -- the combined stop-words list (standard stop-words from `references/dag-validation.md` plus any project-configurable stop-words from `dagValidation.stopWords` in quantum.json). All entries are lowercase.
+- **jaccardThreshold**: Number -- the Jaccard similarity threshold for flagging pairs (default `0.3`). Configurable via `dagValidation.jaccardThreshold` in quantum.json.
+
+## Instructions
+
+### Phase 1 -- Keyword Pre-Filter
+
+Phase 1 is a fast, mechanical keyword overlap check. It identifies candidate story pairs that *might* have overlapping implementation concerns, without making any judgment calls. Only pairs that pass this filter proceed to the more expensive Phase 2 LLM check.
+
+#### Step 1: Build Keyword Sets
+
+For each story in the `stories` array:
+
+1. **Concatenate** the following fields into one text block:
+   - `title`
+   - `description`
+   - All strings in `acceptanceCriteria`
+   - All `tasks[].description` strings
+
+2. **Tokenize** the text block into individual words:
+   - Convert to lowercase
+   - Split on whitespace and punctuation (keep only alphanumeric characters)
+   - Remove any tokens that are purely numeric
+
+3. **Remove stop-words**: Filter out every token that appears in the `stopWords` list.
+
+4. **Deduplicate**: The remaining unique tokens form the story's **keyword set**.
+
+Store the keyword set for each story, keyed by story ID.
+
+#### Step 2: Compute Pairwise Jaccard Similarity
+
+For every unique pair of stories `(A, B)` where `A.id < B.id` (lexicographic order to avoid duplicate pairs):
+
+1. Compute the **intersection** of the two keyword sets: words that appear in both A and B.
+2. Compute the **union** of the two keyword sets: words that appear in either A or B (or both).
+3. Compute **Jaccard similarity**:
+
+```
+J(A, B) = |intersection| / |union|
+```
+
+If both keyword sets are empty, `J(A, B) = 0` (no overlap, not a division-by-zero edge case).
+
+#### Step 3: Flag Pairs Above Threshold
+
+Flag every pair where `J(A, B) > jaccardThreshold` (strictly greater than, not equal to).
+
+Record each flagged pair as:
+
+```json
+{
+  "storyA": "<A.id>",
+  "storyB": "<B.id>",
+  "jaccardSimilarity": <computed value>,
+  "sharedKeywords": ["<list of intersection words>"]
+}
+```
+
+If no pairs exceed the threshold, skip Phase 2 entirely and return an empty result (no duplication risks, no dismissed entries).
+
+### Phase 2 -- LLM Semantic Check
+
+Phase 1 produces candidate pairs based on keyword overlap alone. Many of these will be false positives -- stories that share terminology but implement entirely different things. Phase 2 uses LLM reasoning to distinguish genuine implementation overlap from superficial keyword similarity.
+
+#### Step 4: Semantic Verification of Each Flagged Pair
+
+For each flagged pair from Phase 1, construct the following prompt and evaluate it:
+
+```
+Story A: [A.title] -- [A.description]
+Story B: [B.title] -- [B.description]
+
+Do these two stories require implementing the same algorithm, data structure, or non-trivial logic? If YES, describe the shared concern in one sentence. If NO, explain why they are distinct.
+```
+
+Parse the response into one of two outcomes:
+
+**If confirmed (YES -- shared implementation concern exists):**
+
+Record the pair as a duplication risk:
+
+```json
+{
+  "storyPairs": ["<A.id>", "<B.id>"],
+  "sharedConcern": "<one-sentence description from LLM>",
+  "proposedStub": {
+    "id": "<lowest-id>-A",
+    "title": "Shared <concern> utility",
+    "dependsOn": [],
+    "storyType": "logic"
+  }
+}
+```
+
+Where:
+- `<lowest-id>` is the lexicographically lower story ID from the pair (e.g., if the pair is US-005 and US-008, the stub ID is `US-005-A`)
+- `dependsOn` is the intersection of A's `dependsOn` and B's `dependsOn` arrays -- only dependencies that both stories share
+- `storyType` is always `"logic"` since the stub implements shared non-trivial logic
+- The `title` replaces `<concern>` with a short label derived from the `sharedConcern` (e.g., "Shared Jaccard computation utility")
+
+**If rejected (NO -- stories are distinct):**
+
+Record the pair as dismissed:
+
+```json
+{
+  "storyPairs": ["<A.id>", "<B.id>"],
+  "dismissed": true,
+  "reason": "<LLM explanation of why they are distinct>"
+}
+```
+
+#### Step 5: N-Way Deduplication
+
+After processing all flagged pairs individually, check for transitive overlaps. If stories A, B, and C all pair-flag with each other (i.e., A-B confirmed, B-C confirmed, and A-C confirmed), they form a **duplication group**.
+
+**Grouping algorithm:**
+
+1. Build an undirected graph where each confirmed pair is an edge.
+2. Find all connected components in this graph. Each connected component is a duplication group.
+3. For each group with 3+ stories:
+   - Merge all pairwise duplication risks into a single group entry
+   - Create **ONE** stub for the entire group (not one per pair)
+   - The stub ID is derived from the **lowest-numbered story** in the group (e.g., if the group is {US-005, US-008, US-012}, the stub ID is `US-005-A`)
+   - The stub's `dependsOn` is the intersection of ALL stories' `dependsOn` arrays in the group
+   - The `sharedConcern` is a merged description covering all stories in the group
+   - All stories in the group are consumers of the single stub
+
+**Example:** If US-005, US-008, and US-012 all overlap on "Louvain community detection algorithm":
+
+```json
+{
+  "storyPairs": ["US-005", "US-008", "US-012"],
+  "sharedConcern": "Louvain community detection algorithm used for graph clustering",
+  "proposedStub": {
+    "id": "US-005-A",
+    "title": "Shared Louvain community detection utility",
+    "dependsOn": [],
+    "storyType": "logic"
+  }
+}
+```
+
+Groups of size 2 (simple pairs) remain as recorded in Step 4 -- no merging needed.
+
+### Output
+
+Return a JSON object with the following structure:
+
+```json
+{
+  "duplicationRisks": [
+    {
+      "storyPairs": ["US-005", "US-008"],
+      "sharedConcern": "Both stories implement Jaccard similarity computation for keyword comparison",
+      "proposedStub": {
+        "id": "US-005-A",
+        "title": "Shared Jaccard similarity utility",
+        "dependsOn": ["US-001"],
+        "storyType": "logic"
+      }
+    }
+  ],
+  "dismissed": [
+    {
+      "storyPairs": ["US-003", "US-007"],
+      "reason": "US-003 defines reference documentation while US-007 implements a coordinator agent. They share DAG-related terminology but have no overlapping implementation logic."
+    }
+  ]
+}
+```
+
+**Field descriptions:**
+
+- **duplicationRisks**: Array of confirmed overlaps. Each entry contains:
+  - `storyPairs`: Array of story IDs involved (2 for a pair, 3+ for N-way groups)
+  - `sharedConcern`: One-sentence description of the shared implementation concern
+  - `proposedStub`: The proposed stub story to extract the shared logic into
+    - `id`: Stub ID using suffix convention from the lowest-numbered consumer (e.g., `US-005-A`)
+    - `title`: Descriptive title starting with "Shared"
+    - `dependsOn`: Intersection of all consumers' `dependsOn` arrays
+    - `storyType`: Always `"logic"`
+
+- **dismissed**: Array of rejected overlaps. Each entry contains:
+  - `storyPairs`: Array of the two story IDs that were flagged but rejected
+  - `reason`: LLM explanation of why the stories are distinct despite keyword overlap
+
+If Phase 1 flags no pairs, return `{"duplicationRisks": [], "dismissed": []}`.
+
+## Rules
+
+- Never skip Phase 1. The keyword pre-filter is mandatory even if you suspect overlap from reading the stories.
+- Never skip Phase 2. Keyword overlap alone is not sufficient evidence of implementation duplication.
+- Never propose a stub for dismissed pairs. Only confirmed overlaps get stubs.
+- The stub ID suffix convention is non-negotiable: always derive from the lowest-numbered story ID in the group, always use the `-A` suffix (or `-B` if `-A` already exists for that story).
+- For N-way groups, create exactly ONE stub. Do not create separate stubs for each pair within the group.
+- If a story has an empty keyword set (all tokens were stop-words or the story has no text), its Jaccard similarity with any other story is 0. Do not flag it.
+- Preserve the exact story IDs from the input. Do not normalize or transform them.

--- a/agents/duplication-detector.md
+++ b/agents/duplication-detector.md
@@ -87,8 +87,8 @@ After processing all flagged pairs, check for transitive overlaps:
 3. For each group with 3+ stories:
    - Merge all pairwise duplication risks into a single group entry
    - Create **ONE** stub for the entire group (not one per pair)
-   - Stub ID derived from the **lowest-numbered story** in the group (e.g., `US-005-A`)
-   - Stub's `dependsOn` = intersection of ALL stories' `dependsOn` arrays
+   - Stub ID derived from the **numerically lowest story** in the group (extract integer from ID, e.g., US-005 → 5; `US-005-A`)
+   - Stub's `dependsOn` = intersection of ALL stories' `dependsOn` arrays. If the intersection is empty (consumers have fully disjoint dependencies), use the **union** instead to ensure the stub has maximum upstream context
    - `sharedConcern` = merged description covering all stories in the group
    - All stories in the group are consumers of the single stub
 

--- a/docs/plans/2026-03-24-dag-intelligence-design.md
+++ b/docs/plans/2026-03-24-dag-intelligence-design.md
@@ -1,0 +1,429 @@
+# Design: DAG Intelligence — Parallel Specialist Validation for ql-plan
+
+**Date:** 2026-03-24
+**Status:** Approved
+**Approach:** Parallel Specialists (Approach B)
+**Source:** `Logical_inference/docs/post-mortems/quantum-loop-observations-2026-03-24.md`
+**Post-mortem issues addressed:** #5 (sequential bottleneck), #8 (duplicate implementation), #9 (incomplete fileConflicts), partially #1 (barrel file conflicts), #10 (wave-end duplication gap)
+
+## Overview
+
+**What we're building:** A post-generation DAG validation system for `ql-plan` that detects and fixes three classes of planning defects — sequential bottlenecks, functional duplication across stories, and incomplete `fileConflicts` — using parallel specialist agents coordinated by a `dag-validator` agent.
+
+**Why:** The 2026-03-24 post-mortem on an 18-story, 8-wave execution revealed that the planner produces DAGs with avoidable inefficiencies: two single-story waves added ~12 minutes of idle time (#5), two stories independently implemented identical Louvain algorithms wasting ~100 lines (#8), and `fileConflicts` missed the most-conflicting file in the project causing ~10 manual merge resolutions (#9). These are all detectable at planning time before any agent is spawned.
+
+**How it fits into the existing flow:**
+
+```
+Today:    ql-plan -> [user reviews quantum.json] -> ql-execute
+
+Proposed: ql-plan -> dag-validator (spawns 3 parallel specialists)
+                  -> restructure DAG + create stubs
+                  -> re-invoke planner for stubs only
+                  -> [user reviews quantum.json + DAG Health Report]
+                  -> ql-execute
+```
+
+**Key constraint:** The validation system only modifies `quantum.json` — it does not touch source code. All changes are DAG restructuring (dependency edges, story ordering, extracted stubs) and metadata annotations (`fileConflicts`, duplication warnings). The user sees the restructured DAG during their normal plan review step and can revert any specific change.
+
+**Files involved:** `agents/dag-validator.md` (new), `agents/bottleneck-analyzer.md` (new), `agents/duplication-detector.md` (new), `agents/conflict-auditor.md` (new), `skills/ql-plan/SKILL.md` (modified), `skills/ql-plan/references/dag-validation.md` (new reference).
+
+## User Experience
+
+**What changes for the user during `/ql-plan`:**
+
+Today, `ql-plan` generates `quantum.json` and the user reviews it. After this change, the user sees one additional output block before their review — a **DAG Health Report** — and the DAG they review may have been restructured.
+
+**New output the user sees after plan generation:**
+
+```
+[DAG-VALIDATOR] Analyzing plan (18 stories, 47 tasks)...
+  [BOTTLENECK]  Analyzing dependency chains...
+  [DUPLICATION]  Scanning for shared algorithms...
+  [CONFLICTS]   Computing fileConflicts from filePaths...
+
+[DAG-VALIDATOR] Analysis complete.
+
+-- DAG Health Report -----------------------------------------------
+
+Bottlenecks found: 1
+  ! Linear chain: US-001 -> US-002 -> US-003 (3 sequential waves)
+    Fix applied: Extracted US-001B "Shared types stub" from US-001.
+    US-002 and US-003 now depend on US-001B instead of US-001.
+    Impact: Waves reduced from 8 -> 6, max parallelism 3 -> 4.
+
+Duplication risks: 1
+  ! US-008 (DomainInferencer) and US-013 (CrossRepoAnalyzer)
+    Both reference: "community detection", "Louvain algorithm"
+    LLM confirmed: semantically overlapping implementation
+    Fix applied: Created stub US-000 "Shared Louvain utility"
+    US-008 and US-013 now depend on US-000.
+
+fileConflicts auto-computed: 4 pairs
+  + src/features/v2/index.ts  (US-003, US-005, US-007, US-009, US-011)
+  + demo/pipeline.ts          (US-012, US-014)
+  + src/graph/wiki-types.ts   (US-008, US-013)
+  + src/shared/types/index.ts (US-001, US-003, US-005)
+
+Stubs requiring planner flesh-out: 2
+  -> US-001B: Shared types stub (fleshed out)
+  -> US-000: Shared Louvain utility (fleshed out)
+
+----------------------------------------------------------------
+```
+
+**User interaction at review time:**
+
+The user reviews `quantum.json` as today — nothing changes about the review step itself. The restructured DAG and new stub stories are already in `quantum.json`. If the user disagrees with a restructuring:
+
+- They can manually edit `quantum.json` to revert (e.g., remove the stub story and restore the original dependency)
+- Or they can tell Claude: "Revert the bottleneck fix on US-001, keep the duplication extraction"
+
+**No new commands or flags.** The validation runs automatically as the final step of `ql-plan`. If the validator finds nothing to fix, the report says "No issues found" and the flow is identical to today.
+
+**During `/ql-execute`:** No UX changes. Stub stories that were fleshed out by the planner execute like any other story. The only visible difference is potentially fewer waves and fewer merge conflicts.
+
+## Data Model
+
+**No new fields in `quantum.json`.** This design reuses existing schema structures. The changes are about what gets *populated* and one new metadata block in the plan output.
+
+### Auto-computed `fileConflicts`
+
+Today, `fileConflicts` is manually enumerated by the planner:
+
+```json
+"fileConflicts": [
+  {"files": ["demo/pipeline.ts"], "stories": ["US-012", "US-014"]}
+]
+```
+
+After this change, the conflict auditor computes it mechanically by intersecting all stories' task `filePaths` arrays. Same schema, just complete:
+
+```json
+"fileConflicts": [
+  {"files": ["demo/pipeline.ts"], "stories": ["US-012", "US-014"]},
+  {"files": ["src/features/v2/index.ts"], "stories": ["US-003", "US-005", "US-007", "US-009", "US-011"]},
+  {"files": ["src/graph/wiki-types.ts"], "stories": ["US-008", "US-013"]},
+  {"files": ["src/shared/types/index.ts"], "stories": ["US-001", "US-003", "US-005"]}
+]
+```
+
+### Stub stories
+
+Extracted stub stories use the existing story schema with a `stubSource` marker in the `notes` field so the planner knows to flesh them out:
+
+```json
+{
+  "id": "US-000",
+  "title": "Shared Louvain community detection utility",
+  "priority": 1,
+  "status": "pending",
+  "dependsOn": ["US-001"],
+  "notes": "STUB: extracted by dag-validator from US-008 + US-013 duplication. Planner must flesh out tasks and acceptance criteria.",
+  "tasks": [],
+  "acceptanceCriteria": [],
+  "filePaths": [],
+  "retries": {"maxAttempts": 3, "attempts": 0, "failureLog": []}
+}
+```
+
+After the planner fleshes it out, `tasks`, `acceptanceCriteria`, and `filePaths` are populated and `notes` is updated to remove the `STUB:` prefix.
+
+### DAG Health Report
+
+Stored as a new top-level field `dagValidation` in `quantum.json` for traceability:
+
+```json
+"dagValidation": {
+  "timestamp": "2026-03-24T14:30:00Z",
+  "bottlenecks": [
+    {
+      "chain": ["US-001", "US-002", "US-003"],
+      "fix": "extracted US-001B as shared types stub",
+      "wavesReduced": {"before": 8, "after": 6}
+    }
+  ],
+  "duplicationRisks": [
+    {
+      "stories": ["US-008", "US-013"],
+      "keywords": ["community detection", "Louvain algorithm"],
+      "fix": "extracted US-000 as shared utility stub"
+    }
+  ],
+  "fileConflictsComputed": 4,
+  "stubsCreated": ["US-000", "US-001B"]
+}
+```
+
+This field is informational only — no runtime code reads it. It exists so the user can review what the validator changed and so post-mortem generation can report on validator effectiveness.
+
+### Dependency updates on downstream stories
+
+When the validator extracts a stub (e.g., US-000 from US-008 + US-013), it also modifies the `dependsOn` arrays of the consuming stories:
+
+- **Before:** `US-008.dependsOn: ["US-001"]`, `US-013.dependsOn: ["US-008"]`
+- **After:** `US-008.dependsOn: ["US-001", "US-000"]`, `US-013.dependsOn: ["US-008", "US-000"]`
+
+No new fields needed — this is a value change on existing `dependsOn` arrays.
+
+## Architecture
+
+### Component Overview
+
+```
+ql-plan SKILL.md (modified)
+  |-- Existing: Generate DAG, stories, tasks, contracts
+  |-- New inline: Auto-compute fileConflicts from filePaths intersections
+  +-- New final step: Spawn dag-validator agent
+        |
+        |-- Spawns 3 specialists in parallel:
+        |   |-- bottleneck-analyzer agent
+        |   |-- duplication-detector agent
+        |   +-- conflict-auditor agent
+        |
+        |-- Collects 3 structured reports
+        |-- Applies changes in order:
+        |   1. Bottleneck restructuring (modifies DAG shape)
+        |   2. Duplication extraction (creates stubs, adds dependencies)
+        |   3. fileConflicts recomputation (on the restructured DAG)
+        |
+        |-- Writes restructured quantum.json + dagValidation metadata
+        +-- Returns stub story IDs to ql-plan
+
+  ql-plan re-invokes planner for stub stories only
+  +-- Planner fills tasks, acceptanceCriteria, filePaths for each stub
+```
+
+### Agent Responsibilities
+
+**`dag-validator`** (coordinator) — `agents/dag-validator.md`
+- Receives: `quantum.json` path, PRD path
+- Spawns the three specialists as parallel subagents
+- Collects their reports
+- Applies restructuring in deterministic order (bottleneck -> duplication -> conflicts)
+- Resolves contradictions: if bottleneck restructuring creates a new story that shares `filePaths` with existing stories, the conflict recomputation catches it automatically since it runs last
+- Creates stub stories with `STUB:` marker in notes
+- Writes updated `quantum.json` and `dagValidation` block
+- Returns: list of stub story IDs + DAG Health Report text
+
+**`bottleneck-analyzer`** (specialist) — `agents/bottleneck-analyzer.md`
+- Receives: stories array with `dependsOn` edges
+- Builds adjacency list, computes wave assignment via topological sort
+- Detects: linear chains of length > 2, waves with only 1 story, stories that block 5+ downstream stories
+- For each bottleneck, proposes a restructuring:
+  - If a story's only dependency is a "types-only" story -> suggest extracting shared types into a stub that can run in Wave 1
+  - If a single story blocks N stories -> suggest splitting into parallel subtasks
+  - If a chain A -> B -> C exists where B doesn't actually consume A's code output (only its types) -> suggest relaxing the dependency to a shared types stub
+- Returns: structured JSON report with `chain`, `fix`, `newStories[]`, `modifiedDependsOn[]`
+
+**`duplication-detector`** (specialist) — `agents/duplication-detector.md`
+- Receives: stories array with titles, descriptions, acceptance criteria, task descriptions
+- Phase 1 (keyword pre-filter): Extracts technical terms from each story. Computes Jaccard similarity on term sets for all story pairs. Flags pairs with similarity > 0.3.
+- Phase 2 (LLM semantic check): For flagged pairs only, asks: "Do these two stories require implementing the same algorithm, data structure, or non-trivial logic? If yes, describe the shared concern."
+- For each confirmed duplication, proposes extraction: new stub story with title derived from the shared concern, both original stories gain the stub as a dependency
+- Returns: structured JSON report with `storyPairs`, `sharedConcern`, `proposedStub`
+
+**`conflict-auditor`** (specialist) — `agents/conflict-auditor.md`
+- Receives: stories array with task `filePaths`
+- Computes intersection: for every file path, collects which stories touch it
+- Filters to files touched by 2+ stories
+- Classifies conflict severity:
+  - **High:** barrel/index files, shared type files, config files (likely to conflict on every parallel wave)
+  - **Medium:** source files touched by 2 stories in the same wave
+  - **Low:** source files touched by 2 stories in different waves (merge order resolves naturally)
+- Returns: structured JSON report with `fileConflicts[]` array (same schema as quantum.json) plus severity annotations
+
+### Orchestration Sequence
+
+```
+1. ql-plan generates quantum.json (existing flow)
+2. ql-plan inline: compute preliminary fileConflicts from filePaths
+3. ql-plan spawns dag-validator agent
+4. dag-validator spawns 3 specialists in parallel
+5. All 3 return reports (~30s wall time)
+6. dag-validator applies restructuring:
+   a. Bottleneck fixes -> may add stub stories, modify dependsOn
+   b. Duplication fixes -> may add stub stories, modify dependsOn
+   c. Conflict auditor results -> overwrite fileConflicts (recomputed on restructured DAG)
+7. dag-validator writes quantum.json + dagValidation
+8. dag-validator returns stub IDs + health report to ql-plan
+9. ql-plan re-invokes planner with: "Flesh out these stub stories: [IDs].
+   Here is the PRD and the existing quantum.json for context.
+   Add tasks, acceptanceCriteria, and filePaths. Do NOT modify other stories."
+10. Planner fills stubs, writes final quantum.json
+11. User reviews (existing flow)
+```
+
+### File Map
+
+| File | Status | Role |
+|---|---|---|
+| `agents/dag-validator.md` | NEW | Coordinator agent |
+| `agents/bottleneck-analyzer.md` | NEW | Specialist: DAG shape analysis |
+| `agents/duplication-detector.md` | NEW | Specialist: semantic duplication scan |
+| `agents/conflict-auditor.md` | NEW | Specialist: fileConflicts computation |
+| `skills/ql-plan/SKILL.md` | MODIFIED | Add validation step after DAG generation |
+| `skills/ql-plan/references/dag-validation.md` | NEW | Reference doc for validation heuristics |
+
+## Edge Cases & Error Handling
+
+### Bottleneck analyzer finds no bottlenecks
+
+**Scenario:** All waves have 2+ stories, no linear chains > 2, no single story blocking 5+ downstream.
+
+**Handling:** Analyzer returns an empty `bottlenecks` array. The coordinator skips restructuring step (a) and proceeds. The DAG Health Report shows "Bottlenecks found: 0". This is the happy path — no cost beyond the analysis time.
+
+### Duplication detector flags a false positive
+
+**Scenario:** Keyword pre-filter flags US-004 ("build graph visualizer") and US-009 ("build dependency graph") as duplicates because both mention "graph." LLM semantic check confirms they're unrelated — one renders SVG, the other computes DAG edges.
+
+**Handling:** The LLM phase exists specifically for this. If the LLM says "no shared implementation concern," the pair is dropped from the report. The Health Report shows it as a dismissed candidate: `"Dismissed: US-004 + US-009 (keyword overlap on 'graph', semantically distinct)."` No DAG modification.
+
+### Duplication detector misses a true positive
+
+**Scenario:** Two stories both need rate limiting but describe it differently — "throttle API calls" vs "enforce request quotas." Keywords don't overlap enough (Jaccard < 0.3), so the pair is never sent to LLM.
+
+**Handling:** This is an accepted limitation of the hybrid approach. The keyword threshold (0.3) is a tunable parameter in `references/dag-validation.md`. If post-mortems repeatedly show missed duplications, the threshold can be lowered or additional synonym expansion added. The wave-end type audit (L5, already implemented) remains the runtime safety net for duplication that slips through planning.
+
+### Bottleneck restructuring creates a circular dependency
+
+**Scenario:** The analyzer proposes extracting US-001B from US-001, and making US-002 depend on US-001B instead of US-001. But US-001B itself depends on US-002 (because the shared types reference a type that US-002 defines).
+
+**Handling:** After applying all restructuring, the coordinator runs a cycle detection pass (topological sort on the modified DAG). If a cycle is detected:
+1. Revert the specific restructuring that introduced the cycle
+2. Log in the Health Report: `"Reverted: US-001B extraction would create cycle US-001B -> US-002 -> US-001B"`
+3. The original bottleneck remains — it's reported but unfixed
+
+This is a hard gate. The coordinator never writes a DAG with cycles to `quantum.json`.
+
+### Stub story creation collides with existing story IDs
+
+**Scenario:** The validator wants to create US-000 but that ID already exists.
+
+**Handling:** The coordinator generates stub IDs by finding the lowest unused ID. It reads all existing story IDs, computes `max(numeric_suffix) + 1` for new stories, and uses a suffix convention: `US-019-A`, `US-019-B` for extracted stubs. This avoids collision with both existing and future planner-generated IDs.
+
+### Planner fails to flesh out a stub
+
+**Scenario:** The planner is re-invoked for stubs but produces empty or malformed output for one stub.
+
+**Handling:** After the planner returns, `ql-plan` validates each stub: `tasks.length > 0` and `acceptanceCriteria.length > 0`. If a stub fails validation:
+1. Remove the stub story from `quantum.json`
+2. Revert the `dependsOn` modifications that referenced it
+3. Log in Health Report: `"Stub US-000 could not be fleshed out — reverted to original DAG structure"`
+4. The underlying duplication/bottleneck remains but the DAG is valid
+
+The principle: a failed validation step always reverts cleanly to the pre-validation DAG. The validator never makes the plan worse.
+
+### Specialist agent crashes or times out
+
+**Scenario:** One of the three parallel specialists crashes mid-analysis (e.g., context overflow on a 50-story plan).
+
+**Handling:** The coordinator waits for all three with a timeout (90 seconds per specialist). If a specialist fails:
+- Its analysis is skipped
+- The coordinator proceeds with the reports from the other two
+- Health Report notes: `"! bottleneck-analyzer timed out — bottleneck analysis skipped for this plan"`
+- The DAG still benefits from the other two analyses
+
+No specialist is required for the plan to proceed. All three are independently valuable — graceful degradation.
+
+### Very small plans (< 5 stories)
+
+**Scenario:** A plan has only 3 stories. Running 3 parallel specialist agents is overkill.
+
+**Handling:** The coordinator checks story count before spawning specialists:
+- **< 5 stories:** Skip bottleneck analysis (too few stories for meaningful parallelism gains). Run duplication and conflict auditor only, sequentially within the coordinator (no sub-spawn).
+- **5-15 stories:** Run all three, but sequentially within the coordinator to avoid agent spawn overhead exceeding analysis time.
+- **16+ stories:** Full parallel specialist spawn.
+
+These thresholds are configurable in `references/dag-validation.md`.
+
+## Testing Strategy
+
+### Tier 1: Unit Tests per Specialist
+
+**Bottleneck Analyzer**
+
+| Test | Input | Expected Output |
+|---|---|---|
+| Linear chain detection | Stories: A->B->C->D (chain of 4) | Flags chain `[A,B,C,D]`, proposes extraction |
+| No bottleneck | Stories: A, B, C all independent | Empty `bottlenecks` array |
+| Single-story wave detection | DAG where Wave 2 has only 1 story, Waves 1,3 have 3+ | Flags the single-story wave |
+| Fan-out blocker | Story A blocks B,C,D,E,F (5+ downstream) | Flags A as fan-out blocker, proposes split |
+| Types-only dependency relaxation | B depends on A, but A only produces type definitions | Proposes extracting types stub so B can run in parallel with A |
+| Already optimal DAG | 4 waves, all with 3+ stories, no chains > 2 | "No bottlenecks found" |
+
+**Duplication Detector**
+
+| Test | Input | Expected Output |
+|---|---|---|
+| Keyword match triggers LLM | US-008 mentions "Louvain", "community detection"; US-013 mentions "Louvain", "graph clustering" | Jaccard > 0.3, LLM confirms overlap, proposes stub |
+| Keyword match, LLM rejects | US-004 "build graph visualizer", US-009 "build dependency graph" | Jaccard > 0.3 on "graph"+"build", LLM says semantically distinct, dismissed |
+| No keyword overlap | All stories have distinct technical vocabularies | No pairs flagged, no LLM calls |
+| Three-way duplication | US-008, US-013, US-017 all mention "rate limiting" | All three pairs flagged; single shared stub created with all three as consumers |
+| Threshold tuning | Two stories share 1 keyword out of 10 each (Jaccard ~0.1) | Below 0.3 threshold, not flagged |
+
+**Conflict Auditor**
+
+| Test | Input | Expected Output |
+|---|---|---|
+| Index.ts in 5 stories | 5 stories all list `src/features/v2/index.ts` in `filePaths` | `fileConflicts` entry with severity "high" |
+| No overlapping files | Each story touches unique files | Empty `fileConflicts` array |
+| Two stories, same wave | US-003 and US-005 both touch `config.ts`, assigned to Wave 2 | Severity "medium" (same wave) |
+| Two stories, different waves | US-003 (Wave 1) and US-012 (Wave 5) share `pipeline.ts` | Severity "low" (merge order resolves) |
+| Barrel file classification | File named `index.ts`, `index.py`, `__init__.py`, or `mod.rs` | Auto-classified as severity "high" regardless of story count |
+
+### Tier 2: Coordinator Integration Tests
+
+| Test | Scenario | Expected Behavior |
+|---|---|---|
+| All three specialists return results | Bottleneck: 1 fix, Duplication: 1 stub, Conflicts: 3 pairs | All applied in order. Stub appears in stories. `fileConflicts` recomputed on restructured DAG. `dagValidation` has all three sections populated. |
+| Bottleneck fix creates new conflict | Extracted stub US-001B touches `types/index.ts` which 3 other stories also touch | Conflict auditor (running last) catches it. `fileConflicts` includes the new entry. |
+| Cycle detection after restructuring | Bottleneck fix introduces A->B->A cycle | Fix reverted. Health Report logs the revert. Original bottleneck remains. DAG is cycle-free. |
+| One specialist times out | Duplication detector exceeds 90s | Coordinator proceeds with bottleneck + conflict results only. Health Report notes: "duplication analysis skipped (timeout)". |
+| All specialists return empty | No bottlenecks, no duplication, no conflicts | `dagValidation` written with all-empty arrays. Health Report: "No issues found." quantum.json unchanged except for `dagValidation` block. |
+| Small plan bypass | 3-story plan | No sub-agents spawned. Coordinator runs conflict computation inline. Bottleneck and duplication analysis skipped. |
+| Stub ID collision | Existing stories US-001 through US-018 | New stubs get IDs US-019-A, US-019-B. No collision. |
+
+### Tier 3: Stub Flesh-Out Tests
+
+| Test | Scenario | Expected Behavior |
+|---|---|---|
+| Planner successfully fills stub | Stub US-000 "Shared Louvain utility" with PRD context | `tasks.length > 0`, `acceptanceCriteria.length > 0`, `filePaths.length > 0`, `notes` no longer has `STUB:` prefix |
+| Planner returns empty stub | Stub too vague for planner to flesh out | Stub removed from quantum.json, `dependsOn` references reverted, Health Report notes the revert |
+| Multiple stubs fleshed out | 2 stubs from bottleneck + 1 from duplication | All 3 validated independently. Partial failure (1 of 3 fails) reverts only the failed stub |
+
+### Tier 4: End-to-End Validation
+
+Replay the actual 2026-03-24 Hierarchical Feature Extraction plan through the validator:
+
+**Setup:** Take the original `quantum.json` from the Logical_inference execution (18 stories, 8 waves) and feed it to the dag-validator.
+
+**Expected results:**
+- Bottleneck analyzer flags the US-001->US-002->US-003 chain and the two single-story waves
+- Duplication detector flags US-008 + US-013 (both mention community detection / Louvain)
+- Conflict auditor computes `src/features/v2/index.ts` in 5+ stories (the file the post-mortem says was missed)
+- Waves reduced from 8 -> fewer (target: 6)
+- One shared utility stub created for the Louvain algorithm
+
+**Success criteria:**
+- All three issues from the post-mortem (#5, #8, #9) would have been caught
+- No cycles introduced
+- Stub stories are valid and flesh-able
+- Total validation time < 2 minutes
+
+### What NOT to Test
+
+- **Planner's initial DAG quality** — We're validating the DAG, not generating it. The planner's AI judgment is tested by running real plans.
+- **LLM semantic accuracy** — The duplication detector's LLM phase is non-deterministic. We test that the LLM is called on the right pairs, not that it always gives the right answer. False negatives are caught by runtime L5 audit.
+- **Orchestrator behavior with restructured DAGs** — The orchestrator already handles any valid quantum.json. Our job is to produce a valid one.
+
+## Open Questions
+
+- Should the Jaccard similarity threshold (0.3) for duplication pre-filtering be configurable per-project, or is a single default sufficient? Post-mortem data from future runs will inform this.
+- Should the bottleneck analyzer consider story estimated complexity (task count, file count) when deciding whether a single-story wave is worth optimizing? A 1-story wave with 8 tasks may not be a bottleneck if the story is genuinely large.
+- Should the conflict-auditor's severity classifications influence the orchestrator's wave scheduling (e.g., never co-schedule stories with "high" severity conflicts), or is the annotation purely informational for human review?
+- What is the right specialist timeout? 90 seconds is proposed, but very large plans (50+ stories) with many story pairs for duplication checking may need more. Consider making it configurable.
+
+## Next Steps
+
+Run `/quantum-loop:ql-spec` to generate a formal Product Requirements Document from this design.

--- a/quantum.json.example
+++ b/quantum.json.example
@@ -321,9 +321,34 @@
         "US-007",
         "US-008"
       ],
+      "severity": "medium",
       "reconciliationTask": "US-008 T-004: Reconcile generator.py changes from US-007"
     }
   ],
+  "_comment_severity": "Allowed values for fileConflicts severity: 'high' (barrel/index files, shared type files, config files), 'medium' (same-wave source file overlap), 'low' (different-wave source file overlap)",
+  "dagValidation": {
+    "timestamp": "2026-03-24T12:00:00Z",
+    "bottlenecks": [
+      {
+        "chain": ["US-001", "US-002", "US-003"],
+        "fix": "Split US-002 into independent sub-stories to allow parallel execution",
+        "wavesReduced": {
+          "before": 4,
+          "after": 3
+        }
+      }
+    ],
+    "duplicationRisks": [
+      {
+        "stories": ["US-004", "US-005"],
+        "keywords": ["validation", "schema", "input"],
+        "fix": "Extract shared validation logic into a common module before implementing both stories"
+      }
+    ],
+    "fileConflictsComputed": 1,
+    "stubsCreated": ["US-006"]
+  },
+  "_comment_dagValidation": "This block is written by the dag-validator agent and is informational only. It describes detected bottlenecks, duplication risks, computed file conflicts, and stubs created during DAG analysis.",
   "_comment_runtime_fields": "The following fields are added at runtime by the orchestrator and are not part of the initial schema:",
   "_execution_example": {
     "mode": "parallel",

--- a/quantum.json.example
+++ b/quantum.json.example
@@ -1,5 +1,6 @@
 {
   "project": "MyApp",
+  "_comment_storyType": "Each story may have a 'storyType' field. Allowed values: 'types-only' (stories that only define types/interfaces/schemas), 'logic' (stories with business logic), 'config' (scaffold/config-only stories), 'test' (test-only stories). When absent, defaults to 'logic'.",
   "branchName": "ql/task-priority",
   "description": "Task Priority System - Add priority levels to tasks with filtering and sorting",
   "prdPath": "tasks/prd-task-priority.md",
@@ -9,6 +10,7 @@
   "stories": [
     {
       "id": "US-001",
+      "storyType": "config",
       "title": "Add priority field to database",
       "description": "As a developer, I need to store task priority so it persists across sessions.",
       "acceptanceCriteria": [
@@ -86,6 +88,7 @@
     },
     {
       "id": "US-002",
+      "storyType": "logic",
       "title": "Display priority indicator on task cards",
       "description": "As a user, I want to see task priority at a glance so I can focus on what matters.",
       "acceptanceCriteria": [
@@ -176,6 +179,7 @@
     },
     {
       "id": "US-003",
+      "storyType": "logic",
       "title": "Filter tasks by priority",
       "description": "As a user, I want to filter the task list by priority so I can see only high-priority items.",
       "acceptanceCriteria": [

--- a/quantum.json.example
+++ b/quantum.json.example
@@ -320,13 +320,12 @@
   "codebasePatterns": [],
   "fileConflicts": [
     {
-      "file": "src/generator.py",
+      "files": ["src/generator.py"],
       "stories": [
         "US-007",
         "US-008"
       ],
-      "severity": "medium",
-      "reconciliationTask": "US-008 T-004: Reconcile generator.py changes from US-007"
+      "severity": "medium"
     }
   ],
   "_comment_severity": "Allowed values for fileConflicts severity: 'high' (barrel/index files, shared type files, config files), 'medium' (same-wave source file overlap), 'low' (different-wave source file overlap)",
@@ -335,22 +334,31 @@
     "bottlenecks": [
       {
         "chain": ["US-001", "US-002", "US-003"],
-        "fix": "Split US-002 into independent sub-stories to allow parallel execution",
-        "wavesReduced": {
-          "before": 4,
-          "after": 3
+        "type": "linear_chain",
+        "fix": "warning",
+        "newStories": [],
+        "modifiedDependsOn": [],
+        "warning": {
+          "type": "warning",
+          "message": "Linear chain US-001 -> US-002 -> US-003 has length 3 -- consider parallelizing"
         }
       }
     ],
     "duplicationRisks": [
       {
-        "stories": ["US-004", "US-005"],
-        "keywords": ["validation", "schema", "input"],
-        "fix": "Extract shared validation logic into a common module before implementing both stories"
+        "storyPairs": ["US-004", "US-005"],
+        "sharedConcern": "Both stories implement input validation logic",
+        "proposedStub": {
+          "id": "US-004-A",
+          "title": "Shared input validation utility",
+          "dependsOn": [],
+          "storyType": "logic"
+        }
       }
     ],
     "fileConflictsComputed": 1,
-    "stubsCreated": ["US-006"]
+    "stubsCreated": ["US-004-A"],
+    "timeouts": []
   },
   "_comment_dagValidation": "This block is written by the dag-validator agent and is informational only. It describes detected bottlenecks, duplication risks, computed file conflicts, and stubs created during DAG analysis.",
   "_comment_runtime_fields": "The following fields are added at runtime by the orchestrator and are not part of the initial schema:",

--- a/skills/ql-plan/SKILL.md
+++ b/skills/ql-plan/SKILL.md
@@ -207,6 +207,46 @@ Key points:
 
 If no type names appear in 2+ stories, do NOT generate `shape` or `definition` fields. The basic contracts block (with `value` and optional `pattern`) is sufficient. This maintains backward compatibility — entries with only `value` and `pattern` remain valid.
 
+### Story Type Tagging
+
+After building the dependency DAG and contracts, assign a `storyType` field to every story. This field is used by the dag-validator to determine which restructuring is safe.
+
+#### Allowed Values
+
+| `storyType` | Description |
+|---|---|
+| `types-only` | Stories where ALL tasks create type definitions, interfaces, schemas, or `.d.ts` files with no runtime logic. |
+| `config` | Scaffold/config-only stories: migrations, `package.json` changes, Dockerfile, CI yaml, pure markdown. |
+| `test` | Stories that only add tests with no new source code. |
+| `logic` | Everything else (the default). Any story with business logic, API handlers, data processing, or external API calls. |
+
+#### Examples
+
+**`types-only`** — `US-001: Define TaskResult interface`
+Tasks only create `.ts` interface files (e.g., `src/types/task-result.ts`). No runtime logic, no function bodies, no side effects — purely structural type definitions.
+
+**`config`** — `US-002: Set up database migration`
+Tasks only create migration files, update `package.json` dependencies, or modify CI configuration. No `if` statements, no loops, no data transformations.
+
+**`test`** — `US-004: Add unit tests for task filtering`
+Tasks only add test files (e.g., `tests/task-filter.test.ts`). No new source modules are created — only test coverage for existing code.
+
+**`logic`** — `US-003: Implement task filtering API`
+Tasks contain `if`/`loop`/data logic, API route handlers, database queries, or calls to external services. This is the default and the most common type.
+
+#### Anti-Rationalization Guard
+
+> **If a story has any task that implements business logic, API handlers, data processing, or calls external APIs, it is `logic`, not `types-only`. When in doubt, use `logic`.**
+
+Common traps:
+- A story that creates an interface AND a helper function is `logic`, not `types-only` — the helper function is runtime code.
+- A story that creates a schema file with validation logic (e.g., Zod schemas with `.refine()`) is `logic` — refinements execute at runtime.
+- A story that creates config AND a small utility to read that config is `logic` — the utility is runtime code.
+
+#### Default Behavior
+
+If you are unsure, set `storyType` to `logic`. It is always safe to over-classify as `logic` — under-classifying as `types-only` can cause incorrect restructuring by the dag-validator, which may reorder stories that should not be reordered.
+
 ### wiring_verification Generation
 
 Tasks that create new modules, handlers, or components **SHOULD** have a `wiring_verification` object unless wiring is handled by a dependent story via `consumedBy`.

--- a/skills/ql-plan/SKILL.md
+++ b/skills/ql-plan/SKILL.md
@@ -442,6 +442,67 @@ If `quantum-loop.sh` already exists, just inform:
 > "Plan saved to `quantum.json` with [N] stories and [M] total tasks.
 > Run `/quantum-loop:ql-execute` or `./quantum-loop.sh --max-iterations 20`."
 
+## Step 7: DAG Validation
+
+After generating quantum.json, spawn the dag-validator agent to analyze the DAG for bottlenecks, duplication, and file conflicts. The validator runs automatically — no user action required.
+
+### Spawning the dag-validator
+
+Use the Agent tool to spawn the dag-validator agent with `subagent_type` set to the dag-validator agent definition. Pass two arguments: the quantum.json path and the PRD path. Wait for the agent to complete.
+
+### Idempotency handling
+
+If the dag-validator returns "Already validated on \<timestamp\>", skip the remaining validation steps. Print:
+
+> "Plan already validated on \<timestamp\>. Skipping DAG validation."
+
+### Receiving results
+
+The dag-validator returns:
+
+1. A list of stub story IDs (may be empty)
+2. A DAG Health Report text string
+
+### Stub flesh-out
+
+If the dag-validator returned stub story IDs:
+
+1. Re-read quantum.json (the validator has modified it)
+2. For each stub ID, the story will have `STUB:` prefix in its `notes` field and empty `tasks`, `acceptanceCriteria`, and `filePaths`
+3. Re-invoke the planner with a scoped prompt:
+
+> "Flesh out these stub stories: [list IDs]. Read the PRD at [prdPath] and the existing quantum.json for context. For each stub, add tasks (with filePaths, commands, testFirst), acceptanceCriteria, and filePaths. Do NOT modify any other stories. Follow all task sizing, testFirst, and wiring rules from this skill."
+
+4. Write the fleshed-out stories back to quantum.json
+
+### Stub validation
+
+After flesh-out, validate each stub:
+
+- `tasks.length > 0`
+- `acceptanceCriteria.length > 0`
+
+If a stub passes validation: remove the `STUB:` prefix from its `notes` field.
+
+### Revert on failure
+
+If a stub fails validation (empty `tasks` or `acceptanceCriteria`):
+
+1. Remove the stub story from the quantum.json `stories` array
+2. For every other story whose `dependsOn` contains the stub ID, remove the stub ID from their `dependsOn` array
+3. Log in the Health Report:
+
+> "Stub \<ID\> could not be fleshed out — reverted to original DAG structure."
+
+### Output
+
+Print the complete DAG Health Report to the user. This is the last thing the user sees before reviewing quantum.json. Format with clear section headers:
+
+- **Bottlenecks** — sequential chains and fan-out blockers detected
+- **Duplication Risks** — overlapping implementation concerns between stories
+- **File Conflicts** — files touched by multiple stories with severity classification
+- **Stubs Created** — new shared-utility stories extracted by the validator
+
 ## Anti-Rationalization Guards
 
 | Excuse | Reality |

--- a/skills/ql-plan/references/dag-validation.md
+++ b/skills/ql-plan/references/dag-validation.md
@@ -1,0 +1,242 @@
+# DAG Validation Reference
+
+Configuration and rules for the dag-validator coordinator and its specialist agents. Load this reference before performing any DAG validation step.
+
+---
+
+## Standard Stop-Words
+
+The following terms are excluded from keyword extraction during duplication detection. These words appear frequently in story titles and descriptions but carry no implementation-specific meaning. Removing them prevents false-positive Jaccard similarity matches.
+
+- implement
+- create
+- add
+- build
+- test
+- update
+- module
+- component
+- function
+- class
+- handle
+- setup
+- configure
+- write
+- define
+- use
+- make
+- get
+- set
+- run
+- ensure
+- support
+- include
+- provide
+- allow
+
+When extracting keywords from story titles, descriptions, and acceptance criteria, strip all terms in this list before computing similarity.
+
+---
+
+## Project-Configurable Stop-Words
+
+Projects may define additional stop-words that are domain-specific and should be excluded from duplication analysis. These are specified via the `dagValidation.stopWords` array in `quantum.json`.
+
+Example configuration:
+
+```json
+{
+  "dagValidation": {
+    "stopWords": ["widget", "dashboard", "endpoint", "migration"]
+  }
+}
+```
+
+When this array is present, the duplication-detector concatenates it with the standard stop-words list above before keyword extraction. Duplicate entries are ignored. The combined list is case-insensitive: `"Widget"` and `"widget"` are treated as the same term.
+
+If the `dagValidation.stopWords` field is absent or empty, only the standard stop-words are used.
+
+---
+
+## Jaccard Threshold
+
+The duplication-detector uses Jaccard similarity to identify story pairs with overlapping technical keywords. Jaccard similarity is defined as:
+
+```
+J(A, B) = |A intersection B| / |A union B|
+```
+
+Where `A` and `B` are the sets of technical keywords extracted from two stories (after stop-word removal).
+
+**Default threshold:** `0.3`
+
+Story pairs with `J(A, B) > 0.3` are flagged for Phase 2 LLM semantic verification. Pairs at or below the threshold are not flagged.
+
+**Override:** Projects can adjust the threshold via `dagValidation.jaccardThreshold` in `quantum.json`:
+
+```json
+{
+  "dagValidation": {
+    "jaccardThreshold": 0.25
+  }
+}
+```
+
+**Guidance on threshold selection:**
+
+| Threshold | Behavior |
+|---|---|
+| `< 0.2` | Aggressive: flags many pairs, higher false-positive rate, more LLM calls |
+| `0.25 - 0.35` | Balanced: catches most genuine overlaps with manageable false positives |
+| `> 0.4` | Conservative: only flags strong overlaps, may miss subtle duplication |
+
+If `dagValidation.jaccardThreshold` is absent, the default `0.3` is used.
+
+---
+
+## Bottleneck Heuristics
+
+The bottleneck-analyzer detects three classes of structural inefficiency in the dependency DAG. Each heuristic runs independently and produces a report entry.
+
+### 1. Linear Chain Detection
+
+A linear chain is a sequence of stories where each story depends on exactly one predecessor, and each predecessor has exactly one downstream consumer, forming a strict A -> B -> C path with no branching.
+
+**Trigger:** Flag chains of length > 2 (three or more stories in strict sequence).
+
+**Why it matters:** Linear chains prevent any parallelism. If stories in the chain only share type dependencies (not logic dependencies), the chain can be shortened by extracting shared types into a stub.
+
+**Example DAG:**
+
+```
+US-001 --> US-002 --> US-003 --> US-004
+```
+
+All four stories are strictly sequential. This is a linear chain of length 4.
+
+**Expected detection output:**
+
+```json
+{
+  "type": "linear_chain",
+  "chain": ["US-001", "US-002", "US-003", "US-004"],
+  "length": 4,
+  "fix": "Examine dependencies between US-001 and US-004. If US-002 and US-003 depend on US-001 only for shared types, extract a types-only stub (US-001-A) and allow US-002, US-003, US-004 to depend on the stub in parallel."
+}
+```
+
+### 2. Single-Story Wave Detection
+
+A wave is a set of stories that can execute in parallel (all their dependencies are satisfied). A single-story wave contains only one story, meaning no parallelism is achieved in that execution round.
+
+**Trigger:** Flag any wave containing exactly 1 story.
+
+**Why it matters:** Single-story waves are serialization points. If the solo story could be merged into an adjacent wave (by relaxing a dependency), total execution time decreases.
+
+**Example DAG:**
+
+```
+Wave 1:  US-001, US-002, US-003  (3 stories in parallel)
+Wave 2:  US-004                   (1 story -- bottleneck)
+Wave 3:  US-005, US-006           (2 stories in parallel)
+```
+
+Wave 2 is a single-story wave.
+
+**Expected detection output:**
+
+```json
+{
+  "type": "single_story_wave",
+  "wave": 2,
+  "story": "US-004",
+  "fix": "Check if US-004's dependency on Wave 1 stories can be narrowed to a types-only stub, allowing US-004 to run in Wave 1."
+}
+```
+
+### 3. Fan-Out Blocker Detection
+
+A fan-out blocker is a story that has 5 or more direct downstream dependents. If this story is delayed or fails, it blocks a large portion of the plan.
+
+**Trigger:** Flag stories where `downstream_count >= 5`.
+
+**Why it matters:** Fan-out blockers are high-risk serialization points. If the blocker provides only types or configuration, extracting a lightweight stub can unblock dependents earlier.
+
+**Example DAG:**
+
+```
+         US-001
+        /  |  |  \  \
+  US-002 US-003 US-004 US-005 US-006
+```
+
+US-001 blocks 5 downstream stories.
+
+**Expected detection output:**
+
+```json
+{
+  "type": "fan_out_blocker",
+  "blocker": "US-001",
+  "downstream": ["US-002", "US-003", "US-004", "US-005", "US-006"],
+  "downstreamCount": 5,
+  "fix": "If US-001 has storyType 'types-only', extract a stub (US-001-A) containing only the type definitions. Consumers depend on US-001-A instead. If US-001 has storyType 'logic', report warning only -- logic dependencies cannot be safely stubbed."
+}
+```
+
+---
+
+## Severity Classification
+
+The conflict-auditor classifies each file conflict by severity based on the file type and the wave relationship of the conflicting stories.
+
+| Severity | Criteria | Examples |
+|---|---|---|
+| **high** | Barrel/index files, shared type definition files, project config files | `index.ts`, `index.js`, `index.tsx`, `index.jsx`, `__init__.py`, `mod.rs`, `lib.rs`, `doc.go`, `types.ts`, `shared/types/*.ts`, `quantum.json`, `tsconfig.json`, `package.json`, `pyproject.toml` |
+| **medium** | Source files touched by 2+ stories scheduled in the same wave | `src/auth/login.ts` modified by US-002 and US-003, both in Wave 1 |
+| **low** | Source files touched by 2+ stories scheduled in different waves | `src/utils/format.ts` modified by US-001 (Wave 1) and US-005 (Wave 3) |
+
+**Resolution rules by severity:**
+
+- **high:** The dag-validator injects synthetic `dependsOn` edges so conflicting stories never execute in the same wave. The highest-priority story (lowest priority number) runs first; all other stories in the conflict group depend on it.
+- **medium:** The dag-validator reports the conflict in the DAG Health Report. The orchestrator uses merge-conflict resolution at wave boundaries.
+- **low:** Informational only. Logged in the DAG Health Report for awareness. No structural changes.
+
+---
+
+## Plan Size Thresholds
+
+The dag-validator coordinator adjusts its execution strategy based on the number of stories in the plan. Smaller plans do not benefit from the overhead of parallel specialist agents.
+
+| Story Count | Strategy | Rationale |
+|---|---|---|
+| **< 5 stories** | Skip bottleneck analysis. Run duplication-detector and conflict-auditor sequentially within the coordinator. | Too few stories for meaningful parallelism gains. Bottleneck restructuring on 3-4 stories risks over-engineering. |
+| **5 - 15 stories** | Run all three specialists (bottleneck-analyzer, duplication-detector, conflict-auditor) sequentially within the coordinator. | Moderate plan size benefits from all analyses, but the overhead of parallel agent spawning is not justified. |
+| **16+ stories** | Spawn all three specialists as parallel subagents. | Large plans benefit from parallel execution. Each specialist operates on the full stories array independently, and the coordinator merges their results after all three complete. |
+
+The coordinator reads `stories.length` from quantum.json and selects the strategy before invoking any specialist. The threshold boundaries are inclusive on the lower end: a plan with exactly 5 stories uses the "5 - 15" strategy; a plan with exactly 16 stories uses the "16+" strategy.
+
+---
+
+## Barrel File Patterns
+
+Barrel files (also called index files or re-export files) aggregate exports from a directory into a single entry point. Because multiple stories frequently need to add exports to the same barrel file, these files are high-severity conflict targets.
+
+The conflict-auditor uses the following patterns to identify barrel files per language:
+
+| Language | Barrel File Names |
+|---|---|
+| **TypeScript** | `index.ts`, `index.js`, `index.tsx`, `index.jsx` |
+| **Python** | `__init__.py` |
+| **Rust** | `mod.rs`, `lib.rs` |
+| **Go** | `doc.go` |
+
+**Detection rule:** When the conflict-auditor encounters a file in the `fileConflicts` set whose basename matches any pattern in the table above, it automatically classifies the conflict as severity `"high"`, regardless of the wave relationship between the conflicting stories.
+
+**Why barrel files are always high severity:**
+
+1. **Merge conflict probability is near 100%.** Two agents adding exports to the same barrel file will almost always produce conflicting diffs (adjacent or overlapping lines).
+2. **Semantic merge is insufficient.** Even if lines do not textually conflict, the order of exports or the combination of re-exports may cause runtime issues (circular dependencies, initialization order).
+3. **Prevention is cheaper than resolution.** Injecting a synthetic `dependsOn` edge ensures barrel file modifications are serialized, eliminating the merge conflict entirely.
+
+The barrel file pattern list is language-specific. If a project uses multiple languages, all relevant patterns are active simultaneously. The conflict-auditor detects the project language(s) from config files in the repository root (see `contract-shapes.md` for language detection rules).

--- a/tasks/prd-dag-intelligence.md
+++ b/tasks/prd-dag-intelligence.md
@@ -1,0 +1,256 @@
+# PRD: DAG Intelligence — Parallel Specialist Validation for ql-plan
+
+## 1. Introduction/Overview
+
+The quantum-loop planner (`ql-plan`) generates dependency DAGs that drive autonomous execution, but it produces DAGs with avoidable inefficiencies: sequential bottlenecks that waste wall-clock time, duplicate implementations across parallel stories, and incomplete `fileConflicts` that cause preventable merge conflicts. This feature adds a post-generation validation system using parallel specialist agents that detect these defects and auto-restructure the DAG before the user reviews it.
+
+The system is triggered automatically as the final step of `ql-plan` and produces a DAG Health Report alongside the restructured `quantum.json`.
+
+## 2. Goals
+
+- Detect and restructure sequential bottlenecks in the dependency DAG, reducing total wave count
+- Detect functional duplication across stories and extract shared utilities into stub stories before execution
+- Auto-compute complete `fileConflicts` from task `filePaths` intersections with severity classification
+- Enforce hard scheduling constraints for high-severity file conflicts via synthetic dependencies
+- Provide a DAG Health Report that summarizes all findings and restructuring actions
+- Run validation in under 2 minutes for plans with up to 30 stories
+- Maintain idempotency: re-running on an already-validated plan is a no-op
+
+## 3. User Stories
+
+### US-001: Add `storyType` field to quantum.json schema
+
+**Description:** As a planner agent, I want each story in quantum.json to have a `storyType` field so that downstream validators can distinguish types-only stories from logic stories without heuristic guessing.
+
+**Acceptance Criteria:**
+- [ ] `quantum.json.example` includes `storyType` field on story objects with allowed values: `"types-only"`, `"logic"`, `"config"`, `"test"`
+- [ ] The `storyType` field is documented with a comment or adjacent description explaining each value
+- [ ] Existing stories without `storyType` are handled gracefully (default to `"logic"` when absent)
+- [ ] Typecheck/lint passes (shellcheck on any modified .sh files)
+
+### US-002: Add `dagValidation` block and severity field to quantum.json schema
+
+**Description:** As a dag-validator agent, I want a `dagValidation` top-level block in quantum.json to store validation results, and a `severity` field on `fileConflicts` entries, so that validation state is traceable and conflict severity is queryable.
+
+**Acceptance Criteria:**
+- [ ] `quantum.json.example` includes `dagValidation` top-level object with fields: `timestamp` (ISO 8601), `bottlenecks` (array), `duplicationRisks` (array), `fileConflictsComputed` (number), `stubsCreated` (array of story IDs)
+- [ ] `quantum.json.example` `fileConflicts` entries include a `severity` field with allowed values: `"high"`, `"medium"`, `"low"`
+- [ ] Both new fields are optional — existing quantum.json files without them remain valid
+- [ ] Typecheck/lint passes
+
+### US-003: Create `references/dag-validation.md` reference document
+
+**Description:** As a dag-validator and its specialist agents, I want a reference document containing stop-word lists, Jaccard threshold configuration, bottleneck heuristics, and severity classification rules so that validation behavior is configurable without modifying agent prompts.
+
+**Acceptance Criteria:**
+- [ ] File exists at `skills/ql-plan/references/dag-validation.md`
+- [ ] Contains a "Standard Stop-Words" section with a list of at least 15 common non-technical terms to exclude from duplication keyword comparison (e.g., "implement", "create", "add", "build", "test", "update", "module", "component", "function", "class", "handle", "setup", "configure", "write", "define")
+- [ ] Contains a "Project-Configurable Stop-Words" section explaining how to add project-specific terms via a `dagValidation.stopWords` array in quantum.json
+- [ ] Contains a "Jaccard Threshold" section documenting the default 0.3 threshold and how to override it via `dagValidation.jaccardThreshold` in quantum.json
+- [ ] Contains a "Bottleneck Heuristics" section documenting: linear chain length > 2, single-story waves, fan-out blocker (5+ downstream)
+- [ ] Contains a "Severity Classification" section documenting: high (barrel/index files, shared type files, config files), medium (same-wave source file overlap), low (different-wave source file overlap)
+- [ ] Contains a "Plan Size Thresholds" section documenting: < 5 stories (skip bottleneck analysis), 5-15 (sequential specialists), 16+ (parallel specialists)
+- [ ] Contains a "Barrel File Patterns" section listing recognized barrel file names per language: `index.ts`, `index.js`, `__init__.py`, `mod.rs`, `lib.rs`
+- [ ] Typecheck/lint passes
+
+### US-004: Create `conflict-auditor` specialist agent
+
+**Description:** As a dag-validator coordinator, I want a conflict-auditor agent that computes complete `fileConflicts` from task `filePaths` intersections with severity classification so that no conflicting files are missed.
+
+**Acceptance Criteria:**
+- [ ] File exists at `agents/conflict-auditor.md`
+- [ ] Agent frontmatter includes `name`, `description`, and `tools` fields
+- [ ] Agent receives stories array with task `filePaths` as input
+- [ ] Agent computes file-to-story mapping by iterating all tasks' `filePaths` arrays
+- [ ] Agent filters to files appearing in 2+ stories
+- [ ] Agent classifies severity per rules in `references/dag-validation.md`: "high" for barrel/index files, shared type files, config files; "medium" for same-wave overlap; "low" for different-wave overlap
+- [ ] Agent returns structured JSON with `fileConflicts` array matching quantum.json schema plus `severity` field
+- [ ] Agent handles empty `filePaths` arrays gracefully (skip stories with no paths)
+- [ ] Typecheck/lint passes
+
+### US-005: Create `bottleneck-analyzer` specialist agent
+
+**Description:** As a dag-validator coordinator, I want a bottleneck-analyzer agent that detects sequential bottlenecks in the DAG and proposes restructuring so that unnecessary serialization is eliminated.
+
+**Acceptance Criteria:**
+- [ ] File exists at `agents/bottleneck-analyzer.md`
+- [ ] Agent frontmatter includes `name`, `description`, and `tools` fields
+- [ ] Agent receives stories array with `dependsOn` edges and `storyType` fields as input
+- [ ] Agent builds adjacency list and computes wave assignment via topological sort
+- [ ] Agent detects linear chains of length > 2 and reports them with story IDs
+- [ ] Agent detects single-story waves and reports them
+- [ ] Agent detects fan-out blockers (stories blocking 5+ downstream) and reports them
+- [ ] For types-only dependencies (where the depended-on story has `storyType: "types-only"`): agent proposes extracting a shared types stub, modifying `dependsOn` so consumers depend on the stub instead
+- [ ] For logic dependencies on fan-out blockers: agent reports a warning only (no auto-restructuring), per design decision
+- [ ] Agent returns structured JSON with `bottlenecks` array containing `chain`, `fix`, `newStories[]`, `modifiedDependsOn[]`
+- [ ] Proposed stub stories use the suffix convention: if extracted from US-003, stub ID is US-003-A
+- [ ] Agent does NOT create circular dependencies (verified by caller)
+- [ ] Typecheck/lint passes
+
+### US-006: Create `duplication-detector` specialist agent
+
+**Description:** As a dag-validator coordinator, I want a duplication-detector agent that identifies stories with overlapping implementation concerns using hybrid keyword + LLM analysis so that shared utilities are extracted before execution.
+
+**Acceptance Criteria:**
+- [ ] File exists at `agents/duplication-detector.md`
+- [ ] Agent frontmatter includes `name`, `description`, and `tools` fields
+- [ ] Agent receives stories array with titles, descriptions, acceptance criteria, and task descriptions as input
+- [ ] Phase 1: Agent extracts technical keywords from each story, excluding stop-words from `references/dag-validation.md` (both standard and project-configurable)
+- [ ] Phase 1: Agent computes Jaccard similarity for all story pairs and flags pairs with similarity > threshold (default 0.3, configurable via `dagValidation.jaccardThreshold`)
+- [ ] Phase 2: For flagged pairs only, agent performs LLM semantic check asking whether both stories require implementing the same algorithm, data structure, or non-trivial logic
+- [ ] Phase 2: If LLM confirms overlap, agent describes the shared concern and proposes a stub story
+- [ ] Phase 2: If LLM rejects overlap, agent logs it as dismissed with reason
+- [ ] For three-way (or N-way) duplication, agent creates a single shared stub with all N stories as consumers
+- [ ] Agent returns structured JSON with `duplicationRisks` array containing `storyPairs`, `sharedConcern`, `proposedStub`, and `dismissed` entries
+- [ ] Proposed stub stories use the suffix convention: derived from the lowest-numbered consumer story ID (e.g., US-008-A)
+- [ ] Typecheck/lint passes
+
+### US-007: Create `dag-validator` coordinator agent
+
+**Description:** As the ql-plan skill, I want a dag-validator coordinator agent that spawns the three specialists, merges their reports, applies restructuring with cycle detection, creates stub stories, and writes the DAG Health Report so that the validation system works end-to-end.
+
+**Acceptance Criteria:**
+- [ ] File exists at `agents/dag-validator.md`
+- [ ] Agent frontmatter includes `name`, `description`, and `tools` fields
+- [ ] Agent receives `quantum.json` path and PRD path as input
+- [ ] Agent reads plan size and applies thresholds from `references/dag-validation.md`: < 5 stories skips bottleneck analysis; 5-15 runs specialists sequentially; 16+ spawns specialists in parallel
+- [ ] Agent applies restructuring in deterministic order: (1) bottleneck fixes, (2) duplication fixes, (3) fileConflicts recomputation
+- [ ] After applying all restructuring, agent runs cycle detection via topological sort on the modified DAG
+- [ ] If cycle detected: agent reverts the specific restructuring that caused it and logs the revert in the Health Report
+- [ ] Agent creates stub stories with `STUB:` prefix in `notes` field, empty `tasks`, `acceptanceCriteria`, `filePaths`, and standard `retries` block
+- [ ] Stub story IDs use suffix convention (e.g., US-003-A, US-008-A)
+- [ ] Agent modifies `dependsOn` arrays of consuming stories to include stub dependencies
+- [ ] For high-severity file conflicts: agent injects synthetic `dependsOn` edges between conflicting stories so they are never co-scheduled in the same wave (highest-priority story has no added dependency; lower-priority stories depend on the highest)
+- [ ] Agent writes `dagValidation` block to quantum.json with timestamp, bottlenecks, duplicationRisks, fileConflictsComputed, stubsCreated
+- [ ] Agent overwrites `fileConflicts` array in quantum.json with the conflict-auditor's complete results
+- [ ] Agent returns list of stub story IDs and DAG Health Report text to caller
+- [ ] Idempotency: if `dagValidation.timestamp` exists and quantum.json file modification time is not newer than the timestamp, agent skips validation and returns "Already validated"
+- [ ] Agent handles specialist timeout (90 seconds per specialist): if a specialist fails, its analysis is skipped and the Health Report notes the skip
+- [ ] Typecheck/lint passes
+
+### US-008: Update `ql-plan` to tag `storyType` on stories
+
+**Description:** As a user running `/ql-plan`, I want the planner to automatically tag each story with a `storyType` field so that the dag-validator can make informed restructuring decisions.
+
+**Acceptance Criteria:**
+- [ ] `skills/ql-plan/SKILL.md` includes a new section "Story Type Tagging" after the dependency analysis step
+- [ ] The section instructs the planner to assign `storyType` to each story: `"types-only"` for stories that only define types/interfaces/schemas, `"config"` for scaffold/config-only stories, `"test"` for test-only stories, `"logic"` for all others
+- [ ] The section includes examples of each type with rationale
+- [ ] Anti-rationalization guard: "If a story has any task that implements business logic, API handlers, or data processing, it is `logic`, not `types-only`"
+- [ ] Typecheck/lint passes
+
+### US-009: Integrate `dag-validator` into `ql-plan` workflow
+
+**Description:** As a user running `/ql-plan`, I want the dag-validator to run automatically after DAG generation and stub stories to be fleshed out by the planner so that I review a complete, optimized plan.
+
+**Acceptance Criteria:**
+- [ ] `skills/ql-plan/SKILL.md` includes a new final section "DAG Validation" after all existing steps
+- [ ] The section instructs the planner to spawn the `dag-validator` agent with the quantum.json path and PRD path
+- [ ] After the dag-validator returns, the planner checks for stub story IDs in the response
+- [ ] If stubs exist: the planner re-invokes itself with a scoped prompt: "Flesh out these stub stories: [IDs]. Add tasks, acceptanceCriteria, and filePaths. Do NOT modify other stories."
+- [ ] After flesh-out: the planner validates each stub has `tasks.length > 0` and `acceptanceCriteria.length > 0`
+- [ ] If a stub fails validation: the planner removes the stub, reverts `dependsOn` modifications that referenced it, and logs the revert in the Health Report
+- [ ] The planner removes the `STUB:` prefix from `notes` on successfully fleshed-out stubs
+- [ ] The planner prints the DAG Health Report to the user as the final output before review
+- [ ] If the dag-validator returns "Already validated" (idempotency), the planner skips the validation step and prints "Plan already validated on [timestamp]"
+- [ ] Typecheck/lint passes
+
+## 4. Functional Requirements
+
+FR-1: The planner shall assign a `storyType` field to every story during generation, with allowed values `"types-only"`, `"logic"`, `"config"`, `"test"`.
+
+FR-2: The dag-validator shall spawn specialist agents in parallel for plans with 16+ stories, sequentially for 5-15 stories, and skip bottleneck analysis for plans with < 5 stories.
+
+FR-3: The bottleneck-analyzer shall detect linear dependency chains of length > 2, single-story waves, and fan-out blockers (stories blocking 5+ downstream).
+
+FR-4: The bottleneck-analyzer shall propose types-only stub extraction for bottlenecks caused by types-only dependencies, and report-only warnings for logic dependencies.
+
+FR-5: The duplication-detector shall exclude standard stop-words and project-configurable stop-words from keyword extraction before computing Jaccard similarity.
+
+FR-6: The duplication-detector shall flag story pairs with Jaccard similarity > 0.3 (configurable) for LLM semantic verification.
+
+FR-7: The duplication-detector shall only propose stub extraction when the LLM confirms overlapping implementation concerns.
+
+FR-8: The conflict-auditor shall compute `fileConflicts` by intersecting all stories' task `filePaths` arrays, filtering to files in 2+ stories.
+
+FR-9: The conflict-auditor shall classify each conflict as `"high"` (barrel/index files, shared type files, config files), `"medium"` (same-wave source file overlap), or `"low"` (different-wave source file overlap).
+
+FR-10: The dag-validator shall apply restructuring in deterministic order: bottleneck fixes, then duplication fixes, then fileConflicts recomputation.
+
+FR-11: The dag-validator shall run cycle detection after all restructuring and revert any change that introduces a cycle.
+
+FR-12: The dag-validator shall inject synthetic `dependsOn` edges for high-severity file conflicts: lower-priority stories in the conflict group shall depend on the highest-priority story, preventing co-scheduling.
+
+FR-13: The dag-validator shall create stub stories with suffix-convention IDs (e.g., US-003-A) and `STUB:` prefix in the `notes` field.
+
+FR-14: The dag-validator shall skip validation if `dagValidation.timestamp` exists and the quantum.json file has not been modified since that timestamp.
+
+FR-15: The planner shall re-invoke itself to flesh out stub stories after the dag-validator returns, and validate that each stub has non-empty `tasks` and `acceptanceCriteria`.
+
+FR-16: The planner shall revert stub stories that fail the flesh-out validation, restoring the original `dependsOn` edges.
+
+FR-17: The dag-validator shall handle specialist timeouts (90 seconds) gracefully, skipping the timed-out specialist's analysis and noting the skip in the Health Report.
+
+## 5. Non-Goals (Out of Scope)
+
+1. **Runtime duplication detection** — This feature operates at planning time only. The wave-end type audit (L5, already implemented) handles runtime duplication. We do not modify `lib/type-audit.sh`.
+
+2. **Barrel file auto-generation** — The conflict-auditor flags barrel files as high-severity, but this feature does not implement post-merge barrel file generation. That is a separate orchestrator-level change.
+
+3. **Machine-checkable assertions** — The post-mortem (#3, #6) proposes `requiredFiles` and `assertions` fields for runtime validation. This is a runtime enforcement concern outside the scope of planner intelligence.
+
+4. **quantum.json location change** — The post-mortem (#4) proposes moving quantum.json out of the git tree. This is an infrastructure change independent of DAG validation.
+
+5. **Worktree base divergence fix** — The post-mortem (#2) proposes synchronizing worktree base commits. This is an orchestrator spawn-time concern, not a planning concern.
+
+6. **Modifying the orchestrator's scheduling algorithm** — The orchestrator already has file-conflict-aware filtering (Step 2.1). We inject synthetic dependencies at planning time so the existing orchestrator logic handles them without modification.
+
+7. **Splitting logic stories automatically** — Per design decision, the bottleneck analyzer only auto-restructures types-only dependencies. Logic story fan-out blockers are reported as warnings for manual resolution.
+
+## 6. Design Considerations
+
+**Agent prompt design:** Each specialist agent has a narrow, focused prompt. The coordinator passes only the data each specialist needs (stories array subset, not full quantum.json) to minimize context and maximize quality.
+
+**Stub ID convention:** Stubs use suffix IDs (US-003-A, US-003-B) derived from the story they were extracted from. This makes the extraction provenance visible in the DAG Health Report and quantum.json.
+
+**Synthetic dependencies for high-severity conflicts:** Rather than modifying the orchestrator, we inject `dependsOn` edges at planning time. This means the orchestrator's existing DAG query and file-conflict-aware filtering handle high-severity conflicts automatically. The synthetic edges are permanent in quantum.json — they survive re-reads and restarts.
+
+**Idempotency mechanism:** The dag-validator compares `dagValidation.timestamp` against the quantum.json file's modification time. If the file hasn't changed since the last validation, validation is skipped. This prevents redundant work when a user re-runs `ql-plan` without modifying the plan.
+
+## 7. Technical Considerations
+
+**Dependencies:** All four new agents (`dag-validator`, `bottleneck-analyzer`, `duplication-detector`, `conflict-auditor`) are `.md` files in the `agents/` directory. They use the standard Claude Code agent frontmatter format. No new shell scripts or libraries are required.
+
+**Existing file modifications:** Only `skills/ql-plan/SKILL.md` and `quantum.json.example` are modified. All other changes are new files.
+
+**Parallel agent spawning:** The dag-validator uses the Agent tool to spawn specialists. For 16+ story plans, all three are spawned in a single message with multiple Agent tool calls. For 5-15 story plans, they are invoked sequentially within the coordinator.
+
+**Cycle detection algorithm:** The coordinator uses Kahn's algorithm (iterative topological sort). If the sorted output has fewer nodes than the total story count, a cycle exists. The coordinator identifies which restructuring introduced the cycle by checking which new edges connect to the cycle's nodes.
+
+**File conflict severity requires wave knowledge:** The conflict-auditor needs wave assignment to classify "medium" (same wave) vs "low" (different wave). The coordinator provides wave assignments computed from the DAG's topological sort alongside the stories array.
+
+## 8. Success Metrics
+
+- The dag-validator would have detected all three planning defects from the 2026-03-24 post-mortem when run on the original 18-story plan: the US-001->US-002->US-003 bottleneck, the US-008/US-013 Louvain duplication, and the missing `index.ts` in `fileConflicts`
+- `fileConflicts` coverage: 100% of files appearing in 2+ stories' `filePaths` are listed (zero false negatives on mechanical computation)
+- Validation completes in < 2 minutes for plans with up to 30 stories
+- Re-running validation on an unchanged plan takes < 5 seconds (idempotency)
+- Zero cycles introduced in restructured DAGs (hard gate, never violated)
+- Stub stories are successfully fleshed out by the planner in > 80% of cases
+
+## 9. Open Questions
+
+1. Should the Jaccard threshold (0.3) and specialist timeout (90s) be exposed as `ql-plan` question-phase prompts, or are they purely reference-doc configuration? Current decision: reference-doc only, configurable via `dagValidation` fields in quantum.json.
+
+2. Should the DAG Health Report be saved as a separate file (e.g., `docs/plans/YYYY-MM-DD-dag-health-report.md`) in addition to the `dagValidation` block in quantum.json? Current decision: quantum.json only, but this could change if users want persistent reports.
+
+3. The conflict-auditor needs wave assignments to classify medium vs low severity. Should the coordinator compute waves before spawning specialists (adding a sequential step), or should the conflict-auditor receive raw `dependsOn` and compute waves itself? Current decision: coordinator computes waves and passes them to the auditor.
+
+### Lifecycle Checklist
+
+- **First-run behavior:** N/A — this feature activates automatically during `ql-plan`. No onboarding or empty state. If no issues are found, the Health Report says "No issues found" and the plan is unchanged.
+- **Returning-user behavior:** Idempotency check: if `dagValidation.timestamp` exists and quantum.json is unmodified, validation is skipped with a message "Plan already validated on [timestamp]."
+- **Update behavior:** N/A — this is a planning-time tool, not a deployed service. New agent versions take effect on next `ql-plan` run. No migration needed.
+- **Error recovery:** Specialist timeout or crash causes graceful degradation — the coordinator proceeds with available results. Failed stub flesh-out is reverted. Cycle detection reverts bad restructuring. The principle: the validator never makes the plan worse.
+- **No-data/empty state:** Plans with < 5 stories skip bottleneck analysis. Plans with no `filePaths` on any task produce empty `fileConflicts`. Plans with no keyword overlap produce no duplication warnings. All handled gracefully.
+- **Uninstall/disable:** Removing the four agent `.md` files and the `ql-plan` validation section restores original behavior. The `dagValidation` block in quantum.json is informational only — no runtime code reads it. Existing plans with `dagValidation` blocks are unaffected.


### PR DESCRIPTION
## Summary

- Add post-generation DAG validation system to `ql-plan` using parallel specialist agents
- **bottleneck-analyzer**: detects linear chains > 2, single-story waves, fan-out blockers (5+ downstream); auto-extracts types-only stubs, warns on logic dependencies
- **duplication-detector**: hybrid keyword pre-filter (Jaccard similarity) + LLM semantic verification; extracts shared utility stubs for confirmed overlaps
- **conflict-auditor**: auto-computes `fileConflicts` from `filePaths` intersections with severity classification (high/medium/low)
- **dag-validator** coordinator: spawns specialists (parallel for 16+ stories), applies restructuring in deterministic order, runs cycle detection with revert, injects synthetic `dependsOn` for high-severity conflicts, produces DAG Health Report
- New `storyType` field on stories (`types-only`, `logic`, `config`, `test`) for safe restructuring decisions
- New `dagValidation` block in quantum.json for traceability
- Reference doc (`dag-validation.md`) with configurable stop-words, Jaccard threshold, bottleneck heuristics, severity rules, barrel file patterns
- Agent prompts optimized for context window efficiency (29% reduction following skill-creator principles)

**Triggered by:** [2026-03-24 post-mortem observations](docs/post-mortems/) — issues #5 (sequential bottleneck), #8 (duplicate Louvain implementation), #9 (incomplete fileConflicts)

## Files changed

| File | Change |
|---|---|
| `agents/dag-validator.md` | NEW — coordinator agent |
| `agents/bottleneck-analyzer.md` | NEW — specialist |
| `agents/duplication-detector.md` | NEW — specialist |
| `agents/conflict-auditor.md` | NEW — specialist |
| `skills/ql-plan/references/dag-validation.md` | NEW — reference doc |
| `skills/ql-plan/SKILL.md` | MODIFIED — storyType tagging + DAG Validation step |
| `quantum.json.example` | MODIFIED — storyType, dagValidation, severity fields |
| `docs/plans/2026-03-24-dag-intelligence-design.md` | NEW — approved design |
| `tasks/prd-dag-intelligence.md` | NEW — PRD |

## Test plan

- [ ] Run `ql-plan` on a new PRD — verify storyType assigned to all stories
- [ ] Run `ql-plan` on a 18+ story plan — verify dag-validator spawns 3 parallel specialists
- [ ] Verify `fileConflicts` auto-computed from `filePaths` intersections (no manual enumeration needed)
- [ ] Verify barrel files (index.ts, __init__.py) classified as severity "high"
- [ ] Verify linear chains > 2 detected and types-only stubs proposed
- [ ] Verify idempotency: re-run on unchanged plan skips validation
- [ ] Replay the 2026-03-24 Logical_inference plan — confirm all 3 post-mortem issues detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)