### PR TITLE
Phase 24 — Trajectory-length early kill (P3.5, arXiv:2511.00197)

### DIFF
--- a/.omc/phase-24-evidence/test_ambiguity.log
+++ b/.omc/phase-24-evidence/test_ambiguity.log
@@ -1,0 +1,68 @@
+=== Phase 19 ambiguity-gate tests ===
+
+Test 1: score_ambiguity arithmetic
+  PASS: all 10s -> 0
+  PASS: all 0s -> 100
+  PASS: all 5s -> 50
+  PASS: goal only -> 60
+  PASS: constraints only -> 70
+  PASS: criteria only -> 70
+
+Test 2: score_ambiguity input validation
+  PASS: 11 rejected
+  PASS: -1 rejected
+  PASS: abc rejected
+
+Test 3: check_gate semantics
+  PASS: score 0 passes
+  PASS: score 19 passes
+  PASS: score 20 blocks
+  PASS: score 50 blocks
+  PASS: score 100 blocks
+  PASS: 30 < 50 passes
+  PASS: 60 >= 50 blocks
+
+Test 4: challenge_mode thresholds
+  PASS: round 1, score 100 -> normal
+  PASS: round 2, score 80  -> normal
+  PASS: round 3, score 45  -> contrarian
+  PASS: round 3, score 35  -> normal
+  PASS: round 4, score 35  -> simplifier
+  PASS: round 4, score 25  -> normal
+  PASS: round 5, score 25  -> ontologist
+  PASS: round 5, score 15  -> normal
+  PASS: round 6, score 50  -> ontologist
+
+Test 5: ontology_extract
+  PASS: extract tokens sorted+unique
+  PASS: empty -> empty
+  PASS: stopwords dropped
+
+Test 6: ontology_diff
+  PASS: 1 added
+  PASS: 1 removed
+  PASS: 2 carried
+  PASS: stability 0.50
+  PASS: identical stability 1.0
+  PASS: empty prior stability 0.00
+
+Test 7: CLI subcommands
+  PASS: CLI score 5 5 5 = 50
+  PASS: CLI gate 10 passes
+  PASS: CLI gate 25 blocks
+  PASS: CLI mode 5 30 = ontologist
+
+Test 8: ql-brainstorm wires lib/ambiguity.sh
+  PASS: Phase 0B ambiguity gate section
+  PASS: calls lib/ambiguity.sh score
+  PASS: calls lib/ambiguity.sh gate
+  PASS: calls lib/ambiguity.sh mode
+  PASS: ontology stability tracking
+  PASS: ontology diff call
+  PASS: contrarian mode described
+  PASS: simplifier mode described
+  PASS: ontologist mode described
+  PASS: thrashing ontology escalation
+  PASS: handoff records final_score
+
+=== Results: 49/49 passed, 0 failed ===

--- a/.omc/phase-24-evidence/test_constitution.log
+++ b/.omc/phase-24-evidence/test_constitution.log
@@ -1,0 +1,51 @@
+=== Phase 22 constitution tests ===
+
+Test 1: load_constitution
+  PASS: loads 2 rules
+  PASS: missing constitution -> empty
+  PASS: missing file -> empty
+  PASS: object form with .rule
+
+Test 2: check_no_secrets detects provider tokens
+  PASS: detects sk-live token
+  PASS: detects ghp_ token
+  PASS: ignores comment about passwords (no literal)
+
+Test 3: generic password/api_key literal
+  PASS: password= long literal flagged
+  PASS: api_key= long literal flagged
+  PASS: short literal not flagged
+
+Test 4: check_sql_injection
+  PASS: flags 2 SQL injections (template + concat)
+  PASS: parameterized query not flagged
+
+Test 5: check_input_validation
+  PASS: flags 2 unvalidated handler reads
+
+Test 6: check_commit_integrity
+  PASS: flags migration file
+  PASS: flags schema.prisma
+  PASS: flags .env.example
+  PASS: does NOT flag regular source file
+
+Test 7: enforce_constitution end-to-end
+  PASS: enforce finds 2 secret+sql findings
+  PASS: input-validation skipped when not active
+  PASS: input-validation active -> finds req.body
+  PASS: no constitution -> empty JSON array
+  PASS: unknown rule -> empty findings (warn only)
+
+Test 8: finding metadata
+  PASS: severity critical
+  PASS: description set
+  PASS: rule id set
+
+Test 9: CLI enforce
+  PASS: CLI enforce returns findings
+
+Test 10: quantum.json.example schema
+  PASS: constitution is array
+  PASS: quantum.json.example still valid JSON
+
+=== Results: 28/28 passed, 0 failed ===

