### PR TITLE
Phase 26 — Merge-conflict severity grading (P3.2, ConGra arXiv:2409.14121)

### DIFF
--- a/.omc/phase-26-evidence/test_ambiguity.log
+++ b/.omc/phase-26-evidence/test_ambiguity.log
@@ -1,0 +1,68 @@
+=== Phase 19 ambiguity-gate tests ===
+
+Test 1: score_ambiguity arithmetic
+  PASS: all 10s -> 0
+  PASS: all 0s -> 100
+  PASS: all 5s -> 50
+  PASS: goal only -> 60
+  PASS: constraints only -> 70
+  PASS: criteria only -> 70
+
+Test 2: score_ambiguity input validation
+  PASS: 11 rejected
+  PASS: -1 rejected
+  PASS: abc rejected
+
+Test 3: check_gate semantics
+  PASS: score 0 passes
+  PASS: score 19 passes
+  PASS: score 20 blocks
+  PASS: score 50 blocks
+  PASS: score 100 blocks
+  PASS: 30 < 50 passes
+  PASS: 60 >= 50 blocks
+
+Test 4: challenge_mode thresholds
+  PASS: round 1, score 100 -> normal
+  PASS: round 2, score 80  -> normal
+  PASS: round 3, score 45  -> contrarian
+  PASS: round 3, score 35  -> normal
+  PASS: round 4, score 35  -> simplifier
+  PASS: round 4, score 25  -> normal
+  PASS: round 5, score 25  -> ontologist
+  PASS: round 5, score 15  -> normal
+  PASS: round 6, score 50  -> ontologist
+
+Test 5: ontology_extract
+  PASS: extract tokens sorted+unique
+  PASS: empty -> empty
+  PASS: stopwords dropped
+
+Test 6: ontology_diff
+  PASS: 1 added
+  PASS: 1 removed
+  PASS: 2 carried
+  PASS: stability 0.50
+  PASS: identical stability 1.0
+  PASS: empty prior stability 0.00
+
+Test 7: CLI subcommands
+  PASS: CLI score 5 5 5 = 50
+  PASS: CLI gate 10 passes
+  PASS: CLI gate 25 blocks
+  PASS: CLI mode 5 30 = ontologist
+
+Test 8: ql-brainstorm wires lib/ambiguity.sh
+  PASS: Phase 0B ambiguity gate section
+  PASS: calls lib/ambiguity.sh score
+  PASS: calls lib/ambiguity.sh gate
+  PASS: calls lib/ambiguity.sh mode
+  PASS: ontology stability tracking
+  PASS: ontology diff call
+  PASS: contrarian mode described
+  PASS: simplifier mode described
+  PASS: ontologist mode described
+  PASS: thrashing ontology escalation
+  PASS: handoff records final_score
+
+=== Results: 49/49 passed, 0 failed ===

--- a/.omc/phase-26-evidence/test_conflict_grade.log
+++ b/.omc/phase-26-evidence/test_conflict_grade.log
@@ -1,0 +1,57 @@
+=== Phase 26 conflict-grade tests ===
+
+Test 1: whitespace-only → grade 1
+  PASS: single-ws diff
+  PASS: bracket-indent diff
+
+Test 2: comment-only → grade 2
+  PASS: line comment change
+  PASS: python-style comment change
+  PASS: block comment change
+
+Test 3: single-token rename → grade 2
+  PASS: single identifier rename
+
+Test 4: small body edit → grade 3
+  PASS: 3-line small body edit
+
+Test 5: moderate overlap → grade 4
+  PASS: 7-line overlap
+
+Test 6: structural reorg → grade 5
+  PASS: 2-function reorder
+  PASS: 2-def reorg (python)
+
+Test 7: split_conflict_hunks single
+  PASS: 1 conflict parsed
+  PASS: ours buffer captured
+  PASS: theirs buffer captured
+  PASS: start_line=2
+  PASS: end_line=7
+
+Test 8: split_conflict_hunks multiple
+  PASS: 2 conflicts parsed
+
+Test 9: grade_file end-to-end
+  PASS: 2 hunks graded
+  PASS: max_grade = 5 (structural)
+  PASS: first hunk grade 2 (comment)
+  PASS: second hunk grade 5 (structural)
+
+Test 10: grade_file clean file
+  PASS: clean file max_grade=0
+  PASS: clean file 0 hunks
+
+Test 11: routing_recommendation
+  PASS: grade 0 → none
+  PASS: grade 1 → auto-git
+  PASS: grade 2 → auto-git
+  PASS: grade 3 → diff3
+  PASS: grade 4 → llm-merge
+  PASS: grade 5 → escalate
+
+Test 12: CLI subcommands
+  PASS: CLI grade single-word rename
+  PASS: CLI route 4 → llm-merge
+
+=== Results: 30/30 passed, 0 failed ===

--- a/.omc/phase-26-evidence/test_constitution.log
+++ b/.omc/phase-26-evidence/test_constitution.log
@@ -1,0 +1,51 @@
+=== Phase 22 constitution tests ===
+
+Test 1: load_constitution
+  PASS: loads 2 rules
+  PASS: missing constitution -> empty
+  PASS: missing file -> empty
+  PASS: object form with .rule
+
+Test 2: check_no_secrets detects provider tokens
+  PASS: detects sk-live token
+  PASS: detects ghp_ token
+  PASS: ignores comment about passwords (no literal)
+
+Test 3: generic password/api_key literal
+  PASS: password= long literal flagged
+  PASS: api_key= long literal flagged
+  PASS: short literal not flagged
+
+Test 4: check_sql_injection
+  PASS: flags 2 SQL injections (template + concat)
+  PASS: parameterized query not flagged
+
+Test 5: check_input_validation
+  PASS: flags 2 unvalidated handler reads
+
+Test 6: check_commit_integrity
+  PASS: flags migration file
+  PASS: flags schema.prisma
+  PASS: flags .env.example
+  PASS: does NOT flag regular source file
+
+Test 7: enforce_constitution end-to-end
+  PASS: enforce finds 2 secret+sql findings
+  PASS: input-validation skipped when not active
+  PASS: input-validation active -> finds req.body
+  PASS: no constitution -> empty JSON array
+  PASS: unknown rule -> empty findings (warn only)
+
+Test 8: finding metadata
+  PASS: severity critical
+  PASS: description set
+  PASS: rule id set
+
+Test 9: CLI enforce
+  PASS: CLI enforce returns findings
+
+Test 10: quantum.json.example schema
+  PASS: constitution is array
+  PASS: quantum.json.example still valid JSON
+
+=== Results: 28/28 passed, 0 failed ===

