### PR TITLE
Phase 25 — HyClone Stage-1 clone fingerprinting (P3.7, arXiv:2508.01357)

### DIFF
--- a/.omc/phase-25-evidence/test_ambiguity.log
+++ b/.omc/phase-25-evidence/test_ambiguity.log
@@ -1,0 +1,68 @@
+=== Phase 19 ambiguity-gate tests ===
+
+Test 1: score_ambiguity arithmetic
+  PASS: all 10s -> 0
+  PASS: all 0s -> 100
+  PASS: all 5s -> 50
+  PASS: goal only -> 60
+  PASS: constraints only -> 70
+  PASS: criteria only -> 70
+
+Test 2: score_ambiguity input validation
+  PASS: 11 rejected
+  PASS: -1 rejected
+  PASS: abc rejected
+
+Test 3: check_gate semantics
+  PASS: score 0 passes
+  PASS: score 19 passes
+  PASS: score 20 blocks
+  PASS: score 50 blocks
+  PASS: score 100 blocks
+  PASS: 30 < 50 passes
+  PASS: 60 >= 50 blocks
+
+Test 4: challenge_mode thresholds
+  PASS: round 1, score 100 -> normal
+  PASS: round 2, score 80  -> normal
+  PASS: round 3, score 45  -> contrarian
+  PASS: round 3, score 35  -> normal
+  PASS: round 4, score 35  -> simplifier
+  PASS: round 4, score 25  -> normal
+  PASS: round 5, score 25  -> ontologist
+  PASS: round 5, score 15  -> normal
+  PASS: round 6, score 50  -> ontologist
+
+Test 5: ontology_extract
+  PASS: extract tokens sorted+unique
+  PASS: empty -> empty
+  PASS: stopwords dropped
+
+Test 6: ontology_diff
+  PASS: 1 added
+  PASS: 1 removed
+  PASS: 2 carried
+  PASS: stability 0.50
+  PASS: identical stability 1.0
+  PASS: empty prior stability 0.00
+
+Test 7: CLI subcommands
+  PASS: CLI score 5 5 5 = 50
+  PASS: CLI gate 10 passes
+  PASS: CLI gate 25 blocks
+  PASS: CLI mode 5 30 = ontologist
+
+Test 8: ql-brainstorm wires lib/ambiguity.sh
+  PASS: Phase 0B ambiguity gate section
+  PASS: calls lib/ambiguity.sh score
+  PASS: calls lib/ambiguity.sh gate
+  PASS: calls lib/ambiguity.sh mode
+  PASS: ontology stability tracking
+  PASS: ontology diff call
+  PASS: contrarian mode described
+  PASS: simplifier mode described
+  PASS: ontologist mode described
+  PASS: thrashing ontology escalation
+  PASS: handoff records final_score
+
+=== Results: 49/49 passed, 0 failed ===

--- a/.omc/phase-25-evidence/test_constitution.log
+++ b/.omc/phase-25-evidence/test_constitution.log
@@ -1,0 +1,51 @@
+=== Phase 22 constitution tests ===
+
+Test 1: load_constitution
+  PASS: loads 2 rules
+  PASS: missing constitution -> empty
+  PASS: missing file -> empty
+  PASS: object form with .rule
+
+Test 2: check_no_secrets detects provider tokens
+  PASS: detects sk-live token
+  PASS: detects ghp_ token
+  PASS: ignores comment about passwords (no literal)
+
+Test 3: generic password/api_key literal
+  PASS: password= long literal flagged
+  PASS: api_key= long literal flagged
+  PASS: short literal not flagged
+
+Test 4: check_sql_injection
+  PASS: flags 2 SQL injections (template + concat)
+  PASS: parameterized query not flagged
+
+Test 5: check_input_validation
+  PASS: flags 2 unvalidated handler reads
+
+Test 6: check_commit_integrity
+  PASS: flags migration file
+  PASS: flags schema.prisma
+  PASS: flags .env.example
+  PASS: does NOT flag regular source file
+
+Test 7: enforce_constitution end-to-end
+  PASS: enforce finds 2 secret+sql findings
+  PASS: input-validation skipped when not active
+  PASS: input-validation active -> finds req.body
+  PASS: no constitution -> empty JSON array
+  PASS: unknown rule -> empty findings (warn only)
+
+Test 8: finding metadata
+  PASS: severity critical
+  PASS: description set
+  PASS: rule id set
+
+Test 9: CLI enforce
+  PASS: CLI enforce returns findings
+
+Test 10: quantum.json.example schema
+  PASS: constitution is array
+  PASS: quantum.json.example still valid JSON
+
+=== Results: 28/28 passed, 0 failed ===