--- a/.omc/phase-24-evidence/test_deep_review.log
+++ b/.omc/phase-24-evidence/test_deep_review.log
@@ -1,0 +1,52 @@
+=== Phase 8 ql-deep-review helper tests ===
+
+Test 1: tier_of_score mapping
+  PASS: 0 -> LOW
+  PASS: 30 -> LOW
+  PASS: 31 -> MEDIUM
+  PASS: 60 -> MEDIUM
+  PASS: 61 -> HIGH
+  PASS: 80 -> HIGH
+  PASS: 81 -> CRITICAL
+  PASS: 100 -> CRITICAL
+
+Test 2: compute_risk_score bounds
+  PASS: empty refs -> 0
+  PASS: intent drift contributes 10
+
+Test 3: actionability_filter
+  PASS: kept count
+  PASS: suppressed count
+  PASS: suppressed has reason
+
+Test 4: dedup_findings
+  PASS: dedup reduces 3 -> 2
+  PASS: merged agents count
+  PASS: kept max confidence
+
+Test 5: hallucination_check suppresses missing files
+  PASS: 1 file kept
+  PASS: 1 file suppressed as hallucination
+  PASS: suppressed reason
+
+Test 6: synthesize_verdict
+  PASS: empty -> APPROVE
+  PASS: only low -> APPROVE
+  PASS: medium 60 -> APPROVE_WITH_COMMENTS
+  PASS: high 75 -> REQUEST_CHANGES
+  PASS: critical 85 -> BLOCKS_MERGE
+  PASS: critical 50 (below threshold) -> APPROVE
+
+Test 7: quantum.json.example schema
+  PASS: reviews is object
+  PASS: quantum.json.example still valid JSON
+
+Test 8: ql-execute mentions the post-pipeline hook
+  PASS: post-pipeline hook header present
+  PASS: references lib/deep-review.sh
+
+Test 9: CLI subcommands work
+  PASS: CLI tier 50 -> MEDIUM
+  PASS: CLI tier 100 -> CRITICAL
+
+=== Results: 31/31 passed, 0 failed ===

--- a/.omc/phase-24-evidence/test_dogfood_e2e.log
+++ b/.omc/phase-24-evidence/test_dogfood_e2e.log
@@ -1,0 +1,38 @@
+=== Phase 10 dogfood end-to-end check ===
+
+Test 1: dogfood quantum.json parses
+  PASS: valid JSON
+
+Test 2: schema fields from Phases 7-9
+  PASS: userIntent.text present
+  PASS: userClarifications is array
+  PASS: intentDrift has entry
+  PASS: reviews has deepReview
+  PASS: deslop field present
+  PASS: codebasePatterns has entries
+  PASS: progress has entries
+
+Test 3: intent-drift gate semantics
+  PASS: NO_DRIFT gate allows merge
+
+Test 4: deep-review synthesize_verdict consumes the dogfood findings array
+  PASS: two HIGH confidence≥70 findings → REQUEST_CHANGES
+
+Test 5: dedup_findings idempotent on dogfood findings
+  PASS: dedup preserves 2-element unique set
+
+Test 6: plan retrospective — 10 stories all passed
+  PASS: 10 stories total
+  PASS: 10 stories passed
+
+Test 7: codebasePatterns contains real Phase-5 lesson
+  PASS: Phase-5 set-e lesson present
+
+Test 8: userIntent verbatim contains the original verbatim message
+  PASS: intent snapshot references IDEA_REPORT.md
+
+Test 9: companion PRD exists and references the dogfood artifact
+  PASS: PRD exists
+  PASS: PRD has AC-15 dogfood + references phase-10-evidence
+
+=== Results: 17/17 passed, 0 failed ===

--- a/.omc/phase-24-evidence/test_far_filter.log
+++ b/.omc/phase-24-evidence/test_far_filter.log
@@ -1,0 +1,41 @@
+=== Phase 23 KBI-FAR far_filter tests ===
+
+Test 1: confidence cutoff
+  PASS: 1 kept (conf ≥60)
+  PASS: 2 suppressed (conf <60)
+  PASS: reason mentions confidence
+
+Test 2: agreement boost lifts across cutoff
+  PASS: agreement-boosted finding kept
+  PASS: confidence boosted 50 -> 65
+  PASS: original_confidence preserved
+  PASS: single-agent below-cutoff suppressed
+
+Test 3: confidence cap at 100
+  PASS: confidence capped at 100
+
+Test 4: knownFalsePositives regex suppression
+  PASS: genuine finding kept
+  PASS: 2 suppressed by regex
+  PASS: suppression reasons reference knownFalsePositives
+
+Test 5: missing quantum.json graceful fallback
+  PASS: finding kept with missing quantum.json
+
+Test 6: empty input
+  PASS: empty kept
+  PASS: empty suppressed
+
+Test 7: CLI subcommand
+  PASS: CLI far kept 1
+
+Test 8: aggregate_reviews wires far_filter
+  PASS: aggregate kept 1 real finding
+  PASS: aggregate suppressed 2 (cutoff + FP)
+  PASS: verdict REQUEST_CHANGES (high ≥70)
+  PASS: FP reason present
+
+Test 9: schema extension
+  PASS: knownFalsePositives is array
+
+=== Results: 20/20 passed, 0 failed ===