--- a/.omc/phase-26-evidence/test_deep_review.log
+++ b/.omc/phase-26-evidence/test_deep_review.log
@@ -1,0 +1,52 @@
+=== Phase 8 ql-deep-review helper tests ===
+
+Test 1: tier_of_score mapping
+  PASS: 0 -> LOW
+  PASS: 30 -> LOW
+  PASS: 31 -> MEDIUM
+  PASS: 60 -> MEDIUM
+  PASS: 61 -> HIGH
+  PASS: 80 -> HIGH
+  PASS: 81 -> CRITICAL
+  PASS: 100 -> CRITICAL
+
+Test 2: compute_risk_score bounds
+  PASS: empty refs -> 0
+  PASS: intent drift contributes 10
+
+Test 3: actionability_filter
+  PASS: kept count
+  PASS: suppressed count
+  PASS: suppressed has reason
+
+Test 4: dedup_findings
+  PASS: dedup reduces 3 -> 2
+  PASS: merged agents count
+  PASS: kept max confidence
+
+Test 5: hallucination_check suppresses missing files
+  PASS: 1 file kept
+  PASS: 1 file suppressed as hallucination
+  PASS: suppressed reason
+
+Test 6: synthesize_verdict
+  PASS: empty -> APPROVE
+  PASS: only low -> APPROVE
+  PASS: medium 60 -> APPROVE_WITH_COMMENTS
+  PASS: high 75 -> REQUEST_CHANGES
+  PASS: critical 85 -> BLOCKS_MERGE
+  PASS: critical 50 (below threshold) -> APPROVE
+
+Test 7: quantum.json.example schema
+  PASS: reviews is object
+  PASS: quantum.json.example still valid JSON
+
+Test 8: ql-execute mentions the post-pipeline hook
+  PASS: post-pipeline hook header present
+  PASS: references lib/deep-review.sh
+
+Test 9: CLI subcommands work
+  PASS: CLI tier 50 -> MEDIUM
+  PASS: CLI tier 100 -> CRITICAL
+
+=== Results: 31/31 passed, 0 failed ===

--- a/.omc/phase-26-evidence/test_dogfood_e2e.log
+++ b/.omc/phase-26-evidence/test_dogfood_e2e.log
@@ -1,0 +1,38 @@
+=== Phase 10 dogfood end-to-end check ===
+
+Test 1: dogfood quantum.json parses
+  PASS: valid JSON
+
+Test 2: schema fields from Phases 7-9
+  PASS: userIntent.text present
+  PASS: userClarifications is array
+  PASS: intentDrift has entry
+  PASS: reviews has deepReview
+  PASS: deslop field present
+  PASS: codebasePatterns has entries
+  PASS: progress has entries
+
+Test 3: intent-drift gate semantics
+  PASS: NO_DRIFT gate allows merge
+
+Test 4: deep-review synthesize_verdict consumes the dogfood findings array
+  PASS: two HIGH confidence≥70 findings → REQUEST_CHANGES
+
+Test 5: dedup_findings idempotent on dogfood findings
+  PASS: dedup preserves 2-element unique set
+
+Test 6: plan retrospective — 10 stories all passed
+  PASS: 10 stories total
+  PASS: 10 stories passed
+
+Test 7: codebasePatterns contains real Phase-5 lesson
+  PASS: Phase-5 set-e lesson present
+
+Test 8: userIntent verbatim contains the original verbatim message
+  PASS: intent snapshot references IDEA_REPORT.md
+
+Test 9: companion PRD exists and references the dogfood artifact
+  PASS: PRD exists
+  PASS: PRD has AC-15 dogfood + references phase-10-evidence
+
+=== Results: 17/17 passed, 0 failed ===

--- a/.omc/phase-26-evidence/test_far_filter.log
+++ b/.omc/phase-26-evidence/test_far_filter.log
@@ -1,0 +1,41 @@
+=== Phase 23 KBI-FAR far_filter tests ===
+
+Test 1: confidence cutoff
+  PASS: 1 kept (conf ≥60)
+  PASS: 2 suppressed (conf <60)
+  PASS: reason mentions confidence
+
+Test 2: agreement boost lifts across cutoff
+  PASS: agreement-boosted finding kept
+  PASS: confidence boosted 50 -> 65
+  PASS: original_confidence preserved
+  PASS: single-agent below-cutoff suppressed
+
+Test 3: confidence cap at 100
+  PASS: confidence capped at 100
+
+Test 4: knownFalsePositives regex suppression
+  PASS: genuine finding kept
+  PASS: 2 suppressed by regex
+  PASS: suppression reasons reference knownFalsePositives
+
+Test 5: missing quantum.json graceful fallback
+  PASS: finding kept with missing quantum.json
+
+Test 6: empty input
+  PASS: empty kept
+  PASS: empty suppressed
+
+Test 7: CLI subcommand
+  PASS: CLI far kept 1
+
+Test 8: aggregate_reviews wires far_filter
+  PASS: aggregate kept 1 real finding
+  PASS: aggregate suppressed 2 (cutoff + FP)
+  PASS: verdict REQUEST_CHANGES (high ≥70)
+  PASS: FP reason present
+
+Test 9: schema extension
+  PASS: knownFalsePositives is array
+
+=== Results: 20/20 passed, 0 failed ===

