### PR TITLE
Phase 23 — KBI-FAR reviewer split (P3.3, arXiv:2505.17928)

### DIFF
--- a/.omc/phase-23-evidence/test_ambiguity.log
+++ b/.omc/phase-23-evidence/test_ambiguity.log
@@ -1,0 +1,68 @@
+=== Phase 19 ambiguity-gate tests ===
+
+Test 1: score_ambiguity arithmetic
+  PASS: all 10s -> 0
+  PASS: all 0s -> 100
+  PASS: all 5s -> 50
+  PASS: goal only -> 60
+  PASS: constraints only -> 70
+  PASS: criteria only -> 70
+
+Test 2: score_ambiguity input validation
+  PASS: 11 rejected
+  PASS: -1 rejected
+  PASS: abc rejected
+
+Test 3: check_gate semantics
+  PASS: score 0 passes
+  PASS: score 19 passes
+  PASS: score 20 blocks
+  PASS: score 50 blocks
+  PASS: score 100 blocks
+  PASS: 30 < 50 passes
+  PASS: 60 >= 50 blocks
+
+Test 4: challenge_mode thresholds
+  PASS: round 1, score 100 -> normal
+  PASS: round 2, score 80  -> normal
+  PASS: round 3, score 45  -> contrarian
+  PASS: round 3, score 35  -> normal
+  PASS: round 4, score 35  -> simplifier
+  PASS: round 4, score 25  -> normal
+  PASS: round 5, score 25  -> ontologist
+  PASS: round 5, score 15  -> normal
+  PASS: round 6, score 50  -> ontologist
+
+Test 5: ontology_extract
+  PASS: extract tokens sorted+unique
+  PASS: empty -> empty
+  PASS: stopwords dropped
+
+Test 6: ontology_diff
+  PASS: 1 added
+  PASS: 1 removed
+  PASS: 2 carried
+  PASS: stability 0.50
+  PASS: identical stability 1.0
+  PASS: empty prior stability 0.00
+
+Test 7: CLI subcommands
+  PASS: CLI score 5 5 5 = 50
+  PASS: CLI gate 10 passes
+  PASS: CLI gate 25 blocks
+  PASS: CLI mode 5 30 = ontologist
+
+Test 8: ql-brainstorm wires lib/ambiguity.sh
+  PASS: Phase 0B ambiguity gate section
+  PASS: calls lib/ambiguity.sh score
+  PASS: calls lib/ambiguity.sh gate
+  PASS: calls lib/ambiguity.sh mode
+  PASS: ontology stability tracking
+  PASS: ontology diff call
+  PASS: contrarian mode described
+  PASS: simplifier mode described
+  PASS: ontologist mode described
+  PASS: thrashing ontology escalation
+  PASS: handoff records final_score
+
+=== Results: 49/49 passed, 0 failed ===

--- a/.omc/phase-23-evidence/test_constitution.log
+++ b/.omc/phase-23-evidence/test_constitution.log
@@ -1,0 +1,51 @@
+=== Phase 22 constitution tests ===
+
+Test 1: load_constitution
+  PASS: loads 2 rules
+  PASS: missing constitution -> empty
+  PASS: missing file -> empty
+  PASS: object form with .rule
+
+Test 2: check_no_secrets detects provider tokens
+  PASS: detects sk-live token
+  PASS: detects ghp_ token
+  PASS: ignores comment about passwords (no literal)
+
+Test 3: generic password/api_key literal
+  PASS: password= long literal flagged
+  PASS: api_key= long literal flagged
+  PASS: short literal not flagged
+
+Test 4: check_sql_injection
+  PASS: flags 2 SQL injections (template + concat)
+  PASS: parameterized query not flagged
+
+Test 5: check_input_validation
+  PASS: flags 2 unvalidated handler reads
+
+Test 6: check_commit_integrity
+  PASS: flags migration file
+  PASS: flags schema.prisma
+  PASS: flags .env.example
+  PASS: does NOT flag regular source file
+
+Test 7: enforce_constitution end-to-end
+  PASS: enforce finds 2 secret+sql findings
+  PASS: input-validation skipped when not active
+  PASS: input-validation active -> finds req.body
+  PASS: no constitution -> empty JSON array
+  PASS: unknown rule -> empty findings (warn only)
+
+Test 8: finding metadata
+  PASS: severity critical
+  PASS: description set
+  PASS: rule id set
+
+Test 9: CLI enforce
+  PASS: CLI enforce returns findings
+
+Test 10: quantum.json.example schema
+  PASS: constitution is array
+  PASS: quantum.json.example still valid JSON
+
+=== Results: 28/28 passed, 0 failed ===

