### PR TITLE
chore: bump plugin.json to 0.4.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Universal CLI orchestrator with multi-runner support. Autonomous spec-driven development pipeline with dependency DAG, parallel worktree execution, two-stage review gates, DAG intelligence validation, and modular merge hardening",
-    "version": "0.4.0"
+    "version": "0.4.1"
   },
   "plugins": [
     {
       "name": "quantum-loop",
       "source": "./",
       "description": "6 skills (brainstorm, spec, plan, execute, verify, review) and 5 agents for autonomous spec-driven development with multi-runner support, DAG intelligence, and modular merge hardening",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "keywords": ["autonomous", "prd", "tdd", "verification", "review", "planning", "agent-loop", "multi-runner", "codex", "copilot", "gemini", "universal-orchestrator"],
       "category": "productivity"
     }

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "quantum-loop",
-  "version": "0.3.6",
-  "description": "Autonomous spec-driven development pipeline with dependency DAG, parallel worktree execution, two-stage review gates, DAG intelligence validation, and modular merge hardening",
+  "version": "0.4.1",
+  "description": "Universal CLI orchestrator with multi-runner support. Autonomous spec-driven development with dependency DAG, parallel worktree execution, two-stage review gates, and modular merge hardening",
   "homepage": "https://github.com/andyzengmath/quantum-loop"
 }


### PR DESCRIPTION
Bumps plugin.json version from 0.3.6 to 0.4.0 to match marketplace.json.

This is the **root cause** of the plugin update issue — the Claude Code plugin
manager reads version from plugin.json (not marketplace.json), so installs
were stuck at the old version.