--- a/.omc/phase-26-evidence/test_hyclone.log
+++ b/.omc/phase-26-evidence/test_hyclone.log
@@ -1,0 +1,53 @@
+=== Phase 25 HyClone Stage-1 tests ===
+
+Test 1: alpha_normalize basics
+  PASS: whitespace-only renames x
+  PASS: extra whitespace collapsed
+  PASS: multiple identifiers numbered
+
+Test 2: repeated identifiers reuse placeholder
+  PASS: repeated identifier reuses placeholder
+
+Test 3: keywords preserved
+  PASS: keywords preserved
+
+Test 4: comments stripped
+  PASS: line comment // stripped
+  PASS: line comment # stripped
+  PASS: block comment stripped
+
+Test 5: string literals preserved
+  PASS: double-quoted string preserved
+  PASS: single-quoted string preserved
+
+Test 6: clone fingerprints match
+  PASS: different names → same fingerprint
+  PASS: different whitespace → same fingerprint
+
+Test 7: semantic difference → different fingerprints
+  PASS: operator difference changes fingerprint
+  PASS: while vs if different
+
+Test 8: find_clones detects a clone pair
+  PASS: finds 1 clone group
+  PASS: group has 2 members
+  PASS: fnA in clone group
+  PASS: fnB in clone group
+  PASS: fnC NOT in clone group
+
+Test 9: find_clones with all unique functions
+  PASS: no clone groups
+
+Test 10: find_clones with triple
+  PASS: 3-way clone grouped
+  PASS: triple has 3 members
+
+Test 11: CLI subcommands
+  PASS: CLI normalize
+  PASS: CLI fingerprint is 64 hex chars
+
+Test 12: empty input handling
+  PASS: empty normalize -> empty
+  PASS: empty find_clones -> []
+
+=== Results: 26/26 passed, 0 failed ===