--- a/.omc/phase-24-evidence/test_orchestrator_wiring.log
+++ b/.omc/phase-24-evidence/test_orchestrator_wiring.log
@@ -1,0 +1,65 @@
+=== Phase 17 orchestrator-wiring prompt tests ===
+
+Test 1: lib/wave-boundary.sh wired at wave boundary
+  PASS: 3C.NEG1 section present
+  PASS: references wave-boundary.sh scan
+  PASS: routes HIGH severity to fix-story
+
+Test 2: lib/watchdog.sh wired in monitor loop
+  PASS: watchdog tick header
+  PASS: references watchdog.sh poll
+  PASS: status-probe action branch
+  PASS: kill-and-requeue action branch
+  PASS: mark-failed action branch
+  PASS: circuit-breaker bump
+  PASS: circuit-breaker check
+
+Test 3: lib/deep-review.sh wired at full-feature review
+  PASS: 4B.5 deep-review section
+  PASS: score-from-quantum call
+  PASS: tier lookup
+  PASS: dispatch-set call
+  PASS: context preparation
+  PASS: aggregate pipe
+  PASS: BLOCKS_MERGE handled
+  PASS: REQUEST_CHANGES handled
+  PASS: persists into quantum.reviews
+
+Test 4: lib/deslop.sh wired between review-pass and commit
+  PASS: 3A.5B deslop section
+  PASS: validate_scope gate
+  PASS: baseline snapshot before
+  PASS: compare_baseline call
+  PASS: rollback on regression
+  PASS: DESLOP_ROLLED_BACK signal
+  PASS: opt-out via story.deslop.skip
+
+Test 5: lib/commit-trailers.sh validation gate
+  PASS: commit-trailers reference
+  PASS: non-blocking warning
+
+Test 6: handoff.sh ownership is skill-side (orchestrator doesn't write)
+  PASS: orchestrator does NOT write handoffs directly (skills do)
+
+Test 7: all wirings carry a Phase-17 attribution comment
+  PASS: 5 Phase-17 attributions
+
+Test 8: deslop wiring uses DESLOP_AVAILABLE + BASE_SHA
+  PASS: DESLOP_AVAILABLE guard present
+  PASS: DESLOP_AVAILABLE file check
+  PASS: Fallback skip branch
+  PASS: scope loop uses BASE_SHA
+  PASS: rollback uses BASE_SHA
+  PASS: no active STORY_BASE_SHA refs in 3A.5B
+
+Test 9: RUNNER_EXTRA_FLAGS validated after pre_spawn()
+  PASS: RUNNER_EXTRA_FLAGS validation present
+  PASS: blocklist present (regex form varies)
+
+Test 10: runner_build_cmd rejects injection via RUNNER_EXTRA_FLAGS
+  PASS: injection payload rejected with clear error
+
+Test 11: lib/watchdog.sh doc comment corrected
+  PASS: watchdog threshold comment matches code (>30 min = timed-out)
+
+=== Results: 40/40 passed, 0 failed ===

--- a/.omc/phase-24-evidence/test_reaper.log
+++ b/.omc/phase-24-evidence/test_reaper.log
@@ -1,0 +1,62 @@
+=== Phase 20 reaper + spawn exec-capture tests ===
+
+Test 1: detect_platform recognizes current environment
+  PASS: platform is valid enum
+  (detected: msys)
+
+Test 2: _msys_to_winpid handles current PID
+  PASS: numeric winpid (5848)
+
+Test 3: write + read pidfile round-trip
+  PASS: pidfile exists
+  PASS: msys_pid round-trips
+  PASS: cmd round-trips
+  PASS: missing pidfile -> {}
+
+Test 4: is_agent_alive tracks liveness
+  PASS: alive while running
+  PASS: dead after kill
+
+Test 5: is_agent_alive on missing pidfile
+  PASS: missing pidfile -> not alive
+
+Test 6: reap_agent on already-dead process cleans pidfile
+  PASS: reap exits 0
+  PASS: pidfile removed
+
+Test 7: reap_agent terminates a live process
+  PASS: reap_agent exits 0
+  PASS: process not alive
+  PASS: pidfile removed
+
+Test 8: reap_orphans cleans stale pidfiles only
+  PASS: no stale-orphans reaped
+  PASS: dead pidfile removed
+  PASS: live pidfile kept
+
+Test 9: reap_orphans safe on missing/empty dir
+  PASS: missing dir -> 0
+  PASS: empty dir -> 0
+
+Test 10: lib/spawn.sh contains the exec-replacement fix
+  PASS: exec prepended to claude invocation
+  PASS: runner-path uses eval "exec $cmd"
+  PASS: spawn writes pidfile
+
+Test 11: quantum-loop.sh trap uses reaper
+  PASS: cleanup_on_exit calls reap_agent
+  PASS: startup calls reap_orphans
+
+Test 13: _proc_start_epoch is per-process (not a constant)
+  PASS: distinct processes have distinct start epochs (11429848 vs 11430916)
+
+Test 14: cleanup_on_exit uses parallel reap pattern
+  PASS: cleanup_on_exit parallelizes reap_agent calls
+
+Test 15: timeout branch uses reap_agent on Git Bash
+  PASS: TIMED_OUT branch prefers reap_agent
+
+Test 12: CLI subcommands work
+  PASS: CLI platform output: msys
+
+=== Results: 28/28 passed, 0 failed ===

--- a/.omc/phase-24-evidence/test_trajectory.log
+++ b/.omc/phase-24-evidence/test_trajectory.log
@@ -1,0 +1,49 @@
+=== Phase 24 trajectory-kill tests ===
+
+Test 1: parse on missing file
+  PASS: exists=false
+  PASS: total=0
+
+Test 2: parse counts tools
+  PASS: reads=5
+  PASS: greps=3
+  PASS: edits=2
+  PASS: writes=1
+  PASS: bashes=4
+  PASS: total=15
+  PASS: read_pct=53
+  PASS: edit_pct=20
+
+Test 3: productive trajectory
+  PASS: classify productive
+  PASS: productive -> no kill (exit 1)
+
+Test 4: searching trajectory
+  PASS: classify searching (below thrash min)
+  PASS: searching -> no kill
+
+Test 5: thrashing trajectory
+  PASS: classify thrashing
+  PASS: thrashing -> kill (exit 0)
+
+Test 6: stuck trajectory
+  PASS: classify stuck
+  PASS: stuck -> kill (exit 0)
+
+Test 7: env-var overrides take effect
+  PASS: default: searching
+  PASS: override THRASH_MIN=5: thrashing
+
+Test 8: empty file handling
+  PASS: empty file total=0
+  PASS: empty file classify=productive (no signal)
+
+Test 9: CLI subcommands
+  PASS: CLI parse total=26
+  PASS: CLI classify thrashing
+  PASS: CLI kill exits 0 for thrashing
+
+Test 10: classify reads stdin
+  PASS: stdin classify productive
+
+=== Results: 26/26 passed, 0 failed ===

--- a/.omc/phase-24-evidence/test_watchdog.log
+++ b/.omc/phase-24-evidence/test_watchdog.log
@@ -1,0 +1,55 @@
+=== Phase 16 watchdog + circuit-breaker tests ===
+
+Test 1: classify_age thresholds
+  PASS: 0s -> fresh
+  PASS: 300s -> fresh
+  PASS: 301s -> stale-check
+  PASS: 600s -> stale-check
+  PASS: 601s -> stale-reassign
+  PASS: 1200s -> stale-reassign
+  PASS: 1201s -> stale-reassign
+  PASS: 1800s -> stale-reassign
+  PASS: 1801s -> timed-out
+  PASS: 7200s -> timed-out
+
+Test 2: watchdog_poll on empty state
+  PASS: missing quantum.json -> []
+
+Test 3: watchdog_poll fresh in_progress story
+  PASS: only the in_progress story returned
+  PASS: story_id is US-001
+  PASS: fresh -> continue
+  PASS: classification fresh
+
+Test 4: watchdog_poll stale-check (~400s old)
+  PASS: 400s -> stale-check
+  PASS: stale-check -> status-probe
+
+Test 5: watchdog_poll timed-out (>30min old)
+  PASS: 2400s -> timed-out
+  PASS: timed-out -> mark-failed
+
+Test 6: error_counter_bump same signature increments
+  PASS: first bump count 1
+  PASS: second bump count 2
+  PASS: third bump count 3
+
+Test 7: different signature resets counter
+  PASS: sig-A count reaches 2
+  PASS: sig-B resets to 1
+  PASS: sig-B next bump is 2
+
+Test 8: should_circuit_break crosses threshold
+  PASS: count=1, threshold=3 -> no break (exit 1)
+  PASS: count=3, threshold=3 -> BREAK (exit 0)
+  PASS: count=3, threshold=10 -> no break
+
+Test 9: error_counter_reset
+  PASS: after reset, no break
+  PASS: count after reset=1
+
+Test 10: CLI subcommands
+  PASS: CLI classify 500 -> stale-check
+  PASS: CLI bump first -> 1
+
+=== Results: 32/32 passed, 0 failed ===

--- a/lib/trajectory.sh
+++ b/lib/trajectory.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# lib/trajectory.sh — trajectory-length early kill (Phase 24 / P3.5).
+#
+# Sources:
+#   arXiv:2511.00197 — trajectory features (step count, read/edit ratio)
+#                      predict story success/failure early
+#   TRAJEVAL 2603.24631 — benchmark showing thrashing agents (high read-
+#                         to-edit ratio) rarely recover without intervention
+#
+# Complements lib/watchdog.sh which tracks wall-clock staleness. This
+# library tracks the SHAPE of the agent's work: how many tool calls did it
+# make, how many were reads/greps vs edits/writes, is it making progress?
+#
+# An agent stuck in a read/grep loop without making edits is usually lost.
+# Better to kill it early, log the trajectory, and let the retry path do
+# something different (different agent, clearer prompt, smaller scope).
+#
+# Functions:
+#   parse_trajectory OUTPUT_FILE
+#     Scans an agent's stdout file for tool-call patterns. Emits JSON
+#     with counts per category plus derived ratios.
+#   classify_trajectory JSON
+#     Returns one of: productive | searching | thrashing | stuck.
+#   should_early_kill JSON
+#     Exit 0 if trajectory suggests kill (thrashing or stuck). Exit 1
+#     otherwise. Caller threads this into the monitor loop alongside
+#     the time-based watchdog.
+#
+# Library contract: no shell flags at source time; CLI block enables
+# strict mode locally.
+
+TRAJECTORY_LIB_DIR="${TRAJECTORY_LIB_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+
+# Tuning knobs, all env-overrideable.
+: "${TRAJECTORY_THRASH_MIN_CALLS:=20}"   # need at least this many calls to call it thrashing
+: "${TRAJECTORY_STUCK_MIN_CALLS:=30}"    # after this many calls with 0 edits, we're stuck
+: "${TRAJECTORY_THRASH_READ_RATIO:=70}"  # % of calls that are reads/greps to flag thrashing
+: "${TRAJECTORY_THRASH_EDIT_RATIO:=5}"   # edits/writes must stay below this % to be thrashing
+
+# parse_trajectory(output_file)
+# Parses a Claude Code agent's stdout dump for tool-call markers. We look
+# for the common patterns Claude emits when it invokes a tool:
+#   "Tool use: Read"  /  "Tool: Grep"  /  "⏺ Edit(..."  /  "Calling Bash"
+# Emits a compact JSON object with counts and derived ratios.
+#
+# Since Claude's output format varies across CLI versions, we use a
+# deliberately broad set of patterns per tool and dedup by line number.
+parse_trajectory() {
+  local out="${1:?output_file required}"
+  [[ -f "$out" ]] || {
+    jq -cn '{total_calls: 0, reads: 0, greps: 0, edits: 0, writes: 0, bashes: 0, other: 0, read_edit_ratio: 0, exists: false}'
+    return 0
+  }
+
+  # Per-tool regex patterns (case-insensitive, broad)
+  local reads greps edits writes bashes other_calls
+  reads=$(grep -cE "(⏺|•|\*) (Read|Tool: Read|Tool use: Read)|tool.?use.*\"?name\"?:.?\"?Read\"?" "$out" 2>/dev/null || echo 0)
+  greps=$(grep -cE "(⏺|•|\*) (Grep|Glob|Search|Tool: Grep)|tool.?use.*\"?name\"?:.?\"?Grep\"?" "$out" 2>/dev/null || echo 0)
+  edits=$(grep -cE "(⏺|•|\*) (Edit|MultiEdit|Tool: Edit)|tool.?use.*\"?name\"?:.?\"?(Edit|MultiEdit)\"?" "$out" 2>/dev/null || echo 0)
+  writes=$(grep -cE "(⏺|•|\*) (Write|Tool: Write)|tool.?use.*\"?name\"?:.?\"?Write\"?" "$out" 2>/dev/null || echo 0)
+  bashes=$(grep -cE "(⏺|•|\*) (Bash|Tool: Bash)|tool.?use.*\"?name\"?:.?\"?Bash\"?" "$out" 2>/dev/null || echo 0)
+  # "other" = generic tool-use marker not matching specific names
+  other_calls=$(grep -cE "(⏺|•|\*) (Agent|Task|Glob|TodoWrite|WebFetch|Git|NotebookEdit)" "$out" 2>/dev/null || echo 0)
+  # Trim whitespace
+  reads=$(echo "$reads" | tr -d ' \n')
+  greps=$(echo "$greps" | tr -d ' \n')
+  edits=$(echo "$edits" | tr -d ' \n')
+  writes=$(echo "$writes" | tr -d ' \n')
+  bashes=$(echo "$bashes" | tr -d ' \n')
+  other_calls=$(echo "$other_calls" | tr -d ' \n')
+
+  local total=$(( reads + greps + edits + writes + bashes + other_calls ))
+  local prod=$(( edits + writes ))
+  # ratio as integer %, avoid div-by-zero
+  local read_pct=0 edit_pct=0
+  if (( total > 0 )); then
+    read_pct=$(( (reads + greps) * 100 / total ))
+    edit_pct=$(( prod * 100 / total ))
+  fi
+  jq -cn \
+    --argjson r "$reads" --argjson g "$greps" --argjson e "$edits" \
+    --argjson w "$writes" --argjson b "$bashes" --argjson o "$other_calls" \
+    --argjson total "$total" --argjson rp "$read_pct" --argjson ep "$edit_pct" \
+    '{total_calls: $total, reads: $r, greps: $g, edits: $e, writes: $w,
+      bashes: $b, other: $o, read_pct: $rp, edit_pct: $ep, exists: true}'
+}
+
+# classify_trajectory(json)
+# Echoes one of: productive | searching | thrashing | stuck.
+# Rules:
+#   stuck       — total_calls >= STUCK_MIN and edits+writes == 0
+#   thrashing   — total_calls >= THRASH_MIN AND read_pct >= THRASH_READ_RATIO
+#                 AND edit_pct <= THRASH_EDIT_RATIO
+#   searching   — read_pct > 50 (early exploration, OK so far)
+#   productive  — otherwise
+classify_trajectory() {
+  local json="${1:-}"
+  [[ -z "$json" ]] && json=$(cat)
+  local total rp ep prod
+  total=$(jq -r '.total_calls // 0' <<< "$json")
+  rp=$(jq -r '.read_pct // 0' <<< "$json")
+  ep=$(jq -r '.edit_pct // 0' <<< "$json")
+  prod=$(jq -r '(.edits // 0) + (.writes // 0)' <<< "$json")
+
+  if (( total >= TRAJECTORY_STUCK_MIN_CALLS && prod == 0 )); then
+    printf "stuck"; return 0
+  fi
+  if (( total >= TRAJECTORY_THRASH_MIN_CALLS \
+       && rp >= TRAJECTORY_THRASH_READ_RATIO \
+       && ep <= TRAJECTORY_THRASH_EDIT_RATIO )); then
+    printf "thrashing"; return 0
+  fi
+  if (( rp > 50 )); then
+    printf "searching"; return 0
+  fi
+  printf "productive"
+}
+
+# should_early_kill(json)
+# Exit 0 if classification is "thrashing" or "stuck" (caller should kill
+# the agent). Exit 1 otherwise.
+should_early_kill() {
+  local cls
+  cls=$(classify_trajectory "$@")
+  case "$cls" in
+    thrashing|stuck) return 0 ;;
+    *)               return 1 ;;
+  esac
+}
+
+# ------------------------------------------------------------------------------
+# CLI entry
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  set -euo pipefail
+  subcmd="${1:-}"
+  shift || true
+  case "$subcmd" in
+    parse)    parse_trajectory "$@" ;;
+    classify) classify_trajectory "$@"; printf "\n" ;;
+    kill)     should_early_kill "$@" ;;
+    *)
+      cat >&2 <<USAGE
+Usage: bash lib/trajectory.sh <subcmd> [args...]
+  parse OUTPUT_FILE               — emit JSON with tool-call counts and ratios
+  classify [JSON]                 — one of productive|searching|thrashing|stuck
+  kill [JSON]                     — exit 0 if thrashing or stuck
+USAGE
+      exit 2
+      ;;
+  esac
+fi