--- a/.omc/phase-25-evidence/test_deep_review.log
+++ b/.omc/phase-25-evidence/test_deep_review.log
@@ -1,0 +1,52 @@
+=== Phase 8 ql-deep-review helper tests ===
+
+Test 1: tier_of_score mapping
+  PASS: 0 -> LOW
+  PASS: 30 -> LOW
+  PASS: 31 -> MEDIUM
+  PASS: 60 -> MEDIUM
+  PASS: 61 -> HIGH
+  PASS: 80 -> HIGH
+  PASS: 81 -> CRITICAL
+  PASS: 100 -> CRITICAL
+
+Test 2: compute_risk_score bounds
+  PASS: empty refs -> 0
+  PASS: intent drift contributes 10
+
+Test 3: actionability_filter
+  PASS: kept count
+  PASS: suppressed count
+  PASS: suppressed has reason
+
+Test 4: dedup_findings
+  PASS: dedup reduces 3 -> 2
+  PASS: merged agents count
+  PASS: kept max confidence
+
+Test 5: hallucination_check suppresses missing files
+  PASS: 1 file kept
+  PASS: 1 file suppressed as hallucination
+  PASS: suppressed reason
+
+Test 6: synthesize_verdict
+  PASS: empty -> APPROVE
+  PASS: only low -> APPROVE
+  PASS: medium 60 -> APPROVE_WITH_COMMENTS
+  PASS: high 75 -> REQUEST_CHANGES
+  PASS: critical 85 -> BLOCKS_MERGE
+  PASS: critical 50 (below threshold) -> APPROVE
+
+Test 7: quantum.json.example schema
+  PASS: reviews is object
+  PASS: quantum.json.example still valid JSON
+
+Test 8: ql-execute mentions the post-pipeline hook
+  PASS: post-pipeline hook header present
+  PASS: references lib/deep-review.sh
+
+Test 9: CLI subcommands work
+  PASS: CLI tier 50 -> MEDIUM
+  PASS: CLI tier 100 -> CRITICAL
+
+=== Results: 31/31 passed, 0 failed ===

--- a/.omc/phase-25-evidence/test_dogfood_e2e.log
+++ b/.omc/phase-25-evidence/test_dogfood_e2e.log
@@ -1,0 +1,38 @@
+=== Phase 10 dogfood end-to-end check ===
+
+Test 1: dogfood quantum.json parses
+  PASS: valid JSON
+
+Test 2: schema fields from Phases 7-9
+  PASS: userIntent.text present
+  PASS: userClarifications is array
+  PASS: intentDrift has entry
+  PASS: reviews has deepReview
+  PASS: deslop field present
+  PASS: codebasePatterns has entries
+  PASS: progress has entries
+
+Test 3: intent-drift gate semantics
+  PASS: NO_DRIFT gate allows merge
+
+Test 4: deep-review synthesize_verdict consumes the dogfood findings array
+  PASS: two HIGH confidence≥70 findings → REQUEST_CHANGES
+
+Test 5: dedup_findings idempotent on dogfood findings
+  PASS: dedup preserves 2-element unique set
+
+Test 6: plan retrospective — 10 stories all passed
+  PASS: 10 stories total
+  PASS: 10 stories passed
+
+Test 7: codebasePatterns contains real Phase-5 lesson
+  PASS: Phase-5 set-e lesson present
+
+Test 8: userIntent verbatim contains the original verbatim message
+  PASS: intent snapshot references IDEA_REPORT.md
+
+Test 9: companion PRD exists and references the dogfood artifact
+  PASS: PRD exists
+  PASS: PRD has AC-15 dogfood + references phase-10-evidence
+
+=== Results: 17/17 passed, 0 failed ===

--- a/.omc/phase-25-evidence/test_far_filter.log
+++ b/.omc/phase-25-evidence/test_far_filter.log
@@ -1,0 +1,41 @@
+=== Phase 23 KBI-FAR far_filter tests ===
+
+Test 1: confidence cutoff
+  PASS: 1 kept (conf ≥60)
+  PASS: 2 suppressed (conf <60)
+  PASS: reason mentions confidence
+
+Test 2: agreement boost lifts across cutoff
+  PASS: agreement-boosted finding kept
+  PASS: confidence boosted 50 -> 65
+  PASS: original_confidence preserved
+  PASS: single-agent below-cutoff suppressed
+
+Test 3: confidence cap at 100
+  PASS: confidence capped at 100
+
+Test 4: knownFalsePositives regex suppression
+  PASS: genuine finding kept
+  PASS: 2 suppressed by regex
+  PASS: suppression reasons reference knownFalsePositives
+
+Test 5: missing quantum.json graceful fallback
+  PASS: finding kept with missing quantum.json
+
+Test 6: empty input
+  PASS: empty kept
+  PASS: empty suppressed
+
+Test 7: CLI subcommand
+  PASS: CLI far kept 1
+
+Test 8: aggregate_reviews wires far_filter
+  PASS: aggregate kept 1 real finding
+  PASS: aggregate suppressed 2 (cutoff + FP)
+  PASS: verdict REQUEST_CHANGES (high ≥70)
+  PASS: FP reason present
+
+Test 9: schema extension
+  PASS: knownFalsePositives is array
+
+=== Results: 20/20 passed, 0 failed ===