--- a/.omc/phase-23-evidence/test_deep_review.log
+++ b/.omc/phase-23-evidence/test_deep_review.log
@@ -1,0 +1,52 @@
+=== Phase 8 ql-deep-review helper tests ===
+
+Test 1: tier_of_score mapping
+  PASS: 0 -> LOW
+  PASS: 30 -> LOW
+  PASS: 31 -> MEDIUM
+  PASS: 60 -> MEDIUM
+  PASS: 61 -> HIGH
+  PASS: 80 -> HIGH
+  PASS: 81 -> CRITICAL
+  PASS: 100 -> CRITICAL
+
+Test 2: compute_risk_score bounds
+  PASS: empty refs -> 0
+  PASS: intent drift contributes 10
+
+Test 3: actionability_filter
+  PASS: kept count
+  PASS: suppressed count
+  PASS: suppressed has reason
+
+Test 4: dedup_findings
+  PASS: dedup reduces 3 -> 2
+  PASS: merged agents count
+  PASS: kept max confidence
+
+Test 5: hallucination_check suppresses missing files
+  PASS: 1 file kept
+  PASS: 1 file suppressed as hallucination
+  PASS: suppressed reason
+
+Test 6: synthesize_verdict
+  PASS: empty -> APPROVE
+  PASS: only low -> APPROVE
+  PASS: medium 60 -> APPROVE_WITH_COMMENTS
+  PASS: high 75 -> REQUEST_CHANGES
+  PASS: critical 85 -> BLOCKS_MERGE
+  PASS: critical 50 (below threshold) -> APPROVE
+
+Test 7: quantum.json.example schema
+  PASS: reviews is object
+  PASS: quantum.json.example still valid JSON
+
+Test 8: ql-execute mentions the post-pipeline hook
+  PASS: post-pipeline hook header present
+  PASS: references lib/deep-review.sh
+
+Test 9: CLI subcommands work
+  PASS: CLI tier 50 -> MEDIUM
+  PASS: CLI tier 100 -> CRITICAL
+
+=== Results: 31/31 passed, 0 failed ===

--- a/.omc/phase-23-evidence/test_deslop.log
+++ b/.omc/phase-23-evidence/test_deslop.log
@@ -1,0 +1,41 @@
+=== Phase 9 ql-deslop helper tests ===
+
+Test 1: validate_scope
+  PASS: in-scope file accepted (exit 0)
+  PASS: out-of-scope file rejected (exit 1)
+
+Test 2: take_baseline snapshot shape
+  PASS: snapshot has test_exit
+  PASS: snapshot has lint_exit
+  PASS: snapshot has typecheck_exit
+  PASS: snapshot test_exit = 0
+
+Test 3: compare_baseline regression detection
+  PASS: matching baselines -> clean (exit 0)
+  PASS: test regression -> dirty (exit 1)
+  PASS: improvement -> clean (exit 0)
+
+Test 4: rollback_pass restores baseline content
+  PASS: pre-rollback content
+  PASS: post-rollback content
+
+Test 5: detect_language marker-file dispatch
+  PASS: empty dir -> unknown|skip
+  PASS: tsconfig.json -> typescript
+  PASS: package.json -> javascript
+  PASS: go.mod -> go
+  PASS: Cargo.toml -> rust
+
+Test 6: quantum.json.example schema
+  PASS: deslop is object
+  PASS: quantum.json.example still valid JSON
+
+Test 7: ql-execute mentions ql-deslop hook
+  PASS: slop-cleanup hook header present
+  PASS: references lib/deslop.sh
+  PASS: mentions DESLOP_ROLLED_BACK signal
+
+Test 8: CLI entrypoints
+  PASS: CLI detect-language typescript prefix
+
+=== Results: 22/22 passed, 0 failed ===

--- a/.omc/phase-23-evidence/test_dispatch_set.log
+++ b/.omc/phase-23-evidence/test_dispatch_set.log
@@ -1,0 +1,50 @@
+=== Phase 12 dispatch-set tests ===
+
+Test 1: dispatch_set cardinality per tier
+  PASS: LOW has 2 reviewers
+  PASS: MEDIUM has 4 reviewers
+  PASS: HIGH has 6 reviewers
+  PASS: CRITICAL has 7 reviewers
+
+Test 2: tier subset invariant
+  PASS: LOW ⊆ MEDIUM
+  PASS: MEDIUM ⊆ HIGH
+  PASS: HIGH ⊆ CRITICAL
+
+Test 3: core reviewers always present
+  PASS: LOW has code-reviewer
+  PASS: LOW has synthesizer
+  PASS: MEDIUM has code-reviewer
+  PASS: MEDIUM has synthesizer
+  PASS: HIGH has code-reviewer
+  PASS: HIGH has synthesizer
+  PASS: CRITICAL has code-reviewer
+  PASS: CRITICAL has synthesizer
+
+Test 4: CRITICAL tier includes cross-provider critic
+  PASS: CRITICAL has omc:ask-codex-critic
+  PASS: HIGH does NOT include cross-provider critic
+
+Test 5: unknown tier errors
+  PASS: unknown tier exits 1
+
+Test 6: risk_score_from_quantum extracts critical count
+  PASS: intent drift critical=1 contributes 10
+  PASS: missing quantum.json yields 0
+
+Test 7: prepare_review_context shape
+  PASS: context has base_sha
+  PASS: context has tier
+  PASS: context has verbatim intent
+  PASS: context has 1 changed file
+  PASS: context has evidence_requirements.must_cite with 3 entries
+
+Test 8: aggregate_reviews chain
+  PASS: aggregate kept 1 finding
+  PASS: aggregate suppressed 2 findings
+  PASS: verdict REQUEST_CHANGES (high ≥70)
+
+Test 9: CLI subcommands
+  PASS: CLI dispatch-set LOW -> 2
+
+=== Results: 29/29 passed, 0 failed ===

