### PR TITLE
fix: bump .claude-plugin/plugin.json to 0.4.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "quantum-loop",
-  "description": "Spec-driven autonomous development loop: brainstorm, spec, plan, execute with TDD, two-stage review gates, and Iron Law verification.",
-  "version": "0.3.4",
+  "description": "Universal CLI orchestrator with multi-runner support. Autonomous spec-driven development with dependency DAG, parallel worktree execution, two-stage review gates, and modular merge hardening.",
+  "version": "0.4.1",
   "author": {
     "name": "andyzengmath"
   }


### PR DESCRIPTION
Root cause: plugin manager reads .claude-plugin/plugin.json (was 0.3.4), not plugin.json (was 0.4.1).