--- a/.omc/phase-25-evidence/test_hyclone.log
+++ b/.omc/phase-25-evidence/test_hyclone.log
@@ -1,0 +1,53 @@
+=== Phase 25 HyClone Stage-1 tests ===
+
+Test 1: alpha_normalize basics
+  PASS: whitespace-only renames x
+  PASS: extra whitespace collapsed
+  PASS: multiple identifiers numbered
+
+Test 2: repeated identifiers reuse placeholder
+  PASS: repeated identifier reuses placeholder
+
+Test 3: keywords preserved
+  PASS: keywords preserved
+
+Test 4: comments stripped
+  PASS: line comment // stripped
+  PASS: line comment # stripped
+  PASS: block comment stripped
+
+Test 5: string literals preserved
+  PASS: double-quoted string preserved
+  PASS: single-quoted string preserved
+
+Test 6: clone fingerprints match
+  PASS: different names → same fingerprint
+  PASS: different whitespace → same fingerprint
+
+Test 7: semantic difference → different fingerprints
+  PASS: operator difference changes fingerprint
+  PASS: while vs if different
+
+Test 8: find_clones detects a clone pair
+  PASS: finds 1 clone group
+  PASS: group has 2 members
+  PASS: fnA in clone group
+  PASS: fnB in clone group
+  PASS: fnC NOT in clone group
+
+Test 9: find_clones with all unique functions
+  PASS: no clone groups
+
+Test 10: find_clones with triple
+  PASS: 3-way clone grouped
+  PASS: triple has 3 members
+
+Test 11: CLI subcommands
+  PASS: CLI normalize
+  PASS: CLI fingerprint is 64 hex chars
+
+Test 12: empty input handling
+  PASS: empty normalize -> empty
+  PASS: empty find_clones -> []
+
+=== Results: 26/26 passed, 0 failed ===