--- a/.omc/phase-23-evidence/test_dogfood_e2e.log
+++ b/.omc/phase-23-evidence/test_dogfood_e2e.log
@@ -1,0 +1,38 @@
+=== Phase 10 dogfood end-to-end check ===
+
+Test 1: dogfood quantum.json parses
+  PASS: valid JSON
+
+Test 2: schema fields from Phases 7-9
+  PASS: userIntent.text present
+  PASS: userClarifications is array
+  PASS: intentDrift has entry
+  PASS: reviews has deepReview
+  PASS: deslop field present
+  PASS: codebasePatterns has entries
+  PASS: progress has entries
+
+Test 3: intent-drift gate semantics
+  PASS: NO_DRIFT gate allows merge
+
+Test 4: deep-review synthesize_verdict consumes the dogfood findings array
+  PASS: two HIGH confidence≥70 findings → REQUEST_CHANGES
+
+Test 5: dedup_findings idempotent on dogfood findings
+  PASS: dedup preserves 2-element unique set
+
+Test 6: plan retrospective — 10 stories all passed
+  PASS: 10 stories total
+  PASS: 10 stories passed
+
+Test 7: codebasePatterns contains real Phase-5 lesson
+  PASS: Phase-5 set-e lesson present
+
+Test 8: userIntent verbatim contains the original verbatim message
+  PASS: intent snapshot references IDEA_REPORT.md
+
+Test 9: companion PRD exists and references the dogfood artifact
+  PASS: PRD exists
+  PASS: PRD has AC-15 dogfood + references phase-10-evidence
+
+=== Results: 17/17 passed, 0 failed ===

--- a/.omc/phase-23-evidence/test_far_filter.log
+++ b/.omc/phase-23-evidence/test_far_filter.log
@@ -1,0 +1,41 @@
+=== Phase 23 KBI-FAR far_filter tests ===
+
+Test 1: confidence cutoff
+  PASS: 1 kept (conf ≥60)
+  PASS: 2 suppressed (conf <60)
+  PASS: reason mentions confidence
+
+Test 2: agreement boost lifts across cutoff
+  PASS: agreement-boosted finding kept
+  PASS: confidence boosted 50 -> 65
+  PASS: original_confidence preserved
+  PASS: single-agent below-cutoff suppressed
+
+Test 3: confidence cap at 100
+  PASS: confidence capped at 100
+
+Test 4: knownFalsePositives regex suppression
+  PASS: genuine finding kept
+  PASS: 2 suppressed by regex
+  PASS: suppression reasons reference knownFalsePositives
+
+Test 5: missing quantum.json graceful fallback
+  PASS: finding kept with missing quantum.json
+
+Test 6: empty input
+  PASS: empty kept
+  PASS: empty suppressed
+
+Test 7: CLI subcommand
+  PASS: CLI far kept 1
+
+Test 8: aggregate_reviews wires far_filter
+  PASS: aggregate kept 1 real finding
+  PASS: aggregate suppressed 2 (cutoff + FP)
+  PASS: verdict REQUEST_CHANGES (high ≥70)
+  PASS: FP reason present
+
+Test 9: schema extension
+  PASS: knownFalsePositives is array
+
+=== Results: 20/20 passed, 0 failed ===