--- a/.omc/phase-26-evidence/test_orchestrator_wiring.log
+++ b/.omc/phase-26-evidence/test_orchestrator_wiring.log
@@ -1,0 +1,65 @@
+=== Phase 17 orchestrator-wiring prompt tests ===
+
+Test 1: lib/wave-boundary.sh wired at wave boundary
+  PASS: 3C.NEG1 section present
+  PASS: references wave-boundary.sh scan
+  PASS: routes HIGH severity to fix-story
+
+Test 2: lib/watchdog.sh wired in monitor loop
+  PASS: watchdog tick header
+  PASS: references watchdog.sh poll
+  PASS: status-probe action branch
+  PASS: kill-and-requeue action branch
+  PASS: mark-failed action branch
+  PASS: circuit-breaker bump
+  PASS: circuit-breaker check
+
+Test 3: lib/deep-review.sh wired at full-feature review
+  PASS: 4B.5 deep-review section
+  PASS: score-from-quantum call
+  PASS: tier lookup
+  PASS: dispatch-set call
+  PASS: context preparation
+  PASS: aggregate pipe
+  PASS: BLOCKS_MERGE handled
+  PASS: REQUEST_CHANGES handled
+  PASS: persists into quantum.reviews
+
+Test 4: lib/deslop.sh wired between review-pass and commit
+  PASS: 3A.5B deslop section
+  PASS: validate_scope gate
+  PASS: baseline snapshot before
+  PASS: compare_baseline call
+  PASS: rollback on regression
+  PASS: DESLOP_ROLLED_BACK signal
+  PASS: opt-out via story.deslop.skip
+
+Test 5: lib/commit-trailers.sh validation gate
+  PASS: commit-trailers reference
+  PASS: non-blocking warning
+
+Test 6: handoff.sh ownership is skill-side (orchestrator doesn't write)
+  PASS: orchestrator does NOT write handoffs directly (skills do)
+
+Test 7: all wirings carry a Phase-17 attribution comment
+  PASS: 5 Phase-17 attributions
+
+Test 8: deslop wiring uses DESLOP_AVAILABLE + BASE_SHA
+  PASS: DESLOP_AVAILABLE guard present
+  PASS: DESLOP_AVAILABLE file check
+  PASS: Fallback skip branch
+  PASS: scope loop uses BASE_SHA
+  PASS: rollback uses BASE_SHA
+  PASS: no active STORY_BASE_SHA refs in 3A.5B
+
+Test 9: RUNNER_EXTRA_FLAGS validated after pre_spawn()
+  PASS: RUNNER_EXTRA_FLAGS validation present
+  PASS: blocklist present (regex form varies)
+
+Test 10: runner_build_cmd rejects injection via RUNNER_EXTRA_FLAGS
+  PASS: injection payload rejected with clear error
+
+Test 11: lib/watchdog.sh doc comment corrected
+  PASS: watchdog threshold comment matches code (>30 min = timed-out)
+
+=== Results: 40/40 passed, 0 failed ===

--- a/.omc/phase-26-evidence/test_reaper.log
+++ b/.omc/phase-26-evidence/test_reaper.log
@@ -1,0 +1,62 @@
+=== Phase 20 reaper + spawn exec-capture tests ===
+
+Test 1: detect_platform recognizes current environment
+  PASS: platform is valid enum
+  (detected: msys)
+
+Test 2: _msys_to_winpid handles current PID
+  PASS: numeric winpid (34744)
+
+Test 3: write + read pidfile round-trip
+  PASS: pidfile exists
+  PASS: msys_pid round-trips
+  PASS: cmd round-trips
+  PASS: missing pidfile -> {}
+
+Test 4: is_agent_alive tracks liveness
+  PASS: alive while running
+  PASS: dead after kill
+
+Test 5: is_agent_alive on missing pidfile
+  PASS: missing pidfile -> not alive
+
+Test 6: reap_agent on already-dead process cleans pidfile
+  PASS: reap exits 0
+  PASS: pidfile removed
+
+Test 7: reap_agent terminates a live process
+  PASS: reap_agent exits 0
+  PASS: process not alive
+  PASS: pidfile removed
+
+Test 8: reap_orphans cleans stale pidfiles only
+  PASS: no stale-orphans reaped
+  PASS: dead pidfile removed
+  PASS: live pidfile kept
+
+Test 9: reap_orphans safe on missing/empty dir
+  PASS: missing dir -> 0
+  PASS: empty dir -> 0
+
+Test 10: lib/spawn.sh contains the exec-replacement fix
+  PASS: exec prepended to claude invocation
+  PASS: runner-path uses eval "exec $cmd"
+  PASS: spawn writes pidfile
+
+Test 11: quantum-loop.sh trap uses reaper
+  PASS: cleanup_on_exit calls reap_agent
+  PASS: startup calls reap_orphans
+
+Test 13: _proc_start_epoch is per-process (not a constant)
+  PASS: distinct processes have distinct start epochs (15728164 vs 15729222)
+
+Test 14: cleanup_on_exit uses parallel reap pattern
+  PASS: cleanup_on_exit parallelizes reap_agent calls
+
+Test 15: timeout branch uses reap_agent on Git Bash
+  PASS: TIMED_OUT branch prefers reap_agent
+
+Test 12: CLI subcommands work
+  PASS: CLI platform output: msys
+
+=== Results: 28/28 passed, 0 failed ===

--- a/.omc/phase-26-evidence/test_trajectory.log
+++ b/.omc/phase-26-evidence/test_trajectory.log
@@ -1,0 +1,49 @@
+=== Phase 24 trajectory-kill tests ===
+
+Test 1: parse on missing file
+  PASS: exists=false
+  PASS: total=0
+
+Test 2: parse counts tools
+  PASS: reads=5
+  PASS: greps=3
+  PASS: edits=2
+  PASS: writes=1
+  PASS: bashes=4
+  PASS: total=15
+  PASS: read_pct=53
+  PASS: edit_pct=20
+
+Test 3: productive trajectory
+  PASS: classify productive
+  PASS: productive -> no kill (exit 1)
+
+Test 4: searching trajectory
+  PASS: classify searching (below thrash min)
+  PASS: searching -> no kill
+
+Test 5: thrashing trajectory
+  PASS: classify thrashing
+  PASS: thrashing -> kill (exit 0)
+
+Test 6: stuck trajectory
+  PASS: classify stuck
+  PASS: stuck -> kill (exit 0)
+
+Test 7: env-var overrides take effect
+  PASS: default: searching
+  PASS: override THRASH_MIN=5: thrashing
+
+Test 8: empty file handling
+  PASS: empty file total=0
+  PASS: empty file classify=productive (no signal)
+
+Test 9: CLI subcommands
+  PASS: CLI parse total=26
+  PASS: CLI classify thrashing
+  PASS: CLI kill exits 0 for thrashing
+
+Test 10: classify reads stdin
+  PASS: stdin classify productive
+
+=== Results: 26/26 passed, 0 failed ===

--- a/.omc/phase-26-evidence/test_watchdog.log
+++ b/.omc/phase-26-evidence/test_watchdog.log
@@ -1,0 +1,55 @@
+=== Phase 16 watchdog + circuit-breaker tests ===
+
+Test 1: classify_age thresholds
+  PASS: 0s -> fresh
+  PASS: 300s -> fresh
+  PASS: 301s -> stale-check
+  PASS: 600s -> stale-check
+  PASS: 601s -> stale-reassign
+  PASS: 1200s -> stale-reassign
+  PASS: 1201s -> stale-reassign
+  PASS: 1800s -> stale-reassign
+  PASS: 1801s -> timed-out
+  PASS: 7200s -> timed-out
+
+Test 2: watchdog_poll on empty state
+  PASS: missing quantum.json -> []
+
+Test 3: watchdog_poll fresh in_progress story
+  PASS: only the in_progress story returned
+  PASS: story_id is US-001
+  PASS: fresh -> continue
+  PASS: classification fresh
+
+Test 4: watchdog_poll stale-check (~400s old)
+  PASS: 400s -> stale-check
+  PASS: stale-check -> status-probe
+
+Test 5: watchdog_poll timed-out (>30min old)
+  PASS: 2400s -> timed-out
+  PASS: timed-out -> mark-failed
+
+Test 6: error_counter_bump same signature increments
+  PASS: first bump count 1
+  PASS: second bump count 2
+  PASS: third bump count 3
+
+Test 7: different signature resets counter
+  PASS: sig-A count reaches 2
+  PASS: sig-B resets to 1
+  PASS: sig-B next bump is 2
+
+Test 8: should_circuit_break crosses threshold
+  PASS: count=1, threshold=3 -> no break (exit 1)
+  PASS: count=3, threshold=3 -> BREAK (exit 0)
+  PASS: count=3, threshold=10 -> no break
+
+Test 9: error_counter_reset
+  PASS: after reset, no break
+  PASS: count after reset=1
+
+Test 10: CLI subcommands
+  PASS: CLI classify 500 -> stale-check
+  PASS: CLI bump first -> 1
+
+=== Results: 32/32 passed, 0 failed ===

--- a/lib/conflict-grade.sh
+++ b/lib/conflict-grade.sh
@@ -1,0 +1,304 @@
+#!/usr/bin/env bash
+# lib/conflict-grade.sh — merge-conflict severity grading (Phase 26 / P3.2).
+#
+# Source: ConGra (arXiv:2409.14121) — grade each conflict hunk by
+# operation complexity before routing resolution. Cheap grades can be
+# auto-merged by git; expensive grades need LLM assistance; structural
+# grades escalate to operator.
+#
+# Grade scale:
+#   1  whitespace / formatting only
+#   2  single-token rename or comment-only change
+#   3  small body edit (≤5 lines each side)
+#   4  moderate overlap (>5 lines each side, within one function)
+#   5  structural reorganization (spans multiple function/class boundaries)
+#
+# Complements lib/merge-strategy.sh (classify_and_merge) which routes by
+# FILE KIND (dependency_manifest, barrel_export, etc). ConGra routes by
+# CONFLICT SHAPE within a file.
+#
+# Functions:
+#   split_conflict_hunks FILE
+#     Emits one JSON object per conflict marker block:
+#       {start_line, end_line, ours, theirs}
+#   grade_hunk_text OURS THEIRS
+#     Returns an integer 1-5 for a single hunk.
+#   grade_file FILE
+#     Emits JSON: {max_grade, hunks: [{start_line, end_line, grade}, ...]}
+#   routing_recommendation GRADE
+#     Echoes one of: auto-git | diff3 | llm-merge | escalate
+#
+# Library contract: no shell flags at source time; CLI block enables
+# strict mode locally.
+
+CONFLICT_GRADE_LIB_DIR="${CONFLICT_GRADE_LIB_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+
+# _count_nonempty_lines(text)
+# Count lines that contain at least one non-whitespace character.
+_count_nonempty_lines() {
+  local text="${1:-}"
+  [[ -z "$text" ]] && { printf "0"; return; }
+  printf '%s' "$text" | awk 'NF > 0 { c++ } END { print c+0 }'
+}
+
+# _strip_ws(text)
+# Strip ALL whitespace. Used to detect whitespace-only differences
+# (Grade 1). Two snippets comparing equal after this strip differ only in
+# indentation / newline / spacing.
+#
+# Known edge case: `return x` vs `returnx` both strip to `returnx`. In
+# practice this happens in hand-crafted adversarial inputs, not in real
+# merge conflicts — accepted as a narrow false-positive for Grade 1.
+_strip_ws() {
+  local text="${1:-}"
+  printf '%s' "$text" | tr -d '[:space:]'
+}
+
+# _strip_comments(text)
+# Remove line comments (# and //) and block comments (/* ... */) for
+# grade-2 detection (comment-only change).
+_strip_comments() {
+  local text="${1:-}"
+  printf '%s' "$text" | awk '
+    BEGIN { in_block = 0 }
+    {
+      line = $0
+      out = ""
+      i = 1
+      while (i <= length(line)) {
+        c2 = substr(line, i, 2)
+        c  = substr(line, i, 1)
+        if (in_block) {
+          if (c2 == "*/") { in_block = 0; i += 2 } else { i += 1 }
+        } else if (c2 == "/*") {
+          in_block = 1; i += 2
+        } else if (c2 == "//" || c == "#") {
+          break
+        } else {
+          out = out c
+          i += 1
+        }
+      }
+      print out
+    }
+  '
+}
+
+# _function_boundary_count(text)
+# Count function/class/method definition starts in the text. Heuristic for
+# grade-5 detection (structural reorganization). Patterns cover TS/JS/Py/
+# Go/Rust/Java/C.
+_function_boundary_count() {
+  local text="${1:-}"
+  [[ -z "$text" ]] && { printf "0"; return; }
+  # grep -c ALWAYS prints a count to stdout (including "0"), so don't
+  # add a `|| echo 0` fallback — that would yield "0\n0" on no-match
+  # and break the numeric comparison in the caller.
+  { printf '%s' "$text" | grep -cE '^\s*(function |def |class |interface |struct |func |pub fn |impl |module )' ; } || true
+}
+
+# split_conflict_hunks(file)
+# Parses a file with conflict markers; for each hunk emits a JSON object:
+#   {start_line, end_line, ours, theirs}
+# Returns a JSON array of such objects.
+split_conflict_hunks() {
+  local file="${1:?file required}"
+  [[ -f "$file" ]] || { printf "[]"; return 0; }
+
+  local out='[]'
+  local in_conflict=0
+  local in_theirs=0
+  local start_line=0
+  local line_no=0
+  local ours_buf=""
+  local theirs_buf=""
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line_no=$((line_no + 1))
+    case "$line" in
+      "<<<<<<<"*)
+        in_conflict=1; in_theirs=0
+        start_line=$line_no
+        ours_buf=""
+        theirs_buf=""
+        ;;
+      "======="*)
+        in_theirs=1
+        ;;
+      ">>>>>>>"*)
+        # Emit the hunk
+        out=$(jq -c \
+          --argjson s "$start_line" --argjson e "$line_no" \
+          --arg ours "$ours_buf" --arg theirs "$theirs_buf" \
+          '. + [{start_line: $s, end_line: $e, ours: $ours, theirs: $theirs}]' \
+          <<< "$out")
+        in_conflict=0; in_theirs=0
+        ;;
+      *)
+        if (( in_conflict )); then
+          if (( in_theirs )); then
+            theirs_buf+="${line}"$'\n'
+          else
+            ours_buf+="${line}"$'\n'
+          fi
+        fi
+        ;;
+    esac
+  done < "$file"
+
+  printf '%s' "$out"
+}
+
+# grade_hunk_text(ours_text, theirs_text)
+# Returns 1-5 integer grade for a single hunk.
+grade_hunk_text() {
+  local ours="${1:-}"
+  local theirs="${2:-}"
+
+  # Grade 1: whitespace only
+  local ours_ws theirs_ws
+  ours_ws=$(_strip_ws "$ours")
+  theirs_ws=$(_strip_ws "$theirs")
+  if [[ "$ours_ws" == "$theirs_ws" ]]; then
+    printf "1"; return 0
+  fi
+
+  # Grade 2: comment-only or single-token rename
+  local ours_nc theirs_nc
+  ours_nc=$(_strip_comments "$ours" | tr -s '[:space:]' ' ' | sed 's/^ //; s/ $//')
+  theirs_nc=$(_strip_comments "$theirs" | tr -s '[:space:]' ' ' | sed 's/^ //; s/ $//')
+  if [[ "$ours_nc" == "$theirs_nc" ]]; then
+    # Code identical once comments stripped
+    printf "2"; return 0
+  fi
+  # Single-token diff check: if both sides have same word count AND differ
+  # in exactly one word at the same position, it's a rename.
+  local ours_words theirs_words ours_n theirs_n
+  ours_words=$(printf '%s' "$ours_nc" | tr -s ' ' '\n' | grep -v '^$')
+  theirs_words=$(printf '%s' "$theirs_nc" | tr -s ' ' '\n' | grep -v '^$')
+  ours_n=$(printf '%s\n' "$ours_words" | wc -l)
+  theirs_n=$(printf '%s\n' "$theirs_words" | wc -l)
+  # Sanitize wc output (leading/trailing whitespace)
+  ours_n=$(echo "$ours_n" | tr -d '[:space:]')
+  theirs_n=$(echo "$theirs_n" | tr -d '[:space:]')
+  [[ -z "$ours_n" ]]   && ours_n=0
+  [[ -z "$theirs_n" ]] && theirs_n=0
+  if [[ "$ours_n" -eq "$theirs_n" && "$ours_n" -gt 0 ]]; then
+    local diff_count
+    # grep -c always prints a count (including "0") — no `|| echo 0` needed
+    diff_count=$({ diff <(printf '%s' "$ours_words") <(printf '%s' "$theirs_words") 2>/dev/null | grep -cE '^[<>]' ; } || true)
+    diff_count=$(echo "$diff_count" | tr -d '[:space:]')
+    [[ -z "$diff_count" ]] && diff_count=0
+    # Each differing word shows as `<` once and `>` once, so total 2 for one rename.
+    if (( diff_count <= 2 )); then
+      printf "2"; return 0
+    fi
+  fi
+
+  # Grade 5: structural reorganization (spans multiple function boundaries)
+  local ours_funcs theirs_funcs
+  ours_funcs=$(_function_boundary_count "$ours" | tr -d '[:space:]')
+  theirs_funcs=$(_function_boundary_count "$theirs" | tr -d '[:space:]')
+  [[ -z "$ours_funcs" ]]   && ours_funcs=0
+  [[ -z "$theirs_funcs" ]] && theirs_funcs=0
+  if (( ours_funcs >= 2 || theirs_funcs >= 2 )); then
+    printf "5"; return 0
+  fi
+
+  # Grade 3 vs 4: by line count of meaningful changes
+  local ours_lines theirs_lines
+  ours_lines=$(_count_nonempty_lines "$ours")
+  theirs_lines=$(_count_nonempty_lines "$theirs")
+  local max_lines=$ours_lines
+  (( theirs_lines > max_lines )) && max_lines=$theirs_lines
+  if (( max_lines <= 5 )); then
+    printf "3"; return 0
+  fi
+  printf "4"
+}
+
+# grade_file(file)
+# Emits JSON:
+#   {max_grade, hunks: [{start_line, end_line, grade}, ...]}
+# Empty hunks array if file has no conflicts.
+grade_file() {
+  local file="${1:?file required}"
+  local hunks
+  hunks=$(split_conflict_hunks "$file")
+  local n
+  n=$(printf '%s' "$hunks" | jq 'length')
+  if (( n == 0 )); then
+    printf '{"max_grade":0,"hunks":[]}'
+    return 0
+  fi
+
+  local i=0
+  local out='[]'
+  local max_g=0
+  while (( i < n )); do
+    local h ours theirs grade s e
+    h=$(printf '%s' "$hunks" | jq -c ".[$i]")
+    ours=$(printf '%s' "$h" | jq -r '.ours')
+    theirs=$(printf '%s' "$h" | jq -r '.theirs')
+    s=$(printf '%s' "$h" | jq -r '.start_line')
+    e=$(printf '%s' "$h" | jq -r '.end_line')
+    grade=$(grade_hunk_text "$ours" "$theirs")
+    (( grade > max_g )) && max_g=$grade
+    out=$(jq -c \
+      --argjson s "$s" --argjson e "$e" --argjson g "$grade" \
+      '. + [{start_line: $s, end_line: $e, grade: $g}]' \
+      <<< "$out")
+    i=$((i + 1))
+  done
+  jq -cn --argjson m "$max_g" --argjson hunks "$out" \
+    '{max_grade: $m, hunks: $hunks}'
+}
+
+# routing_recommendation(grade)
+# Given a grade (1-5 or 0), echo the recommended resolution path:
+#   0  — no conflict (nothing to route)
+#   1  — auto-git (git merge -X ours|theirs by policy)
+#   2  — auto-git
+#   3  — diff3 (3-way textual merge)
+#   4  — llm-merge (semantic/AST-aware via lib/merge-semantic.sh)
+#   5  — escalate (operator intervention)
+routing_recommendation() {
+  local grade="${1:?grade required}"
+  case "$grade" in
+    0)   printf "none" ;;
+    1|2) printf "auto-git" ;;
+    3)   printf "diff3" ;;
+    4)   printf "llm-merge" ;;
+    5)   printf "escalate" ;;
+    *)   printf "unknown" ;;
+  esac
+}
+
+# ------------------------------------------------------------------------------
+# CLI entry
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  set -euo pipefail
+  subcmd="${1:-}"
+  shift || true
+  case "$subcmd" in
+    split)   split_conflict_hunks "$@" ;;
+    grade)   grade_file "$@" ;;
+    grade-hunk)
+      # grade-hunk OURS_FILE THEIRS_FILE
+      _ours=$(cat "${1:?ours file}")
+      _theirs=$(cat "${2:?theirs file}")
+      grade_hunk_text "$_ours" "$_theirs"; printf "\n"
+      ;;
+    route)   routing_recommendation "$@"; printf "\n" ;;
+    *)
+      cat >&2 <<USAGE
+Usage: bash lib/conflict-grade.sh <subcmd> [args...]
+  split FILE                          — emit JSON array of hunks
+  grade FILE                          — grade every conflict in FILE
+  grade-hunk OURS_FILE THEIRS_FILE    — grade a single pre-split hunk
+  route GRADE                         — recommend auto-git|diff3|llm-merge|escalate
+USAGE
+      exit 2
+      ;;
+  esac
+fi