--- a/.omc/phase-25-evidence/test_orchestrator_wiring.log
+++ b/.omc/phase-25-evidence/test_orchestrator_wiring.log
@@ -1,0 +1,65 @@
+=== Phase 17 orchestrator-wiring prompt tests ===
+
+Test 1: lib/wave-boundary.sh wired at wave boundary
+  PASS: 3C.NEG1 section present
+  PASS: references wave-boundary.sh scan
+  PASS: routes HIGH severity to fix-story
+
+Test 2: lib/watchdog.sh wired in monitor loop
+  PASS: watchdog tick header
+  PASS: references watchdog.sh poll
+  PASS: status-probe action branch
+  PASS: kill-and-requeue action branch
+  PASS: mark-failed action branch
+  PASS: circuit-breaker bump
+  PASS: circuit-breaker check
+
+Test 3: lib/deep-review.sh wired at full-feature review
+  PASS: 4B.5 deep-review section
+  PASS: score-from-quantum call
+  PASS: tier lookup
+  PASS: dispatch-set call
+  PASS: context preparation
+  PASS: aggregate pipe
+  PASS: BLOCKS_MERGE handled
+  PASS: REQUEST_CHANGES handled
+  PASS: persists into quantum.reviews
+
+Test 4: lib/deslop.sh wired between review-pass and commit
+  PASS: 3A.5B deslop section
+  PASS: validate_scope gate
+  PASS: baseline snapshot before
+  PASS: compare_baseline call
+  PASS: rollback on regression
+  PASS: DESLOP_ROLLED_BACK signal
+  PASS: opt-out via story.deslop.skip
+
+Test 5: lib/commit-trailers.sh validation gate
+  PASS: commit-trailers reference
+  PASS: non-blocking warning
+
+Test 6: handoff.sh ownership is skill-side (orchestrator doesn't write)
+  PASS: orchestrator does NOT write handoffs directly (skills do)
+
+Test 7: all wirings carry a Phase-17 attribution comment
+  PASS: 5 Phase-17 attributions
+
+Test 8: deslop wiring uses DESLOP_AVAILABLE + BASE_SHA
+  PASS: DESLOP_AVAILABLE guard present
+  PASS: DESLOP_AVAILABLE file check
+  PASS: Fallback skip branch
+  PASS: scope loop uses BASE_SHA
+  PASS: rollback uses BASE_SHA
+  PASS: no active STORY_BASE_SHA refs in 3A.5B
+
+Test 9: RUNNER_EXTRA_FLAGS validated after pre_spawn()
+  PASS: RUNNER_EXTRA_FLAGS validation present
+  PASS: blocklist present (regex form varies)
+
+Test 10: runner_build_cmd rejects injection via RUNNER_EXTRA_FLAGS
+  PASS: injection payload rejected with clear error
+
+Test 11: lib/watchdog.sh doc comment corrected
+  PASS: watchdog threshold comment matches code (>30 min = timed-out)
+
+=== Results: 40/40 passed, 0 failed ===

--- a/.omc/phase-25-evidence/test_reaper.log
+++ b/.omc/phase-25-evidence/test_reaper.log
@@ -1,0 +1,62 @@
+=== Phase 20 reaper + spawn exec-capture tests ===
+
+Test 1: detect_platform recognizes current environment
+  PASS: platform is valid enum
+  (detected: msys)
+
+Test 2: _msys_to_winpid handles current PID
+  PASS: numeric winpid (8848)
+
+Test 3: write + read pidfile round-trip
+  PASS: pidfile exists
+  PASS: msys_pid round-trips
+  PASS: cmd round-trips
+  PASS: missing pidfile -> {}
+
+Test 4: is_agent_alive tracks liveness
+  PASS: alive while running
+  PASS: dead after kill
+
+Test 5: is_agent_alive on missing pidfile
+  PASS: missing pidfile -> not alive
+
+Test 6: reap_agent on already-dead process cleans pidfile
+  PASS: reap exits 0
+  PASS: pidfile removed
+
+Test 7: reap_agent terminates a live process
+  PASS: reap_agent exits 0
+  PASS: process not alive
+  PASS: pidfile removed
+
+Test 8: reap_orphans cleans stale pidfiles only
+  PASS: no stale-orphans reaped
+  PASS: dead pidfile removed
+  PASS: live pidfile kept
+
+Test 9: reap_orphans safe on missing/empty dir
+  PASS: missing dir -> 0
+  PASS: empty dir -> 0
+
+Test 10: lib/spawn.sh contains the exec-replacement fix
+  PASS: exec prepended to claude invocation
+  PASS: runner-path uses eval "exec $cmd"
+  PASS: spawn writes pidfile
+
+Test 11: quantum-loop.sh trap uses reaper
+  PASS: cleanup_on_exit calls reap_agent
+  PASS: startup calls reap_orphans
+
+Test 13: _proc_start_epoch is per-process (not a constant)
+  PASS: distinct processes have distinct start epochs (11915984 vs 11917056)
+
+Test 14: cleanup_on_exit uses parallel reap pattern
+  PASS: cleanup_on_exit parallelizes reap_agent calls
+
+Test 15: timeout branch uses reap_agent on Git Bash
+  PASS: TIMED_OUT branch prefers reap_agent
+
+Test 12: CLI subcommands work
+  PASS: CLI platform output: msys
+
+=== Results: 28/28 passed, 0 failed ===

--- a/.omc/phase-25-evidence/test_trajectory.log
+++ b/.omc/phase-25-evidence/test_trajectory.log
@@ -1,0 +1,49 @@
+=== Phase 24 trajectory-kill tests ===
+
+Test 1: parse on missing file
+  PASS: exists=false
+  PASS: total=0
+
+Test 2: parse counts tools
+  PASS: reads=5
+  PASS: greps=3
+  PASS: edits=2
+  PASS: writes=1
+  PASS: bashes=4
+  PASS: total=15
+  PASS: read_pct=53
+  PASS: edit_pct=20
+
+Test 3: productive trajectory
+  PASS: classify productive
+  PASS: productive -> no kill (exit 1)
+
+Test 4: searching trajectory
+  PASS: classify searching (below thrash min)
+  PASS: searching -> no kill
+
+Test 5: thrashing trajectory
+  PASS: classify thrashing
+  PASS: thrashing -> kill (exit 0)
+
+Test 6: stuck trajectory
+  PASS: classify stuck
+  PASS: stuck -> kill (exit 0)
+
+Test 7: env-var overrides take effect
+  PASS: default: searching
+  PASS: override THRASH_MIN=5: thrashing
+
+Test 8: empty file handling
+  PASS: empty file total=0
+  PASS: empty file classify=productive (no signal)
+
+Test 9: CLI subcommands
+  PASS: CLI parse total=26
+  PASS: CLI classify thrashing
+  PASS: CLI kill exits 0 for thrashing
+
+Test 10: classify reads stdin
+  PASS: stdin classify productive
+
+=== Results: 26/26 passed, 0 failed ===

--- a/.omc/phase-25-evidence/test_watchdog.log
+++ b/.omc/phase-25-evidence/test_watchdog.log
@@ -1,0 +1,55 @@
+=== Phase 16 watchdog + circuit-breaker tests ===
+
+Test 1: classify_age thresholds
+  PASS: 0s -> fresh
+  PASS: 300s -> fresh
+  PASS: 301s -> stale-check
+  PASS: 600s -> stale-check
+  PASS: 601s -> stale-reassign
+  PASS: 1200s -> stale-reassign
+  PASS: 1201s -> stale-reassign
+  PASS: 1800s -> stale-reassign
+  PASS: 1801s -> timed-out
+  PASS: 7200s -> timed-out
+
+Test 2: watchdog_poll on empty state
+  PASS: missing quantum.json -> []
+
+Test 3: watchdog_poll fresh in_progress story
+  PASS: only the in_progress story returned
+  PASS: story_id is US-001
+  PASS: fresh -> continue
+  PASS: classification fresh
+
+Test 4: watchdog_poll stale-check (~400s old)
+  PASS: 400s -> stale-check
+  PASS: stale-check -> status-probe
+
+Test 5: watchdog_poll timed-out (>30min old)
+  PASS: 2400s -> timed-out
+  PASS: timed-out -> mark-failed
+
+Test 6: error_counter_bump same signature increments
+  PASS: first bump count 1
+  PASS: second bump count 2
+  PASS: third bump count 3
+
+Test 7: different signature resets counter
+  PASS: sig-A count reaches 2
+  PASS: sig-B resets to 1
+  PASS: sig-B next bump is 2
+
+Test 8: should_circuit_break crosses threshold
+  PASS: count=1, threshold=3 -> no break (exit 1)
+  PASS: count=3, threshold=3 -> BREAK (exit 0)
+  PASS: count=3, threshold=10 -> no break
+
+Test 9: error_counter_reset
+  PASS: after reset, no break
+  PASS: count after reset=1
+
+Test 10: CLI subcommands
+  PASS: CLI classify 500 -> stale-check
+  PASS: CLI bump first -> 1
+
+=== Results: 32/32 passed, 0 failed ===

--- a/lib/hyclone.sh
+++ b/lib/hyclone.sh
@@ -1,0 +1,280 @@
+#!/usr/bin/env bash
+# lib/hyclone.sh — two-stage semantic clone detection (Phase 25 / P3.7).
+#
+# Source: HyClone arXiv:2508.01357. Two-stage detection:
+#   Stage 1: LLM or canonical-form pre-screen to find CANDIDATE clones
+#            (cheap, broad, may have false positives).
+#   Stage 2: Execution validation — run both candidates against shared
+#            inputs, compare outputs to confirm semantic equivalence.
+#
+# This library ships Stage 1 — the canonical-form fingerprint. Stage 2
+# (execution validation) is inherently language-specific and is delegated
+# to the duplication-detector agent, which can invoke the fingerprint
+# checker from here, then call project-specific test harnesses for the
+# actual equivalence check.
+#
+# Functions:
+#   alpha_normalize TEXT
+#     Canonicalize a snippet: strip comments, collapse whitespace, rename
+#     identifiers to sequential placeholders (_v0, _v1, …) in order of
+#     first appearance. Two snippets that differ only in variable names
+#     and formatting produce identical normalized output.
+#   fingerprint TEXT
+#     sha256 of alpha_normalize(TEXT). Stable across whitespace + naming
+#     differences.
+#   find_clones JSON_ARRAY
+#     Input JSON: [{id, body}, ...]. Emits JSON of clone-pair groups:
+#     [{fingerprint, members: [id, id, …]}, …] where each group has ≥2
+#     members (i.e., only genuine clone candidates are returned).
+#
+# Language-agnostic by design. Alpha-renaming is regex-based, so it works
+# best on languages where identifiers look like [A-Za-z_][A-Za-z0-9_]*
+# (TypeScript, JavaScript, Python, Go, Rust, Java, C). Languages with
+# distinct identifier grammars (Lisp :keyword, Perl @array) should pre-
+# process before calling fingerprint.
+#
+# Library contract: no shell flags at source time; CLI-entry block enables
+# strict mode locally.
+
+HYCLONE_LIB_DIR="${HYCLONE_LIB_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+
+# Reserved keyword list — tokens that MUST NOT be renamed, else alpha-
+# normalization would change semantics. Covers TS/JS/Py/Go/Rust/Java/C
+# common intersection. If a reserved keyword overlaps with a local name
+# in some language, false positives are acceptable — clones are still
+# flagged; just with slightly lower recall.
+if [[ -z "${HYCLONE_KEYWORDS+x}" ]]; then
+readonly -a HYCLONE_KEYWORDS=(
+  # Control flow
+  if then else elif fi for while do done case esac switch break continue return yield
+  # Declarations
+  let const var function func def class interface struct enum type trait impl pub
+  # Booleans / special values
+  true false null undefined None True False nil
+  # Operators / keywords
+  and or not in is new delete throw throws try catch finally as of from import export default
+  # Type-ish
+  string number boolean int float double char void bool
+  # Async
+  async await asyncio Promise
+  # Access
+  public private protected readonly static final abstract
+  # Test-ish
+  describe it test expect assert
+)
+fi
+
+# _is_keyword(token)
+# Return 0 if token is in HYCLONE_KEYWORDS, 1 otherwise.
+_is_keyword() {
+  local t="${1:-}"
+  local kw
+  for kw in "${HYCLONE_KEYWORDS[@]}"; do
+    [[ "$t" == "$kw" ]] && return 0
+  done
+  return 1
+}
+
+# alpha_normalize(text)
+# Emits the canonical form on stdout:
+#   1. Remove line comments (# ... or // ... to end of line)
+#   2. Remove block comments (/* ... */) — non-greedy
+#   3. Collapse runs of whitespace to a single space
+#   4. Rename identifiers to _v0, _v1, … in order of first appearance
+#      (keywords are untouched)
+#   5. Trim leading/trailing whitespace
+#
+# Input may be any length. Uses awk for the tokenize-and-rename pass so
+# the whole function stays portable (no python dependency for alphabet).
+alpha_normalize() {
+  local text="${1:-}"
+  [[ -z "$text" ]] && { printf ""; return 0; }
+  # Step 1-2: strip comments. Use sed for line comments. Block comments:
+  # use awk state machine since portable sed doesn't do multiline.
+  local stripped
+  stripped=$(printf '%s' "$text" | awk '
+    BEGIN { in_block = 0 }
+    {
+      line = $0
+      out = ""
+      i = 1
+      while (i <= length(line)) {
+        c  = substr(line, i, 1)
+        c2 = substr(line, i, 2)
+        if (in_block) {
+          if (c2 == "*/") { in_block = 0; i += 2 } else { i += 1 }
+        } else if (c2 == "/*") {
+          in_block = 1; i += 2
+        } else if (c2 == "//" || c == "#") {
+          break  # line comment — skip rest of line
+        } else {
+          out = out c
+          i += 1
+        }
+      }
+      print out
+    }
+  ')
+
+  # Step 3: collapse whitespace
+  stripped=$(printf '%s' "$stripped" | tr -s '[:space:]' ' ')
+
+  # Step 4: tokenize + alpha-rename. Build the keyword set on the awk side
+  # so we don't have to roundtrip to shell. Identifiers: [A-Za-z_][A-Za-z0-9_]*
+  # Strings ("..." / '...') are preserved verbatim (they're not identifiers).
+  local keyword_list="${HYCLONE_KEYWORDS[*]}"
+  printf '%s' "$stripped" | awk -v kws="$keyword_list" '
+    BEGIN {
+      n = split(kws, kwlist, " ")
+      for (i = 1; i <= n; i++) kwset[kwlist[i]] = 1
+      next_id = 0
+    }
+    {
+      out = ""
+      s = $0
+      while (length(s) > 0) {
+        c = substr(s, 1, 1)
+        # String literals — copy through unchanged
+        if (c == "\"" || c == "'\''") {
+          quote = c
+          out = out quote
+          s = substr(s, 2)
+          while (length(s) > 0) {
+            c = substr(s, 1, 1)
+            out = out c
+            if (c == "\\") {
+              out = out substr(s, 2, 1)
+              s = substr(s, 3)
+            } else if (c == quote) {
+              s = substr(s, 2)
+              break
+            } else {
+              s = substr(s, 2)
+            }
+          }
+          continue
+        }
+        # Identifier
+        if (match(s, /^[A-Za-z_][A-Za-z0-9_]*/)) {
+          tok = substr(s, 1, RLENGTH)
+          s = substr(s, RLENGTH + 1)
+          if (tok in kwset) {
+            out = out tok
+          } else {
+            if (!(tok in idmap)) {
+              idmap[tok] = "_v" next_id
+              next_id++
+            }
+            out = out idmap[tok]
+          }
+          continue
+        }
+        # Number literal — copy through
+        if (match(s, /^[0-9]+(\.[0-9]+)?/)) {
+          out = out substr(s, 1, RLENGTH)
+          s = substr(s, RLENGTH + 1)
+          continue
+        }
+        # Any other character (punctuation, operator) — copy single char
+        out = out c
+        s = substr(s, 2)
+      }
+      # Trim leading/trailing
+      gsub(/^ +| +$/, "", out)
+      # Aggressive: drop spaces adjacent to non-alphanumeric tokens so
+      # formatting differences (e.g., `fn(a, b)` vs `fn(a,b)`) collide
+      # into the same fingerprint. This loses readability but is what
+      # HyClone Stage-1 wants — maximum recall across styles.
+      # Keep single space between two identifier-tail/head chars to
+      # preserve token boundaries (e.g., `return _v0` must stay as two
+      # tokens, not `return_v0`).
+      prev = ""
+      out2 = ""
+      for (j = 1; j <= length(out); j++) {
+        c  = substr(out, j, 1)
+        if (c == " ") {
+          nxt = substr(out, j + 1, 1)
+          # Keep the space only if BOTH prev and nxt are word-chars
+          # ([A-Za-z0-9_]); otherwise drop it.
+          if (prev ~ /[A-Za-z0-9_]/ && nxt ~ /[A-Za-z0-9_]/) {
+            out2 = out2 c
+            prev = c
+          }
+        } else {
+          out2 = out2 c
+          prev = c
+        }
+      }
+      print out2
+    }
+  '
+}
+
+# fingerprint(text)
+# sha256 of alpha_normalize(text). 64-char lowercase hex.
+fingerprint() {
+  local text="${1:-}"
+  local norm
+  norm=$(alpha_normalize "$text")
+  printf '%s' "$norm" | sha256sum | awk '{print $1}'
+}
+
+# find_clones(json_array)
+# Input JSON: [{id, body}, ...]. Computes fingerprint(body) for each
+# entry, groups by fingerprint, emits the groups with ≥2 members.
+# Output: [{fingerprint, members: [id, id, ...]}, ...]
+find_clones() {
+  local input="${1:-}"
+  [[ -z "$input" ]] && input=$(cat)
+  local tmp
+  tmp=$(mktemp)
+  # Build lines of "fingerprint<TAB>id"
+  local n
+  n=$(printf '%s' "$input" | jq 'length')
+  local i=0
+  while (( i < n )); do
+    local id body fp
+    id=$(printf '%s' "$input" | jq -r ".[$i].id")
+    body=$(printf '%s' "$input" | jq -r ".[$i].body")
+    fp=$(fingerprint "$body")
+    printf '%s\t%s\n' "$fp" "$id" >> "$tmp"
+    i=$((i + 1))
+  done
+  # Group by fingerprint, retain only groups with ≥2 entries
+  local out='[]'
+  while IFS= read -r fp; do
+    [[ -z "$fp" ]] && continue
+    local members
+    members=$(awk -F '\t' -v fp="$fp" '$1 == fp {print $2}' "$tmp" \
+      | jq -R . | jq -s .)
+    local count
+    count=$(printf '%s' "$members" | jq 'length')
+    (( count >= 2 )) || continue
+    out=$(jq -c --arg fp "$fp" --argjson m "$members" \
+      '. + [{fingerprint: $fp, members: $m}]' <<< "$out")
+  done < <(awk -F '\t' '{print $1}' "$tmp" | sort -u)
+  rm -f "$tmp"
+  printf '%s' "$out"
+}
+
+# ------------------------------------------------------------------------------
+# CLI entry
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  set -euo pipefail
+  subcmd="${1:-}"
+  shift || true
+  case "$subcmd" in
+    normalize)   alpha_normalize "$@"; printf "\n" ;;
+    fingerprint) fingerprint "$@"; printf "\n" ;;
+    clones)      find_clones "$@" ;;
+    *)
+      cat >&2 <<USAGE
+Usage: bash lib/hyclone.sh <subcmd> [args...]
+  normalize TEXT                    — canonical form
+  fingerprint TEXT                  — sha256 of canonical form
+  clones [JSON]                     — find clone groups; reads stdin if no arg
+USAGE
+      exit 2
+      ;;
+  esac
+fi