--- a/.omc/phase-23-evidence/test_orchestrator_wiring.log
+++ b/.omc/phase-23-evidence/test_orchestrator_wiring.log
@@ -1,0 +1,65 @@
+=== Phase 17 orchestrator-wiring prompt tests ===
+
+Test 1: lib/wave-boundary.sh wired at wave boundary
+  PASS: 3C.NEG1 section present
+  PASS: references wave-boundary.sh scan
+  PASS: routes HIGH severity to fix-story
+
+Test 2: lib/watchdog.sh wired in monitor loop
+  PASS: watchdog tick header
+  PASS: references watchdog.sh poll
+  PASS: status-probe action branch
+  PASS: kill-and-requeue action branch
+  PASS: mark-failed action branch
+  PASS: circuit-breaker bump
+  PASS: circuit-breaker check
+
+Test 3: lib/deep-review.sh wired at full-feature review
+  PASS: 4B.5 deep-review section
+  PASS: score-from-quantum call
+  PASS: tier lookup
+  PASS: dispatch-set call
+  PASS: context preparation
+  PASS: aggregate pipe
+  PASS: BLOCKS_MERGE handled
+  PASS: REQUEST_CHANGES handled
+  PASS: persists into quantum.reviews
+
+Test 4: lib/deslop.sh wired between review-pass and commit
+  PASS: 3A.5B deslop section
+  PASS: validate_scope gate
+  PASS: baseline snapshot before
+  PASS: compare_baseline call
+  PASS: rollback on regression
+  PASS: DESLOP_ROLLED_BACK signal
+  PASS: opt-out via story.deslop.skip
+
+Test 5: lib/commit-trailers.sh validation gate
+  PASS: commit-trailers reference
+  PASS: non-blocking warning
+
+Test 6: handoff.sh ownership is skill-side (orchestrator doesn't write)
+  PASS: orchestrator does NOT write handoffs directly (skills do)
+
+Test 7: all wirings carry a Phase-17 attribution comment
+  PASS: 5 Phase-17 attributions
+
+Test 8: deslop wiring uses DESLOP_AVAILABLE + BASE_SHA
+  PASS: DESLOP_AVAILABLE guard present
+  PASS: DESLOP_AVAILABLE file check
+  PASS: Fallback skip branch
+  PASS: scope loop uses BASE_SHA
+  PASS: rollback uses BASE_SHA
+  PASS: no active STORY_BASE_SHA refs in 3A.5B
+
+Test 9: RUNNER_EXTRA_FLAGS validated after pre_spawn()
+  PASS: RUNNER_EXTRA_FLAGS validation present
+  PASS: blocklist present (regex form varies)
+
+Test 10: runner_build_cmd rejects injection via RUNNER_EXTRA_FLAGS
+  PASS: injection payload rejected with clear error
+
+Test 11: lib/watchdog.sh doc comment corrected
+  PASS: watchdog threshold comment matches code (>30 min = timed-out)
+
+=== Results: 40/40 passed, 0 failed ===

--- a/.omc/phase-23-evidence/test_phase_skip.log
+++ b/.omc/phase-23-evidence/test_phase_skip.log
@@ -1,0 +1,55 @@
+=== Phase 18 phase-skip tests ===
+
+Test 1: artifact_hash basics
+  PASS: hash stable across calls
+  PASS: hash is 64 hex chars
+  PASS: missing file -> empty hash
+
+Test 2: artifact_hash differs on content change
+  PASS: hashes differ
+
+Test 3: artifact_hash_inline
+  PASS: inline hash stable
+  PASS: inline hash differs on content change
+
+Test 4: record + read round-trip
+  PASS: stage round-trips
+  PASS: artifact count
+  PASS: sha256 round-trips
+  PASS: recorded_at non-empty
+
+Test 5: read_fingerprint on missing file
+  PASS: missing -> {}
+
+Test 6: should_skip_stage when all artifacts fresh
+  PASS: all-fresh -> skip (exit 0)
+
+Test 7: should_skip_stage after content change
+  PASS: content changed -> re-run (exit 1)
+
+Test 8: should_skip_stage without any record
+  PASS: no record -> re-run (exit 1)
+
+Test 9: artifact count mismatch rejects
+  PASS: count mismatch -> re-run (exit 1)
+
+Test 10: inline: escape class
+  PASS: inline matches -> skip
+  PASS: inline mismatches -> re-run
+
+Test 11: CLI subcommands
+  PASS: CLI hash matches lib hash
+  PASS: CLI inline matches lib inline
+
+Test 12: skills reference lib/phase-skip.sh
+  PASS: brainstorm Phase 0 section
+  PASS: brainstorm calls phase-skip skip
+  PASS: brainstorm records fingerprint
+  PASS: spec Phase 0 section
+  PASS: spec calls phase-skip skip
+  PASS: spec records fingerprint
+  PASS: plan Phase 0 section
+  PASS: plan calls phase-skip skip
+  PASS: plan records fingerprint
+
+=== Results: 28/28 passed, 0 failed ===

--- a/.omc/phase-23-evidence/test_reaper.log
+++ b/.omc/phase-23-evidence/test_reaper.log
@@ -1,0 +1,62 @@
+=== Phase 20 reaper + spawn exec-capture tests ===
+
+Test 1: detect_platform recognizes current environment
+  PASS: platform is valid enum
+  (detected: msys)
+
+Test 2: _msys_to_winpid handles current PID
+  PASS: numeric winpid (19324)
+
+Test 3: write + read pidfile round-trip
+  PASS: pidfile exists
+  PASS: msys_pid round-trips
+  PASS: cmd round-trips
+  PASS: missing pidfile -> {}
+
+Test 4: is_agent_alive tracks liveness
+  PASS: alive while running
+  PASS: dead after kill
+
+Test 5: is_agent_alive on missing pidfile
+  PASS: missing pidfile -> not alive
+
+Test 6: reap_agent on already-dead process cleans pidfile
+  PASS: reap exits 0
+  PASS: pidfile removed
+
+Test 7: reap_agent terminates a live process
+  PASS: reap_agent exits 0
+  PASS: process not alive
+  PASS: pidfile removed
+
+Test 8: reap_orphans cleans stale pidfiles only
+  PASS: no stale-orphans reaped
+  PASS: dead pidfile removed
+  PASS: live pidfile kept
+
+Test 9: reap_orphans safe on missing/empty dir
+  PASS: missing dir -> 0
+  PASS: empty dir -> 0
+
+Test 10: lib/spawn.sh contains the exec-replacement fix
+  PASS: exec prepended to claude invocation
+  PASS: runner-path uses eval "exec $cmd"
+  PASS: spawn writes pidfile
+
+Test 11: quantum-loop.sh trap uses reaper
+  PASS: cleanup_on_exit calls reap_agent
+  PASS: startup calls reap_orphans
+
+Test 13: _proc_start_epoch is per-process (not a constant)
+  PASS: distinct processes have distinct start epochs (11072276 vs 11073345)
+
+Test 14: cleanup_on_exit uses parallel reap pattern
+  PASS: cleanup_on_exit parallelizes reap_agent calls
+
+Test 15: timeout branch uses reap_agent on Git Bash
+  PASS: TIMED_OUT branch prefers reap_agent
+
+Test 12: CLI subcommands work
+  PASS: CLI platform output: msys
+
+=== Results: 28/28 passed, 0 failed ===

--- a/.omc/phase-23-evidence/test_watchdog.log
+++ b/.omc/phase-23-evidence/test_watchdog.log
@@ -1,0 +1,55 @@
+=== Phase 16 watchdog + circuit-breaker tests ===
+
+Test 1: classify_age thresholds
+  PASS: 0s -> fresh
+  PASS: 300s -> fresh
+  PASS: 301s -> stale-check
+  PASS: 600s -> stale-check
+  PASS: 601s -> stale-reassign
+  PASS: 1200s -> stale-reassign
+  PASS: 1201s -> stale-reassign
+  PASS: 1800s -> stale-reassign
+  PASS: 1801s -> timed-out
+  PASS: 7200s -> timed-out
+
+Test 2: watchdog_poll on empty state
+  PASS: missing quantum.json -> []
+
+Test 3: watchdog_poll fresh in_progress story
+  PASS: only the in_progress story returned
+  PASS: story_id is US-001
+  PASS: fresh -> continue
+  PASS: classification fresh
+
+Test 4: watchdog_poll stale-check (~400s old)
+  PASS: 400s -> stale-check
+  PASS: stale-check -> status-probe
+
+Test 5: watchdog_poll timed-out (>30min old)
+  PASS: 2400s -> timed-out
+  PASS: timed-out -> mark-failed
+
+Test 6: error_counter_bump same signature increments
+  PASS: first bump count 1
+  PASS: second bump count 2
+  PASS: third bump count 3
+
+Test 7: different signature resets counter
+  PASS: sig-A count reaches 2
+  PASS: sig-B resets to 1
+  PASS: sig-B next bump is 2
+
+Test 8: should_circuit_break crosses threshold
+  PASS: count=1, threshold=3 -> no break (exit 1)
+  PASS: count=3, threshold=3 -> BREAK (exit 0)
+  PASS: count=3, threshold=10 -> no break
+
+Test 9: error_counter_reset
+  PASS: after reset, no break
+  PASS: count after reset=1
+
+Test 10: CLI subcommands
+  PASS: CLI classify 500 -> stale-check
+  PASS: CLI bump first -> 1
+
+=== Results: 32/32 passed, 0 failed ===

--- a/lib/deep-review.sh
+++ b/lib/deep-review.sh
@@ -195,6 +195,93 @@ synthesize_verdict() {
 }
 
 # ------------------------------------------------------------------------------
+# Phase 23 / P3.3 — KBI-FAR reviewer split (arXiv:2505.17928)
+# ------------------------------------------------------------------------------
+#
+# The ICML 2025 paper decomposes review into two stages:
+#   KBI (Known-Bug-Inspection)  — broad, high-recall sweep: each reviewer
+#                                  aggressively flags anything suspicious.
+#   FAR (False-Alarm-Reduction) — precision filter: drop low-confidence,
+#                                  suppress known-false-positives, boost
+#                                  multi-agent agreement.
+#
+# Our existing actionability_filter + dedup + hallucination_check already do
+# part of FAR. This section adds the explicit precision filter to complete
+# the split: confidence cutoff, multi-agent agreement boost, and known-FP
+# regex suppression from quantum.json.knownFalsePositives[].
+
+: "${FAR_CONFIDENCE_CUTOFF:=60}"
+: "${FAR_AGREEMENT_BOOST:=15}"
+
+# far_filter(findings_json, [quantum_json_path])
+# Input: JSON array of findings on stdin (already actionability-filtered,
+# deduped, and hallucination-checked). Outputs:
+#   { "kept":      [<findings that survived the precision filter>],
+#     "suppressed":[<findings that were dropped, each with .far_reason>] }
+#
+# Steps applied in order:
+#   1. Multi-agent agreement boost: findings whose .agents array has ≥2
+#      distinct entries get +FAR_AGREEMENT_BOOST on their confidence
+#      (capped at 100). Rewrites the input findings in place.
+#   2. Known-FP pattern suppression: if quantum_json_path is provided and
+#      .knownFalsePositives is an array of regexes, drop any finding whose
+#      title OR description matches any regex.
+#   3. Confidence cutoff: drop any finding whose (boosted) confidence is
+#      below FAR_CONFIDENCE_CUTOFF.
+#
+# Preserves original confidence in .original_confidence on boosted findings.
+far_filter() {
+  local qj="${1:-}"
+  local cutoff="${FAR_CONFIDENCE_CUTOFF:-60}"
+  local boost="${FAR_AGREEMENT_BOOST:-15}"
+
+  # Load known-FP regex list (array of strings). Empty if no quantum.json
+  # or field absent.
+  local fp_json='[]'
+  if [[ -n "$qj" && -f "$qj" ]]; then
+    fp_json=$(jq -c '.knownFalsePositives // []' "$qj" 2>/dev/null || echo '[]')
+  fi
+
+  jq -c \
+    --argjson cutoff "$cutoff" \
+    --argjson boost  "$boost" \
+    --argjson fps    "$fp_json" \
+    '
+    def apply_boost:
+      map(
+        if ((.agents // []) | length) >= 2
+        then . + {
+          original_confidence: (.confidence // 0),
+          confidence: ([.confidence // 0, 0] | max + $boost | if . > 100 then 100 else . end)
+        }
+        else .
+        end
+      );
+
+    def matches_fp:
+      . as $f
+      | any($fps[]?;
+          ((. // "") as $re | $re != "" and
+           (($f.title // "") | test($re)) or
+           (($f.description // "") | test($re))));
+
+    def classify:
+      . as $f
+      | if matches_fp then . + {__suppress: true, far_reason: "matched knownFalsePositives pattern"}
+        elif (.confidence // 0) < $cutoff then . + {__suppress: true, far_reason: ("confidence " + ((.confidence // 0) | tostring) + " below cutoff " + ($cutoff | tostring))}
+        else .
+        end;
+
+    . | apply_boost
+      | map(classify)
+      | {
+          kept:       map(select(.__suppress != true)),
+          suppressed: map(select(.__suppress == true) | del(.__suppress))
+        }
+    '
+}
+
+# ------------------------------------------------------------------------------
 # Phase 12 / P1.3 — risk-adaptive reviewer dispatch
 # ------------------------------------------------------------------------------
 
@@ -268,13 +355,17 @@ prepare_review_context() {
     }'
 }
 
-# aggregate_reviews(repo_root)
+# aggregate_reviews(repo_root, [quantum_json])
 # Input: JSON array of finding arrays — one per reviewer — on stdin. Chains:
 #   flatten → actionability_filter → dedup_findings → hallucination_check →
-#   synthesize_verdict, and emits a single JSON object:
-#   { verdict, tier_findings: [kept], suppressed: [with reasons], kudos: [] }
+#   far_filter → synthesize_verdict, and emits a single JSON object:
+#   { verdict, findings: [kept], suppressed: [with reasons] }
+# far_filter applies the KBI-FAR precision pass (Phase 23/P3.3): agreement
+# boost, confidence cutoff, known-FP regex suppression from
+# quantum.json.knownFalsePositives[].
 aggregate_reviews() {
   local repo_root="${1:-.}"
+  local quantum_json="${2:-}"
   local flat
   flat=$(jq -c '[.[] | .[]]')
   local actionable
@@ -284,18 +375,24 @@ aggregate_reviews() {
   sup_action=$(printf '%s' "$actionable"  | jq -c '.suppressed')
   local deduped
   deduped=$(printf '%s' "$kept_action" | dedup_findings)
-  local checked kept_final sup_hall
+  local checked kept_after_hall sup_hall
   checked=$(printf '%s' "$deduped" | hallucination_check "$repo_root")
-  kept_final=$(printf '%s' "$checked" | jq -c '.kept')
+  kept_after_hall=$(printf '%s' "$checked" | jq -c '.kept')
   sup_hall=$(printf '%s'  "$checked" | jq -c '.suppressed')
+  # Phase 23 / P3.3 precision stage
+  local far kept_final sup_far
+  far=$(printf '%s' "$kept_after_hall" | far_filter "$quantum_json")
+  kept_final=$(printf '%s' "$far" | jq -c '.kept')
+  sup_far=$(printf '%s' "$far" | jq -c '.suppressed')
   local verdict
   verdict=$(printf '%s' "$kept_final" | synthesize_verdict)
   jq -cn \
     --argjson k "$kept_final" \
     --argjson sa "$sup_action" \
     --argjson sh "$sup_hall" \
+    --argjson sf "$sup_far" \
     --arg v "$verdict" \
-    '{verdict: $v, findings: $k, suppressed: ($sa + $sh)}'
+    '{verdict: $v, findings: $k, suppressed: ($sa + $sh + $sf)}'
 }
 
 # ------------------------------------------------------------------------------
@@ -316,6 +413,7 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     actionability) actionability_filter ;;
     dedup)         dedup_findings ;;
     hallucination) hallucination_check "$@" ;;
+    far)           far_filter "$@" ;;
     verdict)       synthesize_verdict ;;
     dispatch-set)  dispatch_set "$@"; printf "\n" ;;
     context)       prepare_review_context "$@"; printf "\n" ;;

--- a/quantum.json.example
+++ b/quantum.json.example
@@ -26,6 +26,8 @@
     "no-sql-injection",
     "input-validation"
   ],
+  "_comment_knownFalsePositives": "Regex patterns for review findings that are known-safe and should be suppressed by lib/deep-review.sh far_filter (Phase 23 / P3.3, KBI-FAR arXiv:2505.17928). Match is tested against finding.title and finding.description. Use sparingly — better to fix a noisy linter than to silence it.",
+  "knownFalsePositives": [],
   "stories": [
     {
       "id": "US-001",

--- a/tests/test_far_filter.sh
+++ b/tests/test_far_filter.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# Phase 23 / P3.3 — tests for far_filter (KBI-FAR precision stage).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR/.."
+PASS=0
+FAIL=0
+TOTAL=0
+
+assert() {
+  local name="$1" expected="$2" actual="$3"
+  TOTAL=$((TOTAL + 1))
+  if [[ "$expected" == "$actual" ]]; then
+    echo "  PASS: $name"; PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $name (expected [$expected] got [$actual])"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# shellcheck disable=SC1091
+source "$REPO_ROOT/lib/deep-review.sh"
+
+echo "=== Phase 23 KBI-FAR far_filter tests ==="
+
+# Test 1: below-cutoff findings suppressed
+echo ""
+echo "Test 1: confidence cutoff"
+raw='[
+  {"file":"a.ts","line":1,"severity":"high","confidence":75,"agents":["r1"],"title":"X","description":"bug X"},
+  {"file":"b.ts","line":2,"severity":"low","confidence":40,"agents":["r1"],"title":"Y","description":"nit Y"},
+  {"file":"c.ts","line":3,"severity":"medium","confidence":30,"agents":["r1"],"title":"Z","description":"minor Z"}
+]'
+out=$(printf '%s' "$raw" | far_filter)
+kept=$(printf '%s' "$out" | jq '.kept | length')
+supp=$(printf '%s' "$out" | jq '.suppressed | length')
+assert "1 kept (conf ≥60)" "1" "$kept"
+assert "2 suppressed (conf <60)" "2" "$supp"
+# Check suppression reason mentions confidence
+reason=$(printf '%s' "$out" | jq -r '.suppressed[0].far_reason')
+case "$reason" in
+  *"confidence"*) echo "  PASS: reason mentions confidence"; PASS=$((PASS + 1)) ;;
+  *) echo "  FAIL: reason [$reason]"; FAIL=$((FAIL + 1)) ;;
+esac
+TOTAL=$((TOTAL + 1))
+
+# Test 2: multi-agent agreement boost
+echo ""
+echo "Test 2: agreement boost lifts across cutoff"
+# Baseline confidence 50 (below cutoff 60), but with 2 reviewers, +15 → 65 (above)
+raw='[
+  {"file":"a.ts","line":1,"severity":"high","confidence":50,"agents":["r1","r2"],"title":"X","description":"agreed bug"}
+]'
+out=$(printf '%s' "$raw" | far_filter)
+kept=$(printf '%s' "$out" | jq '.kept | length')
+boosted=$(printf '%s' "$out" | jq -r '.kept[0].confidence')
+orig=$(printf '%s' "$out" | jq -r '.kept[0].original_confidence // empty')
+assert "agreement-boosted finding kept" "1" "$kept"
+assert "confidence boosted 50 -> 65" "65" "$boosted"
+assert "original_confidence preserved" "50" "$orig"
+# Single-agent version of same finding gets cut
+raw_single='[{"file":"a.ts","line":1,"severity":"high","confidence":50,"agents":["r1"],"title":"X"}]'
+out2=$(printf '%s' "$raw_single" | far_filter)
+kept2=$(printf '%s' "$out2" | jq '.kept | length')
+assert "single-agent below-cutoff suppressed" "0" "$kept2"
+
+# Test 3: Agreement boost capped at 100
+echo ""
+echo "Test 3: confidence cap at 100"
+raw='[{"file":"a.ts","line":1,"severity":"critical","confidence":95,"agents":["r1","r2","r3"],"title":"X"}]'
+out=$(printf '%s' "$raw" | far_filter)
+conf=$(printf '%s' "$out" | jq -r '.kept[0].confidence')
+assert "confidence capped at 100" "100" "$conf"
+
+# Test 4: known-FP regex suppression
+echo ""
+echo "Test 4: knownFalsePositives regex suppression"
+TEST_TMPDIR=$(mktemp -d)
+cat > "$TEST_TMPDIR/quantum.json" << 'EOF'
+{
+  "knownFalsePositives": [
+    "TODO comment",
+    "eslint disable.*next-line"
+  ]
+}
+EOF
+raw='[
+  {"file":"a.ts","line":1,"severity":"high","confidence":85,"agents":["r1"],"title":"TODO comment in code","description":"bad practice"},
+  {"file":"b.ts","line":2,"severity":"medium","confidence":75,"agents":["r1"],"title":"real issue","description":"eslint disable-next-line misuse"},
+  {"file":"c.ts","line":3,"severity":"high","confidence":85,"agents":["r1"],"title":"genuine bug","description":"null deref"}
+]'
+out=$(printf '%s' "$raw" | far_filter "$TEST_TMPDIR/quantum.json")
+kept=$(printf '%s' "$out" | jq '.kept | length')
+supp=$(printf '%s' "$out" | jq '.suppressed | length')
+assert "genuine finding kept" "1" "$kept"
+assert "2 suppressed by regex" "2" "$supp"
+# Suppression reasons should mention FP
+reasons=$(printf '%s' "$out" | jq -r '.suppressed[].far_reason' | sort -u)
+case "$reasons" in
+  *"knownFalsePositives"*) echo "  PASS: suppression reasons reference knownFalsePositives"; PASS=$((PASS + 1)) ;;
+  *) echo "  FAIL: reasons [$reasons]"; FAIL=$((FAIL + 1)) ;;
+esac
+TOTAL=$((TOTAL + 1))
+rm -rf "$TEST_TMPDIR"
+
+# Test 5: missing quantum.json - no FP suppression
+echo ""
+echo "Test 5: missing quantum.json graceful fallback"
+raw='[{"file":"a.ts","line":1,"severity":"high","confidence":80,"agents":["r1"],"title":"ok"}]'
+out=$(printf '%s' "$raw" | far_filter "/nonexistent.json")
+kept=$(printf '%s' "$out" | jq '.kept | length')
+assert "finding kept with missing quantum.json" "1" "$kept"
+
+# Test 6: empty input yields empty kept and suppressed
+echo ""
+echo "Test 6: empty input"
+out=$(printf '[]' | far_filter)
+kept=$(printf '%s' "$out" | jq '.kept | length')
+supp=$(printf '%s' "$out" | jq '.suppressed | length')
+assert "empty kept" "0" "$kept"
+assert "empty suppressed" "0" "$supp"
+
+# Test 7: CLI subcommand
+echo ""
+echo "Test 7: CLI subcommand"
+cli_out=$(printf '[{"file":"a.ts","line":1,"severity":"high","confidence":80,"title":"X","agents":["r1"]}]' | \
+  bash "$REPO_ROOT/lib/deep-review.sh" far)
+cli_kept=$(printf '%s' "$cli_out" | jq '.kept | length')
+assert "CLI far kept 1" "1" "$cli_kept"
+
+# Test 8: aggregate_reviews pipeline integrates far_filter
+echo ""
+echo "Test 8: aggregate_reviews wires far_filter"
+TEST_TMPDIR=$(mktemp -d)
+cd "$TEST_TMPDIR"
+mkdir -p src
+echo "real" > src/real.ts
+echo '{"knownFalsePositives":["skipme"]}' > "$TEST_TMPDIR/quantum.json"
+# Two reviewers, one finding each.
+# Finding A: high 80 real file — kept
+# Finding B: medium 30 real file — suppressed by FAR cutoff
+# Finding C: high 90 real file, title contains "skipme" — suppressed by FP
+reviewer_a='[
+  {"file":"src/real.ts","line":1,"severity":"high","confidence":80,"evidence_type":"code-reference","agents":["code-reviewer"],"title":"real bug"},
+  {"file":"src/real.ts","line":2,"severity":"medium","confidence":30,"evidence_type":"code-reference","agents":["code-reviewer"],"title":"minor"}
+]'
+reviewer_b='[
+  {"file":"src/real.ts","line":3,"severity":"high","confidence":90,"evidence_type":"code-reference","agents":["critic"],"title":"skipme pattern"}
+]'
+input=$(jq -cn --argjson a "$reviewer_a" --argjson b "$reviewer_b" '[$a,$b]')
+agg=$(printf '%s' "$input" | aggregate_reviews "$TEST_TMPDIR" "$TEST_TMPDIR/quantum.json")
+agg_kept=$(printf '%s' "$agg" | jq '.findings | length')
+agg_supp=$(printf '%s' "$agg" | jq '.suppressed | length')
+agg_verdict=$(printf '%s' "$agg" | jq -r '.verdict')
+assert "aggregate kept 1 real finding" "1" "$agg_kept"
+assert "aggregate suppressed 2 (cutoff + FP)" "2" "$agg_supp"
+assert "verdict REQUEST_CHANGES (high ≥70)" "REQUEST_CHANGES" "$agg_verdict"
+# Confirm FP suppression present
+has_fp=$(printf '%s' "$agg" | jq '[.suppressed[] | select(.far_reason // "" | test("knownFalsePositives"))] | length')
+assert "FP reason present" "1" "$has_fp"
+cd "$REPO_ROOT"
+rm -rf "$TEST_TMPDIR"
+
+# Test 9: Phase 22 quantum.json.example has knownFalsePositives field
+echo ""
+echo "Test 9: schema extension"
+kfp_type=$(jq -r '.knownFalsePositives | type' "$REPO_ROOT/quantum.json.example")
+assert "knownFalsePositives is array" "array" "$kfp_type"
+
+echo ""
+echo "=== Results: $PASS/$TOTAL passed, $FAIL failed ==="
+exit $((FAIL > 0 ? 1 : 0))


### PR DESCRIPTION
Second P3 academic wedge. Ports the ICML 2025 two-stage review decomposition (Known-Bug-Inspection + False-Alarm-Reduction) as a precision-filter layer bolted onto `lib/deep-review.sh aggregate_reviews`.

## What changed

- **`far_filter`** — new function in `lib/deep-review.sh`. Applies (1) agreement boost (+15 confidence for findings flagged by 2+ agents), (2) known-FP regex suppression from `quantum.json.knownFalsePositives[]`, (3) confidence cutoff (default 60).
- **`aggregate_reviews`** rewired to chain `far_filter` between hallucination-check and synthesize-verdict.
- **Schema**: `quantum.json.knownFalsePositives` array (backward-compat).
- **CLI**: `bash lib/deep-review.sh far [quantum_json]`.

## Tests — 20 new + 10 existing = 324/324 green

Evidence: `.omc/phase-23-evidence/`