--- a/tests/test_trajectory.sh
+++ b/tests/test_trajectory.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# Phase 24 / P3.5 — trajectory-length early kill tests.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR/.."
+PASS=0
+FAIL=0
+TOTAL=0
+
+assert() {
+  local name="$1" expected="$2" actual="$3"
+  TOTAL=$((TOTAL + 1))
+  if [[ "$expected" == "$actual" ]]; then
+    echo "  PASS: $name"; PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $name (expected [$expected] got [$actual])"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# shellcheck disable=SC1091
+source "$REPO_ROOT/lib/trajectory.sh"
+
+echo "=== Phase 24 trajectory-kill tests ==="
+
+# Helper to emit a Claude-style output with N occurrences of each tool marker.
+gen_output() {
+  local out="$1" reads="$2" greps="$3" edits="$4" writes="$5" bashes="$6"
+  : > "$out"
+  for ((i=0; i<reads;  i++)); do echo "⏺ Read(src/file.ts)"     >> "$out"; done
+  for ((i=0; i<greps;  i++)); do echo "⏺ Grep('pattern', foo)"  >> "$out"; done
+  for ((i=0; i<edits;  i++)); do echo "⏺ Edit(src/x.ts)"        >> "$out"; done
+  for ((i=0; i<writes; i++)); do echo "⏺ Write(src/new.ts)"     >> "$out"; done
+  for ((i=0; i<bashes; i++)); do echo "⏺ Bash(command)"         >> "$out"; done
+}
+
+# Test 1: parse_trajectory on missing file returns exists:false
+echo ""
+echo "Test 1: parse on missing file"
+j=$(parse_trajectory /nonexistent/foo.log)
+assert "exists=false"   "false" "$(jq -r '.exists' <<< "$j")"
+assert "total=0"        "0"     "$(jq -r '.total_calls' <<< "$j")"
+
+# Test 2: parse_trajectory counts tool calls correctly
+echo ""
+echo "Test 2: parse counts tools"
+TMP=$(mktemp -d)
+gen_output "$TMP/out.log" 5 3 2 1 4  # 15 total: 5R 3G 2E 1W 4B
+j=$(parse_trajectory "$TMP/out.log")
+assert "reads=5"        "5"  "$(jq -r '.reads' <<< "$j")"
+assert "greps=3"        "3"  "$(jq -r '.greps' <<< "$j")"
+assert "edits=2"        "2"  "$(jq -r '.edits' <<< "$j")"
+assert "writes=1"       "1"  "$(jq -r '.writes' <<< "$j")"
+assert "bashes=4"       "4"  "$(jq -r '.bashes' <<< "$j")"
+assert "total=15"       "15" "$(jq -r '.total_calls' <<< "$j")"
+# read_pct = (5+3)/15 * 100 = 53
+assert "read_pct=53"    "53" "$(jq -r '.read_pct' <<< "$j")"
+# edit_pct = (2+1)/15 * 100 = 20
+assert "edit_pct=20"    "20" "$(jq -r '.edit_pct' <<< "$j")"
+rm -rf "$TMP"
+
+# Test 3: classify — productive (healthy mix of reads + edits)
+echo ""
+echo "Test 3: productive trajectory"
+TMP=$(mktemp -d)
+gen_output "$TMP/out.log" 5 2 8 3 2  # 20 total: 35% reads, 55% edits
+j=$(parse_trajectory "$TMP/out.log")
+cls=$(classify_trajectory "$j")
+assert "classify productive" "productive" "$cls"
+should_early_kill "$j"
+assert "productive -> no kill (exit 1)" "1" "$?"
+rm -rf "$TMP"
+
+# Test 4: classify — searching (mostly reads, early phase)
+echo ""
+echo "Test 4: searching trajectory"
+TMP=$(mktemp -d)
+gen_output "$TMP/out.log" 8 4 1 1 1  # 15 total: 80% reads, 13% edits
+j=$(parse_trajectory "$TMP/out.log")
+cls=$(classify_trajectory "$j")
+# <20 total calls so even high read % is "searching" not "thrashing"
+assert "classify searching (below thrash min)" "searching" "$cls"
+should_early_kill "$j"
+assert "searching -> no kill" "1" "$?"
+rm -rf "$TMP"
+
+# Test 5: classify — thrashing (many reads, no edits, past threshold)
+echo ""
+echo "Test 5: thrashing trajectory"
+TMP=$(mktemp -d)
+gen_output "$TMP/out.log" 20 5 0 0 1  # 26 total: 96% reads, 0% edits
+j=$(parse_trajectory "$TMP/out.log")
+# Total >= 20 AND read% >= 70 AND edit% <= 5
+cls=$(classify_trajectory "$j")
+# Note: prod=0 with total=26 ≥ STUCK_MIN_CALLS (30) — actually with total=26 stuck is NOT triggered (needs >= 30). Thrashing IS triggered.
+# Wait let me recompute — default STUCK_MIN_CALLS=30. total=26 < 30 so stuck NOT fired.
+# Default THRASH_MIN_CALLS=20. total=26 ≥ 20. read%=25/26*100=96 >= 70. edit%=0 <= 5. → thrashing.
+assert "classify thrashing" "thrashing" "$cls"
+should_early_kill "$j"
+assert "thrashing -> kill (exit 0)" "0" "$?"
+rm -rf "$TMP"
+
+# Test 6: classify — stuck (many calls, zero edits)
+echo ""
+echo "Test 6: stuck trajectory"
+TMP=$(mktemp -d)
+gen_output "$TMP/out.log" 15 10 0 0 10  # 35 total, 0 edits — triggers STUCK (>=30, prod=0)
+j=$(parse_trajectory "$TMP/out.log")
+cls=$(classify_trajectory "$j")
+assert "classify stuck" "stuck" "$cls"
+should_early_kill "$j"
+assert "stuck -> kill (exit 0)" "0" "$?"
+rm -rf "$TMP"
+
+# Test 7: threshold overrides via env vars
+echo ""
+echo "Test 7: env-var overrides take effect"
+TMP=$(mktemp -d)
+gen_output "$TMP/out.log" 8 0 0 0 0  # 8 total, all reads
+j=$(parse_trajectory "$TMP/out.log")
+# default thresholds: total=8 < THRASH_MIN=20, so "searching"
+cls=$(classify_trajectory "$j")
+assert "default: searching" "searching" "$cls"
+# With THRASH_MIN=5, total=8 >= 5, read=100>=70, edit=0<=5 → thrashing
+cls_override=$(TRAJECTORY_THRASH_MIN_CALLS=5 classify_trajectory "$j")
+assert "override THRASH_MIN=5: thrashing" "thrashing" "$cls_override"
+rm -rf "$TMP"
+
+# Test 8: empty file is "productive" (no signal to act on)
+echo ""
+echo "Test 8: empty file handling"
+TMP=$(mktemp -d)
+: > "$TMP/empty.log"
+j=$(parse_trajectory "$TMP/empty.log")
+total=$(jq -r '.total_calls' <<< "$j")
+cls=$(classify_trajectory "$j")
+assert "empty file total=0" "0" "$total"
+assert "empty file classify=productive (no signal)" "productive" "$cls"
+rm -rf "$TMP"
+
+# Test 9: CLI subcommands
+echo ""
+echo "Test 9: CLI subcommands"
+TMP=$(mktemp -d)
+gen_output "$TMP/out.log" 20 5 0 0 1  # thrashing shape
+# CLI parse
+cli_parse=$(bash "$REPO_ROOT/lib/trajectory.sh" parse "$TMP/out.log")
+assert "CLI parse total=26" "26" "$(jq -r '.total_calls' <<< "$cli_parse")"
+# CLI classify via stdin (NOT supported — CLI passes $@ as literal) — use arg
+cli_cls=$(bash "$REPO_ROOT/lib/trajectory.sh" classify "$cli_parse" | tr -d '\n')
+assert "CLI classify thrashing" "thrashing" "$cli_cls"
+# CLI kill
+bash "$REPO_ROOT/lib/trajectory.sh" kill "$cli_parse" 2>/dev/null
+assert "CLI kill exits 0 for thrashing" "0" "$?"
+rm -rf "$TMP"
+
+# Test 10: classify_trajectory reads stdin if no arg
+echo ""
+echo "Test 10: classify reads stdin"
+TMP=$(mktemp -d)
+gen_output "$TMP/out.log" 5 2 8 3 2
+j=$(parse_trajectory "$TMP/out.log")
+cls_stdin=$(printf '%s' "$j" | classify_trajectory)
+assert "stdin classify productive" "productive" "$cls_stdin"
+rm -rf "$TMP"
+
+echo ""
+echo "=== Results: $PASS/$TOTAL passed, $FAIL failed ==="
+exit $((FAIL > 0 ? 1 : 0))


### PR DESCRIPTION
Third P3 wedge. Detects agents thrashing in a read/grep loop with zero edits and signals early kill — complements Phase 16 wall-clock watchdog with a work-shape dimension.

## lib/trajectory.sh

- `parse_trajectory` — grep-counts tool calls per category from agent stdout, computes ratios
- `classify_trajectory` — productive | searching | thrashing | stuck
- `should_early_kill` — exit 0 for thrashing/stuck

Thresholds env-overrideable (THRASH_MIN, STUCK_MIN, THRASH_READ/EDIT_RATIO).

## Tests: 26 new, 271 total across 9 suites, all green

Deferred: wiring into the monitor loop — straightforward extension once we decide kill-priority between time-based and trajectory-based signals on disagreement.