--- a/tests/test_hyclone.sh
+++ b/tests/test_hyclone.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# Phase 25 / P3.7 — HyClone Stage-1 fingerprint tests.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR/.."
+PASS=0
+FAIL=0
+TOTAL=0
+
+assert() {
+  local name="$1" expected="$2" actual="$3"
+  TOTAL=$((TOTAL + 1))
+  if [[ "$expected" == "$actual" ]]; then
+    echo "  PASS: $name"; PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $name (expected [$expected] got [$actual])"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# shellcheck disable=SC1091
+source "$REPO_ROOT/lib/hyclone.sh"
+
+echo "=== Phase 25 HyClone Stage-1 tests ==="
+
+# Test 1: alpha_normalize — whitespace collapse + identifier rename
+# Note: aggressive normalization drops spaces adjacent to non-word chars,
+# keeping only single spaces between two word-character runs (e.g.
+# "return x" stays "return _v0" but "x = 42" becomes "_v0=42").
+echo ""
+echo "Test 1: alpha_normalize basics"
+n1=$(alpha_normalize "let x = 42")
+# "let " (word to word-space-word), " x " (word), "= 42" (eq drops spaces)
+assert "whitespace-only renames x" "let _v0=42" "$n1"
+n2=$(alpha_normalize "let  x   =   42")
+assert "extra whitespace collapsed" "let _v0=42" "$n2"
+n3=$(alpha_normalize "let x = y + z")
+assert "multiple identifiers numbered" "let _v0=_v1+_v2" "$n3"
+
+# Test 2: alpha_normalize — repeated identifiers get same placeholder
+echo ""
+echo "Test 2: repeated identifiers reuse placeholder"
+n=$(alpha_normalize "let x = x + 1; let y = x")
+assert "repeated identifier reuses placeholder" "let _v0=_v0+1;let _v1=_v0" "$n"
+
+# Test 3: alpha_normalize — keywords not renamed
+echo ""
+echo "Test 3: keywords preserved"
+n=$(alpha_normalize "if x then return true else return false")
+assert "keywords preserved" "if _v0 then return true else return false" "$n"
+
+# Test 4: alpha_normalize — comments stripped
+echo ""
+echo "Test 4: comments stripped"
+n=$(alpha_normalize "let x = 5 // the answer")
+assert "line comment // stripped" "let _v0=5" "$n"
+n=$(alpha_normalize "let y = 10 # comment here")
+assert "line comment # stripped" "let _v0=10" "$n"
+n=$(alpha_normalize "let /* unused */ z = 7")
+assert "block comment stripped" "let _v0=7" "$n"
+
+# Test 5: alpha_normalize — strings not renamed
+echo ""
+echo "Test 5: string literals preserved"
+n=$(alpha_normalize 'let msg = "hello world"')
+assert "double-quoted string preserved" 'let _v0="hello world"' "$n"
+n=$(alpha_normalize "let m = 'single quotes'")
+assert "single-quoted string preserved" "let _v0='single quotes'" "$n"
+
+# Test 6: fingerprint — same content, different names → same hash
+echo ""
+echo "Test 6: clone fingerprints match"
+f1=$(fingerprint "function add(a, b) { return a + b }")
+f2=$(fingerprint "function sum(x, y) { return x + y }")
+assert "different names → same fingerprint" "$f1" "$f2"
+# Different whitespace
+f3=$(fingerprint "function add(a,b){return a+b}")
+assert "different whitespace → same fingerprint" "$f1" "$f3"
+
+# Test 7: fingerprint — truly different behavior → different hash
+echo ""
+echo "Test 7: semantic difference → different fingerprints"
+f_add=$(fingerprint "function add(a, b) { return a + b }")
+f_sub=$(fingerprint "function sub(a, b) { return a - b }")
+TOTAL=$((TOTAL + 1))
+if [[ "$f_add" != "$f_sub" ]]; then
+  echo "  PASS: operator difference changes fingerprint"; PASS=$((PASS + 1))
+else
+  echo "  FAIL: add vs sub collided"; FAIL=$((FAIL + 1))
+fi
+# Different control flow
+f_loop=$(fingerprint "while (x > 0) { x = x - 1 }")
+f_if=$(fingerprint "if (x > 0) { x = x - 1 }")
+TOTAL=$((TOTAL + 1))
+if [[ "$f_loop" != "$f_if" ]]; then
+  echo "  PASS: while vs if different"; PASS=$((PASS + 1))
+else
+  echo "  FAIL: while and if collided"; FAIL=$((FAIL + 1))
+fi
+
+# Test 8: find_clones — groups ≥2-member candidates
+echo ""
+echo "Test 8: find_clones detects a clone pair"
+input='[
+  {"id":"fnA","body":"function add(a, b) { return a + b }"},
+  {"id":"fnB","body":"function sum(x, y) { return x + y }"},
+  {"id":"fnC","body":"function mul(a, b) { return a * b }"}
+]'
+out=$(find_clones "$input")
+groups=$(printf '%s' "$out" | jq 'length')
+assert "finds 1 clone group" "1" "$groups"
+members=$(printf '%s' "$out" | jq -r '.[0].members | length')
+assert "group has 2 members" "2" "$members"
+# Members should be fnA and fnB
+contains_A=$(printf '%s' "$out" | jq '.[0].members | contains(["fnA"])')
+contains_B=$(printf '%s' "$out" | jq '.[0].members | contains(["fnB"])')
+contains_C=$(printf '%s' "$out" | jq '.[0].members | contains(["fnC"])')
+assert "fnA in clone group" "true" "$contains_A"
+assert "fnB in clone group" "true" "$contains_B"
+assert "fnC NOT in clone group" "false" "$contains_C"
+
+# Test 9: find_clones — no clones
+echo ""
+echo "Test 9: find_clones with all unique functions"
+input='[
+  {"id":"fn1","body":"function a() { return 1 }"},
+  {"id":"fn2","body":"function b() { return 2 }"},
+  {"id":"fn3","body":"function c() { return 3 }"}
+]'
+out=$(find_clones "$input")
+groups=$(printf '%s' "$out" | jq 'length')
+assert "no clone groups" "0" "$groups"
+
+# Test 10: find_clones — 3-way clone (triple)
+echo ""
+echo "Test 10: find_clones with triple"
+input='[
+  {"id":"a","body":"function one(x) { return x * 2 }"},
+  {"id":"b","body":"function two(y) { return y * 2 }"},
+  {"id":"c","body":"function three(z) { return z * 2 }"}
+]'
+out=$(find_clones "$input")
+groups=$(printf '%s' "$out" | jq 'length')
+members=$(printf '%s' "$out" | jq -r '.[0].members | length')
+assert "3-way clone grouped" "1" "$groups"
+assert "triple has 3 members" "3" "$members"
+
+# Test 11: CLI subcommands
+echo ""
+echo "Test 11: CLI subcommands"
+cli_norm=$(bash "$REPO_ROOT/lib/hyclone.sh" normalize "let x = 42" | tr -d '\n')
+assert "CLI normalize" "let _v0=42" "$cli_norm"
+cli_fp=$(bash "$REPO_ROOT/lib/hyclone.sh" fingerprint "let x = 42" | tr -d '\n')
+# Sha256 = 64 hex chars
+TOTAL=$((TOTAL + 1))
+if [[ "${#cli_fp}" -eq 64 ]]; then
+  echo "  PASS: CLI fingerprint is 64 hex chars"; PASS=$((PASS + 1))
+else
+  echo "  FAIL: CLI fp length [${#cli_fp}]"; FAIL=$((FAIL + 1))
+fi
+
+# Test 12: empty input -> empty output
+echo ""
+echo "Test 12: empty input handling"
+n=$(alpha_normalize "")
+assert "empty normalize -> empty" "" "$n"
+out=$(find_clones "[]")
+assert "empty find_clones -> []" "[]" "$out"
+
+echo ""
+echo "=== Results: $PASS/$TOTAL passed, $FAIL failed ==="
+exit $((FAIL > 0 ? 1 : 0))


### PR DESCRIPTION
Fourth P3 wedge. Canonical-form fingerprint for semantic clone detection: alpha-rename + whitespace collapse + comment strip, then sha256. Upgrades text-level Jaccard screen.

## lib/hyclone.sh

- `alpha_normalize TEXT` — canonical form, identifier-renamed + comment-stripped + whitespace-aggressive
- `fingerprint TEXT` — sha256 of canonical form
- `find_clones JSON_ARRAY` — groups by fingerprint, emits pairs/triples

## Test: 26 new, 297 total across 10 suites

Language-agnostic (TS/JS/Py/Go/Rust/Java/C). Stage-2 execution validation is delegated to the duplication-detector agent.