--- a/tests/test_conflict_grade.sh
+++ b/tests/test_conflict_grade.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# Phase 26 / P3.2 — conflict-grade tests.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR/.."
+PASS=0
+FAIL=0
+TOTAL=0
+
+assert() {
+  local name="$1" expected="$2" actual="$3"
+  TOTAL=$((TOTAL + 1))
+  if [[ "$expected" == "$actual" ]]; then
+    echo "  PASS: $name"; PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $name (expected [$expected] got [$actual])"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# shellcheck disable=SC1091
+source "$REPO_ROOT/lib/conflict-grade.sh"
+
+echo "=== Phase 26 conflict-grade tests ==="
+
+# Test 1: Grade 1 — whitespace-only difference
+echo ""
+echo "Test 1: whitespace-only → grade 1"
+g=$(grade_hunk_text "let x = 42" "let x  =  42")
+assert "single-ws diff" "1" "$g"
+g=$(grade_hunk_text $'function a() {\n  return 1\n}' $'function a(){\nreturn 1\n}')
+assert "bracket-indent diff" "1" "$g"
+
+# Test 2: Grade 2 — comment-only change
+echo ""
+echo "Test 2: comment-only → grade 2"
+g=$(grade_hunk_text "let x = 42 // old" "let x = 42 // new")
+assert "line comment change" "2" "$g"
+g=$(grade_hunk_text "let x = 42 # the answer" "let x = 42 # the truth")
+assert "python-style comment change" "2" "$g"
+g=$(grade_hunk_text "let x = 42 /* A */" "let x = 42 /* B */")
+assert "block comment change" "2" "$g"
+
+# Test 3: Grade 2 — single-token rename
+echo ""
+echo "Test 3: single-token rename → grade 2"
+g=$(grade_hunk_text "const count = 5" "const total = 5")
+assert "single identifier rename" "2" "$g"
+
+# Test 4: Grade 3 — small body edit (≤5 non-empty lines each side)
+echo ""
+echo "Test 4: small body edit → grade 3"
+g=$(grade_hunk_text $'foo(1)\nbar(2)' $'baz(1)\nqux(2)\nquux(3)')
+assert "3-line small body edit" "3" "$g"
+
+# Test 5: Grade 4 — moderate overlap (>5 lines, same region)
+echo ""
+echo "Test 5: moderate overlap → grade 4"
+ours=$'a=1\nb=2\nc=3\nd=4\ne=5\nf=6\ng=7'
+theirs=$'A=1\nB=2\nC=3\nD=4\nE=5\nF=6\nG=7'
+g=$(grade_hunk_text "$ours" "$theirs")
+assert "7-line overlap" "4" "$g"
+
+# Test 6: Grade 5 — structural (≥2 function boundaries)
+echo ""
+echo "Test 6: structural reorg → grade 5"
+ours=$'function alpha() { return 1 }\nfunction beta() { return 2 }'
+theirs=$'function beta() { return 2 }\nfunction alpha() { return 1 }'
+g=$(grade_hunk_text "$ours" "$theirs")
+assert "2-function reorder" "5" "$g"
+# Python variant
+ours_py=$'def alpha():\n    pass\ndef beta():\n    pass'
+theirs_py=$'def gamma():\n    pass\ndef delta():\n    pass'
+g=$(grade_hunk_text "$ours_py" "$theirs_py")
+assert "2-def reorg (python)" "5" "$g"
+
+# Test 7: split_conflict_hunks — single conflict
+echo ""
+echo "Test 7: split_conflict_hunks single"
+TEST_TMPDIR=$(mktemp -d)
+cat > "$TEST_TMPDIR/file.txt" << 'EOF'
+line before
+<<<<<<< HEAD
+our version line 1
+our version line 2
+=======
+their version line 1
+>>>>>>> branch
+line after
+EOF
+hunks=$(split_conflict_hunks "$TEST_TMPDIR/file.txt")
+count=$(printf '%s' "$hunks" | jq 'length')
+assert "1 conflict parsed" "1" "$count"
+ours=$(printf '%s' "$hunks" | jq -r '.[0].ours')
+theirs=$(printf '%s' "$hunks" | jq -r '.[0].theirs')
+case "$ours" in *"our version line 1"*"our version line 2"*) echo "  PASS: ours buffer captured"; PASS=$((PASS + 1));;
+                *) echo "  FAIL: ours=[$ours]"; FAIL=$((FAIL + 1));;
+esac
+TOTAL=$((TOTAL + 1))
+case "$theirs" in *"their version line 1"*) echo "  PASS: theirs buffer captured"; PASS=$((PASS + 1));;
+                  *) echo "  FAIL: theirs=[$theirs]"; FAIL=$((FAIL + 1));;
+esac
+TOTAL=$((TOTAL + 1))
+start=$(printf '%s' "$hunks" | jq -r '.[0].start_line')
+end=$(printf '%s' "$hunks" | jq -r '.[0].end_line')
+assert "start_line=2" "2" "$start"
+assert "end_line=7" "7" "$end"
+rm -rf "$TEST_TMPDIR"
+
+# Test 8: split_conflict_hunks — multiple conflicts
+echo ""
+echo "Test 8: split_conflict_hunks multiple"
+TEST_TMPDIR=$(mktemp -d)
+cat > "$TEST_TMPDIR/file.txt" << 'EOF'
+a
+<<<<<<< HEAD
+x
+=======
+y
+>>>>>>> b
+middle
+<<<<<<< HEAD
+p
+=======
+q
+>>>>>>> b
+end
+EOF
+hunks=$(split_conflict_hunks "$TEST_TMPDIR/file.txt")
+count=$(printf '%s' "$hunks" | jq 'length')
+assert "2 conflicts parsed" "2" "$count"
+rm -rf "$TEST_TMPDIR"
+
+# Test 9: grade_file — end-to-end with mixed grades
+echo ""
+echo "Test 9: grade_file end-to-end"
+TEST_TMPDIR=$(mktemp -d)
+cat > "$TEST_TMPDIR/file.ts" << 'EOF'
+line 1
+<<<<<<< HEAD
+let x = 42 // old comment
+=======
+let x = 42 // new comment
+>>>>>>> branch
+middle
+<<<<<<< HEAD
+function alpha() { return 1 }
+function beta() { return 2 }
+=======
+function gamma() { return 3 }
+function delta() { return 4 }
+>>>>>>> branch
+end
+EOF
+graded=$(grade_file "$TEST_TMPDIR/file.ts")
+max_g=$(printf '%s' "$graded" | jq -r '.max_grade')
+n_hunks=$(printf '%s' "$graded" | jq -r '.hunks | length')
+assert "2 hunks graded" "2" "$n_hunks"
+assert "max_grade = 5 (structural)" "5" "$max_g"
+first_grade=$(printf '%s' "$graded" | jq -r '.hunks[0].grade')
+second_grade=$(printf '%s' "$graded" | jq -r '.hunks[1].grade')
+assert "first hunk grade 2 (comment)" "2" "$first_grade"
+assert "second hunk grade 5 (structural)" "5" "$second_grade"
+rm -rf "$TEST_TMPDIR"
+
+# Test 10: grade_file — no conflicts
+echo ""
+echo "Test 10: grade_file clean file"
+TEST_TMPDIR=$(mktemp -d)
+echo "no conflicts here" > "$TEST_TMPDIR/clean.txt"
+graded=$(grade_file "$TEST_TMPDIR/clean.txt")
+max_g=$(printf '%s' "$graded" | jq -r '.max_grade')
+n_hunks=$(printf '%s' "$graded" | jq -r '.hunks | length')
+assert "clean file max_grade=0" "0" "$max_g"
+assert "clean file 0 hunks" "0" "$n_hunks"
+rm -rf "$TEST_TMPDIR"
+
+# Test 11: routing_recommendation
+echo ""
+echo "Test 11: routing_recommendation"
+assert "grade 0 → none"      "none"      "$(routing_recommendation 0)"
+assert "grade 1 → auto-git"  "auto-git"  "$(routing_recommendation 1)"
+assert "grade 2 → auto-git"  "auto-git"  "$(routing_recommendation 2)"
+assert "grade 3 → diff3"     "diff3"     "$(routing_recommendation 3)"
+assert "grade 4 → llm-merge" "llm-merge" "$(routing_recommendation 4)"
+assert "grade 5 → escalate"  "escalate"  "$(routing_recommendation 5)"
+
+# Test 12: CLI subcommands
+echo ""
+echo "Test 12: CLI subcommands"
+TEST_TMPDIR=$(mktemp -d)
+cat > "$TEST_TMPDIR/f.txt" << 'EOF'
+<<<<<<< HEAD
+foo
+=======
+bar
+>>>>>>> b
+EOF
+cli_graded=$(bash "$REPO_ROOT/lib/conflict-grade.sh" grade "$TEST_TMPDIR/f.txt")
+mg=$(printf '%s' "$cli_graded" | jq -r '.max_grade')
+# single word rename — grade 2
+assert "CLI grade single-word rename" "2" "$mg"
+route=$(bash "$REPO_ROOT/lib/conflict-grade.sh" route 4 | tr -d '\n')
+assert "CLI route 4 → llm-merge" "llm-merge" "$route"
+rm -rf "$TEST_TMPDIR"
+
+echo ""
+echo "=== Results: $PASS/$TOTAL passed, $FAIL failed ==="
+exit $((FAIL > 0 ? 1 : 0))


### PR DESCRIPTION
Fifth P3 wedge. Grades each conflict hunk 1-5 by operation complexity so merge routing can escalate by shape, not just by file kind.

## lib/conflict-grade.sh

- `split_conflict_hunks` — parse <<<<<<< ======= >>>>>>> markers
- `grade_hunk_text` — 1 (whitespace) / 2 (rename or comment) / 3 (small) / 4 (moderate) / 5 (structural)
- `grade_file` — max grade + per-hunk breakdown
- `routing_recommendation` — auto-git | diff3 | llm-merge | escalate

Orthogonal to Phase 9 `classify_and_merge` (file-kind routing).

## Tests: 30 new, 327 total across 11 suites, all green