### PR TITLE
Phase 27 — TraceCoder Observe-Analyze-Repair (P3.8, arXiv:2602.06875)

### DIFF
--- a/.omc/phase-27-evidence/test_ambiguity.log
+++ b/.omc/phase-27-evidence/test_ambiguity.log
@@ -1,0 +1,68 @@
+=== Phase 19 ambiguity-gate tests ===
+
+Test 1: score_ambiguity arithmetic
+  PASS: all 10s -> 0
+  PASS: all 0s -> 100
+  PASS: all 5s -> 50
+  PASS: goal only -> 60
+  PASS: constraints only -> 70
+  PASS: criteria only -> 70
+
+Test 2: score_ambiguity input validation
+  PASS: 11 rejected
+  PASS: -1 rejected
+  PASS: abc rejected
+
+Test 3: check_gate semantics
+  PASS: score 0 passes
+  PASS: score 19 passes
+  PASS: score 20 blocks
+  PASS: score 50 blocks
+  PASS: score 100 blocks
+  PASS: 30 < 50 passes
+  PASS: 60 >= 50 blocks
+
+Test 4: challenge_mode thresholds
+  PASS: round 1, score 100 -> normal
+  PASS: round 2, score 80  -> normal
+  PASS: round 3, score 45  -> contrarian
+  PASS: round 3, score 35  -> normal
+  PASS: round 4, score 35  -> simplifier
+  PASS: round 4, score 25  -> normal
+  PASS: round 5, score 25  -> ontologist
+  PASS: round 5, score 15  -> normal
+  PASS: round 6, score 50  -> ontologist
+
+Test 5: ontology_extract
+  PASS: extract tokens sorted+unique
+  PASS: empty -> empty
+  PASS: stopwords dropped
+
+Test 6: ontology_diff
+  PASS: 1 added
+  PASS: 1 removed
+  PASS: 2 carried
+  PASS: stability 0.50
+  PASS: identical stability 1.0
+  PASS: empty prior stability 0.00
+
+Test 7: CLI subcommands
+  PASS: CLI score 5 5 5 = 50
+  PASS: CLI gate 10 passes
+  PASS: CLI gate 25 blocks
+  PASS: CLI mode 5 30 = ontologist
+
+Test 8: ql-brainstorm wires lib/ambiguity.sh
+  PASS: Phase 0B ambiguity gate section
+  PASS: calls lib/ambiguity.sh score
+  PASS: calls lib/ambiguity.sh gate
+  PASS: calls lib/ambiguity.sh mode
+  PASS: ontology stability tracking
+  PASS: ontology diff call
+  PASS: contrarian mode described
+  PASS: simplifier mode described
+  PASS: ontologist mode described
+  PASS: thrashing ontology escalation
+  PASS: handoff records final_score
+
+=== Results: 49/49 passed, 0 failed ===

--- a/.omc/phase-27-evidence/test_conflict_grade.log
+++ b/.omc/phase-27-evidence/test_conflict_grade.log
@@ -1,0 +1,57 @@
+=== Phase 26 conflict-grade tests ===
+
+Test 1: whitespace-only → grade 1
+  PASS: single-ws diff
+  PASS: bracket-indent diff
+
+Test 2: comment-only → grade 2
+  PASS: line comment change
+  PASS: python-style comment change
+  PASS: block comment change
+
+Test 3: single-token rename → grade 2
+  PASS: single identifier rename
+
+Test 4: small body edit → grade 3
+  PASS: 3-line small body edit
+
+Test 5: moderate overlap → grade 4
+  PASS: 7-line overlap
+
+Test 6: structural reorg → grade 5
+  PASS: 2-function reorder
+  PASS: 2-def reorg (python)
+
+Test 7: split_conflict_hunks single
+  PASS: 1 conflict parsed
+  PASS: ours buffer captured
+  PASS: theirs buffer captured
+  PASS: start_line=2
+  PASS: end_line=7
+
+Test 8: split_conflict_hunks multiple
+  PASS: 2 conflicts parsed
+
+Test 9: grade_file end-to-end
+  PASS: 2 hunks graded
+  PASS: max_grade = 5 (structural)
+  PASS: first hunk grade 2 (comment)
+  PASS: second hunk grade 5 (structural)
+
+Test 10: grade_file clean file
+  PASS: clean file max_grade=0
+  PASS: clean file 0 hunks
+
+Test 11: routing_recommendation
+  PASS: grade 0 → none
+  PASS: grade 1 → auto-git
+  PASS: grade 2 → auto-git
+  PASS: grade 3 → diff3
+  PASS: grade 4 → llm-merge
+  PASS: grade 5 → escalate
+
+Test 12: CLI subcommands
+  PASS: CLI grade single-word rename
+  PASS: CLI route 4 → llm-merge
+
+=== Results: 30/30 passed, 0 failed ===

--- a/.omc/phase-27-evidence/test_constitution.log
+++ b/.omc/phase-27-evidence/test_constitution.log
@@ -1,0 +1,51 @@
+=== Phase 22 constitution tests ===
+
+Test 1: load_constitution
+  PASS: loads 2 rules
+  PASS: missing constitution -> empty
+  PASS: missing file -> empty
+  PASS: object form with .rule
+
+Test 2: check_no_secrets detects provider tokens
+  PASS: detects sk-live token
+  PASS: detects ghp_ token
+  PASS: ignores comment about passwords (no literal)
+
+Test 3: generic password/api_key literal
+  PASS: password= long literal flagged
+  PASS: api_key= long literal flagged
+  PASS: short literal not flagged
+
+Test 4: check_sql_injection
+  PASS: flags 2 SQL injections (template + concat)
+  PASS: parameterized query not flagged
+
+Test 5: check_input_validation
+  PASS: flags 2 unvalidated handler reads
+
+Test 6: check_commit_integrity
+  PASS: flags migration file
+  PASS: flags schema.prisma
+  PASS: flags .env.example
+  PASS: does NOT flag regular source file
+
+Test 7: enforce_constitution end-to-end
+  PASS: enforce finds 2 secret+sql findings
+  PASS: input-validation skipped when not active
+  PASS: input-validation active -> finds req.body
+  PASS: no constitution -> empty JSON array
+  PASS: unknown rule -> empty findings (warn only)
+
+Test 8: finding metadata
+  PASS: severity critical
+  PASS: description set
+  PASS: rule id set
+
+Test 9: CLI enforce
+  PASS: CLI enforce returns findings
+
+Test 10: quantum.json.example schema
+  PASS: constitution is array
+  PASS: quantum.json.example still valid JSON
+
+=== Results: 28/28 passed, 0 failed ===

--- a/.omc/phase-27-evidence/test_deep_review.log
+++ b/.omc/phase-27-evidence/test_deep_review.log
@@ -1,0 +1,52 @@
+=== Phase 8 ql-deep-review helper tests ===
+
+Test 1: tier_of_score mapping
+  PASS: 0 -> LOW
+  PASS: 30 -> LOW
+  PASS: 31 -> MEDIUM
+  PASS: 60 -> MEDIUM
+  PASS: 61 -> HIGH
+  PASS: 80 -> HIGH
+  PASS: 81 -> CRITICAL
+  PASS: 100 -> CRITICAL
+
+Test 2: compute_risk_score bounds
+  PASS: empty refs -> 0
+  PASS: intent drift contributes 10
+
+Test 3: actionability_filter
+  PASS: kept count
+  PASS: suppressed count
+  PASS: suppressed has reason
+
+Test 4: dedup_findings
+  PASS: dedup reduces 3 -> 2
+  PASS: merged agents count
+  PASS: kept max confidence
+
+Test 5: hallucination_check suppresses missing files
+  PASS: 1 file kept
+  PASS: 1 file suppressed as hallucination
+  PASS: suppressed reason
+
+Test 6: synthesize_verdict
+  PASS: empty -> APPROVE
+  PASS: only low -> APPROVE
+  PASS: medium 60 -> APPROVE_WITH_COMMENTS
+  PASS: high 75 -> REQUEST_CHANGES
+  PASS: critical 85 -> BLOCKS_MERGE
+  PASS: critical 50 (below threshold) -> APPROVE
+
+Test 7: quantum.json.example schema
+  PASS: reviews is object
+  PASS: quantum.json.example still valid JSON
+
+Test 8: ql-execute mentions the post-pipeline hook
+  PASS: post-pipeline hook header present
+  PASS: references lib/deep-review.sh
+
+Test 9: CLI subcommands work
+  PASS: CLI tier 50 -> MEDIUM
+  PASS: CLI tier 100 -> CRITICAL
+
+=== Results: 31/31 passed, 0 failed ===

--- a/.omc/phase-27-evidence/test_dogfood_e2e.log
+++ b/.omc/phase-27-evidence/test_dogfood_e2e.log
@@ -1,0 +1,38 @@
+=== Phase 10 dogfood end-to-end check ===
+
+Test 1: dogfood quantum.json parses
+  PASS: valid JSON
+
+Test 2: schema fields from Phases 7-9
+  PASS: userIntent.text present
+  PASS: userClarifications is array
+  PASS: intentDrift has entry
+  PASS: reviews has deepReview
+  PASS: deslop field present
+  PASS: codebasePatterns has entries
+  PASS: progress has entries
+
+Test 3: intent-drift gate semantics
+  PASS: NO_DRIFT gate allows merge
+
+Test 4: deep-review synthesize_verdict consumes the dogfood findings array
+  PASS: two HIGH confidence≥70 findings → REQUEST_CHANGES
+
+Test 5: dedup_findings idempotent on dogfood findings
+  PASS: dedup preserves 2-element unique set
+
+Test 6: plan retrospective — 10 stories all passed
+  PASS: 10 stories total
+  PASS: 10 stories passed
+
+Test 7: codebasePatterns contains real Phase-5 lesson
+  PASS: Phase-5 set-e lesson present
+
+Test 8: userIntent verbatim contains the original verbatim message
+  PASS: intent snapshot references IDEA_REPORT.md
+
+Test 9: companion PRD exists and references the dogfood artifact
+  PASS: PRD exists
+  PASS: PRD has AC-15 dogfood + references phase-10-evidence
+
+=== Results: 17/17 passed, 0 failed ===

--- a/.omc/phase-27-evidence/test_far_filter.log
+++ b/.omc/phase-27-evidence/test_far_filter.log
@@ -1,0 +1,41 @@
+=== Phase 23 KBI-FAR far_filter tests ===
+
+Test 1: confidence cutoff
+  PASS: 1 kept (conf ≥60)
+  PASS: 2 suppressed (conf <60)
+  PASS: reason mentions confidence
+
+Test 2: agreement boost lifts across cutoff
+  PASS: agreement-boosted finding kept
+  PASS: confidence boosted 50 -> 65
+  PASS: original_confidence preserved
+  PASS: single-agent below-cutoff suppressed
+
+Test 3: confidence cap at 100
+  PASS: confidence capped at 100
+
+Test 4: knownFalsePositives regex suppression
+  PASS: genuine finding kept
+  PASS: 2 suppressed by regex
+  PASS: suppression reasons reference knownFalsePositives
+
+Test 5: missing quantum.json graceful fallback
+  PASS: finding kept with missing quantum.json
+
+Test 6: empty input
+  PASS: empty kept
+  PASS: empty suppressed
+
+Test 7: CLI subcommand
+  PASS: CLI far kept 1
+
+Test 8: aggregate_reviews wires far_filter
+  PASS: aggregate kept 1 real finding
+  PASS: aggregate suppressed 2 (cutoff + FP)
+  PASS: verdict REQUEST_CHANGES (high ≥70)
+  PASS: FP reason present
+
+Test 9: schema extension
+  PASS: knownFalsePositives is array
+
+=== Results: 20/20 passed, 0 failed ===

--- a/.omc/phase-27-evidence/test_hyclone.log
+++ b/.omc/phase-27-evidence/test_hyclone.log
@@ -1,0 +1,53 @@
+=== Phase 25 HyClone Stage-1 tests ===
+
+Test 1: alpha_normalize basics
+  PASS: whitespace-only renames x
+  PASS: extra whitespace collapsed
+  PASS: multiple identifiers numbered
+
+Test 2: repeated identifiers reuse placeholder
+  PASS: repeated identifier reuses placeholder
+
+Test 3: keywords preserved
+  PASS: keywords preserved
+
+Test 4: comments stripped
+  PASS: line comment // stripped
+  PASS: line comment # stripped
+  PASS: block comment stripped
+
+Test 5: string literals preserved
+  PASS: double-quoted string preserved
+  PASS: single-quoted string preserved
+
+Test 6: clone fingerprints match
+  PASS: different names → same fingerprint
+  PASS: different whitespace → same fingerprint
+
+Test 7: semantic difference → different fingerprints
+  PASS: operator difference changes fingerprint
+  PASS: while vs if different
+
+Test 8: find_clones detects a clone pair
+  PASS: finds 1 clone group
+  PASS: group has 2 members
+  PASS: fnA in clone group
+  PASS: fnB in clone group
+  PASS: fnC NOT in clone group
+
+Test 9: find_clones with all unique functions
+  PASS: no clone groups
+
+Test 10: find_clones with triple
+  PASS: 3-way clone grouped
+  PASS: triple has 3 members
+
+Test 11: CLI subcommands
+  PASS: CLI normalize
+  PASS: CLI fingerprint is 64 hex chars
+
+Test 12: empty input handling
+  PASS: empty normalize -> empty
+  PASS: empty find_clones -> []
+
+=== Results: 26/26 passed, 0 failed ===

--- a/.omc/phase-27-evidence/test_orchestrator_wiring.log
+++ b/.omc/phase-27-evidence/test_orchestrator_wiring.log
@@ -1,0 +1,65 @@
+=== Phase 17 orchestrator-wiring prompt tests ===
+
+Test 1: lib/wave-boundary.sh wired at wave boundary
+  PASS: 3C.NEG1 section present
+  PASS: references wave-boundary.sh scan
+  PASS: routes HIGH severity to fix-story
+
+Test 2: lib/watchdog.sh wired in monitor loop
+  PASS: watchdog tick header
+  PASS: references watchdog.sh poll
+  PASS: status-probe action branch
+  PASS: kill-and-requeue action branch
+  PASS: mark-failed action branch
+  PASS: circuit-breaker bump
+  PASS: circuit-breaker check
+
+Test 3: lib/deep-review.sh wired at full-feature review
+  PASS: 4B.5 deep-review section
+  PASS: score-from-quantum call
+  PASS: tier lookup
+  PASS: dispatch-set call
+  PASS: context preparation
+  PASS: aggregate pipe
+  PASS: BLOCKS_MERGE handled
+  PASS: REQUEST_CHANGES handled
+  PASS: persists into quantum.reviews
+
+Test 4: lib/deslop.sh wired between review-pass and commit
+  PASS: 3A.5B deslop section
+  PASS: validate_scope gate
+  PASS: baseline snapshot before
+  PASS: compare_baseline call
+  PASS: rollback on regression
+  PASS: DESLOP_ROLLED_BACK signal
+  PASS: opt-out via story.deslop.skip
+
+Test 5: lib/commit-trailers.sh validation gate
+  PASS: commit-trailers reference
+  PASS: non-blocking warning
+
+Test 6: handoff.sh ownership is skill-side (orchestrator doesn't write)
+  PASS: orchestrator does NOT write handoffs directly (skills do)
+
+Test 7: all wirings carry a Phase-17 attribution comment
+  PASS: 5 Phase-17 attributions
+
+Test 8: deslop wiring uses DESLOP_AVAILABLE + BASE_SHA
+  PASS: DESLOP_AVAILABLE guard present
+  PASS: DESLOP_AVAILABLE file check
+  PASS: Fallback skip branch
+  PASS: scope loop uses BASE_SHA
+  PASS: rollback uses BASE_SHA
+  PASS: no active STORY_BASE_SHA refs in 3A.5B
+
+Test 9: RUNNER_EXTRA_FLAGS validated after pre_spawn()
+  PASS: RUNNER_EXTRA_FLAGS validation present
+  PASS: blocklist present (regex form varies)
+
+Test 10: runner_build_cmd rejects injection via RUNNER_EXTRA_FLAGS
+  PASS: injection payload rejected with clear error
+
+Test 11: lib/watchdog.sh doc comment corrected
+  PASS: watchdog threshold comment matches code (>30 min = timed-out)
+
+=== Results: 40/40 passed, 0 failed ===

--- a/.omc/phase-27-evidence/test_reaper.log
+++ b/.omc/phase-27-evidence/test_reaper.log
@@ -1,0 +1,62 @@
+=== Phase 20 reaper + spawn exec-capture tests ===
+
+Test 1: detect_platform recognizes current environment
+  PASS: platform is valid enum
+  (detected: msys)
+
+Test 2: _msys_to_winpid handles current PID
+  PASS: numeric winpid (34448)
+
+Test 3: write + read pidfile round-trip
+  PASS: pidfile exists
+  PASS: msys_pid round-trips
+  PASS: cmd round-trips
+  PASS: missing pidfile -> {}
+
+Test 4: is_agent_alive tracks liveness
+  PASS: alive while running
+  PASS: dead after kill
+
+Test 5: is_agent_alive on missing pidfile
+  PASS: missing pidfile -> not alive
+
+Test 6: reap_agent on already-dead process cleans pidfile
+  PASS: reap exits 0
+  PASS: pidfile removed
+
+Test 7: reap_agent terminates a live process
+  PASS: reap_agent exits 0
+  PASS: process not alive
+  PASS: pidfile removed
+
+Test 8: reap_orphans cleans stale pidfiles only
+  PASS: no stale-orphans reaped
+  PASS: dead pidfile removed
+  PASS: live pidfile kept
+
+Test 9: reap_orphans safe on missing/empty dir
+  PASS: missing dir -> 0
+  PASS: empty dir -> 0
+
+Test 10: lib/spawn.sh contains the exec-replacement fix
+  PASS: exec prepended to claude invocation
+  PASS: runner-path uses eval "exec $cmd"
+  PASS: spawn writes pidfile
+
+Test 11: quantum-loop.sh trap uses reaper
+  PASS: cleanup_on_exit calls reap_agent
+  PASS: startup calls reap_orphans
+
+Test 13: _proc_start_epoch is per-process (not a constant)
+  PASS: distinct processes have distinct start epochs (19079540 vs 19080620)
+
+Test 14: cleanup_on_exit uses parallel reap pattern
+  PASS: cleanup_on_exit parallelizes reap_agent calls
+
+Test 15: timeout branch uses reap_agent on Git Bash
+  PASS: TIMED_OUT branch prefers reap_agent
+
+Test 12: CLI subcommands work
+  PASS: CLI platform output: msys
+
+=== Results: 28/28 passed, 0 failed ===

--- a/.omc/phase-27-evidence/test_tracecoder.log
+++ b/.omc/phase-27-evidence/test_tracecoder.log
@@ -1,0 +1,58 @@
+=== Phase 27 TraceCoder tests ===
+
+Test 1: observe a passing command
+  PASS: exit=0
+  PASS: name=greeting
+  PASS: tail contains hello
+
+Test 2: observe a failing command
+  PASS: exit=1
+
+Test 3: observe merges stderr
+  PASS: both streams in tail
+
+Test 4: extract tsc-style markers
+  PASS: 1 marker parsed
+  PASS: file=src/app.ts
+  PASS: line=42
+  PASS: message captured
+
+Test 5: extract python traceback
+  PASS: 1 marker parsed
+  PASS: python file
+  PASS: python line
+
+Test 6: extract node stack
+  PASS: node stack parsed
+  PASS: node file
+  PASS: node line
+
+Test 7: multiple markers + URL noise filtering
+  PASS: 2 real markers (URL filtered)
+
+Test 8: empty tail
+  PASS: empty tail -> []
+
+Test 9: build_analysis_context shape
+  PASS: header present
+  PASS: exit code visible
+  PASS: tail section present
+
+Test 10: context includes markers
+  PASS: marker rendered in context
+
+Test 11: should_repair semantics
+  PASS: failure + markers -> 0
+  PASS: pass -> no repair (1)
+  PASS: opaque failure -> no repair (1)
+
+Test 12: tail truncates to TRACECODER_TAIL_LINES
+  PASS: tail is 10 lines
+  PASS: tail starts at line_191
+
+Test 13: CLI subcommands
+  PASS: CLI observe exit=0
+  PASS: CLI markers count=1
+  PASS: CLI should-repair exits 0
+
+=== Results: 29/29 passed, 0 failed ===

--- a/.omc/phase-27-evidence/test_trajectory.log
+++ b/.omc/phase-27-evidence/test_trajectory.log
@@ -1,0 +1,49 @@
+=== Phase 24 trajectory-kill tests ===
+
+Test 1: parse on missing file
+  PASS: exists=false
+  PASS: total=0
+
+Test 2: parse counts tools
+  PASS: reads=5
+  PASS: greps=3
+  PASS: edits=2
+  PASS: writes=1
+  PASS: bashes=4
+  PASS: total=15
+  PASS: read_pct=53
+  PASS: edit_pct=20
+
+Test 3: productive trajectory
+  PASS: classify productive
+  PASS: productive -> no kill (exit 1)
+
+Test 4: searching trajectory
+  PASS: classify searching (below thrash min)
+  PASS: searching -> no kill
+
+Test 5: thrashing trajectory
+  PASS: classify thrashing
+  PASS: thrashing -> kill (exit 0)
+
+Test 6: stuck trajectory
+  PASS: classify stuck
+  PASS: stuck -> kill (exit 0)
+
+Test 7: env-var overrides take effect
+  PASS: default: searching
+  PASS: override THRASH_MIN=5: thrashing
+
+Test 8: empty file handling
+  PASS: empty file total=0
+  PASS: empty file classify=productive (no signal)
+
+Test 9: CLI subcommands
+  PASS: CLI parse total=26
+  PASS: CLI classify thrashing
+  PASS: CLI kill exits 0 for thrashing
+
+Test 10: classify reads stdin
+  PASS: stdin classify productive
+
+=== Results: 26/26 passed, 0 failed ===

--- a/.omc/phase-27-evidence/test_watchdog.log
+++ b/.omc/phase-27-evidence/test_watchdog.log
@@ -1,0 +1,55 @@
+=== Phase 16 watchdog + circuit-breaker tests ===
+
+Test 1: classify_age thresholds
+  PASS: 0s -> fresh
+  PASS: 300s -> fresh
+  PASS: 301s -> stale-check
+  PASS: 600s -> stale-check
+  PASS: 601s -> stale-reassign
+  PASS: 1200s -> stale-reassign
+  PASS: 1201s -> stale-reassign
+  PASS: 1800s -> stale-reassign
+  PASS: 1801s -> timed-out
+  PASS: 7200s -> timed-out
+
+Test 2: watchdog_poll on empty state
+  PASS: missing quantum.json -> []
+
+Test 3: watchdog_poll fresh in_progress story
+  PASS: only the in_progress story returned
+  PASS: story_id is US-001
+  PASS: fresh -> continue
+  PASS: classification fresh
+
+Test 4: watchdog_poll stale-check (~400s old)
+  PASS: 400s -> stale-check
+  PASS: stale-check -> status-probe
+
+Test 5: watchdog_poll timed-out (>30min old)
+  PASS: 2400s -> timed-out
+  PASS: timed-out -> mark-failed
+
+Test 6: error_counter_bump same signature increments
+  PASS: first bump count 1
+  PASS: second bump count 2
+  PASS: third bump count 3
+
+Test 7: different signature resets counter
+  PASS: sig-A count reaches 2
+  PASS: sig-B resets to 1
+  PASS: sig-B next bump is 2
+
+Test 8: should_circuit_break crosses threshold
+  PASS: count=1, threshold=3 -> no break (exit 1)
+  PASS: count=3, threshold=3 -> BREAK (exit 0)
+  PASS: count=3, threshold=10 -> no break
+
+Test 9: error_counter_reset
+  PASS: after reset, no break
+  PASS: count after reset=1
+
+Test 10: CLI subcommands
+  PASS: CLI classify 500 -> stale-check
+  PASS: CLI bump first -> 1
+
+=== Results: 32/32 passed, 0 failed ===

--- a/lib/tracecoder.sh
+++ b/lib/tracecoder.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+# lib/tracecoder.sh — Observe-Analyze-Repair failure-triage primitives
+# (Phase 27 / P3.8, arXiv:2602.06875).
+#
+# Source: TraceCoder decomposes the repair loop into three explicit stages:
+#   Observe  — collect evidence from the failing state (test output, type
+#              errors, file:line markers) in a structured form.
+#   Analyze  — reason about the root cause from the observation (an LLM
+#              task; this lib prepares the analysis context package).
+#   Repair   — apply one minimal change + re-Observe.
+#
+# The benefit over a single-pass verify: each stage has a clear input and
+# output contract, so the LLM reasoning pass operates on parsed structured
+# evidence instead of raw logs, and the repair step always re-validates
+# with fresh observations. Matches the paper's "evidence-first" principle.
+#
+# This library ships the deterministic pieces: running the command,
+# parsing error markers, packaging the context for LLM analysis. The
+# actual analyze step (which must reason) stays in the skill prompt.
+#
+# Functions:
+#   observe CMD [NAME]
+#     Runs CMD; captures stdout, stderr, exit, wall-clock duration, and a
+#     truncated tail. Emits a JSON object describing the observation.
+#
+#   extract_error_markers OBSERVATION_JSON
+#     Parses the combined output for file:line: error patterns (compiler-
+#     typical). Emits a JSON array of {file, line, message}.
+#
+#   build_analysis_context OBSERVATION_JSON CMD_NAME
+#     Packages the observation into a prompt-friendly context block
+#     ready to hand to an LLM Analyze stage. Includes: command name,
+#     exit code, duration, extracted error markers, tail of output.
+#     Output: plain text (markdown-ish) on stdout.
+#
+#   should_repair OBSERVATION_JSON
+#     Exit 0 if the observation indicates a repairable failure (non-zero
+#     exit AND at least one recognizable error marker). Exit 1 on pass
+#     or unrecognizable failure. Callers use this to decide whether to
+#     enter the repair loop vs immediately failing the story.
+#
+# Library contract: no shell flags at source time; CLI block enables
+# strict mode locally.
+
+TRACECODER_LIB_DIR="${TRACECODER_LIB_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+
+: "${TRACECODER_TAIL_LINES:=40}"  # how many lines of output to retain in the observation tail
+
+# observe(cmd, [name])
+# Runs `cmd` via bash -c, captures stdout+stderr into a single stream,
+# records the exit code and wall-clock duration. Emits JSON:
+#   {
+#     "name":     <name or "anonymous">,
+#     "cmd":      <literal command string>,
+#     "exit":     <integer>,
+#     "duration": <seconds>,
+#     "lines":    <total-line count of combined output>,
+#     "tail":     <last TRACECODER_TAIL_LINES lines>
+#   }
+observe() {
+  local cmd="${1:?observe: command required}"
+  local name="${2:-anonymous}"
+  local tmp
+  tmp=$(mktemp)
+  local start end duration exit_code
+  start=$(date +%s 2>/dev/null || echo 0)
+  bash -c "$cmd" > "$tmp" 2>&1
+  exit_code=$?
+  end=$(date +%s 2>/dev/null || echo 0)
+  duration=$(( end - start ))
+
+  local lines tail_block
+  lines=$(wc -l < "$tmp" 2>/dev/null | tr -d '[:space:]')
+  [[ -z "$lines" ]] && lines=0
+  tail_block=$(tail -n "$TRACECODER_TAIL_LINES" "$tmp" 2>/dev/null)
+  rm -f "$tmp"
+
+  jq -cn \
+    --arg name "$name" \
+    --arg cmd "$cmd" \
+    --argjson exit "$exit_code" \
+    --argjson duration "$duration" \
+    --argjson lines "$lines" \
+    --arg tail "$tail_block" \
+    '{name: $name, cmd: $cmd, exit: $exit, duration: $duration,
+      lines: $lines, tail: $tail}'
+}
+
+# extract_error_markers(observation_json)
+# Parses the .tail field for file:line: error patterns. Covers common
+# compiler / test-runner formats:
+#   path/to/file.ts:42:9: error: ...        (tsc, generic)
+#   path/to/file.py:18: ...                   (python tracebacks)
+#   File "foo.py", line 42, in ...            (python)
+#   at .../file.js:100:5                      (node stacks)
+#
+# Emits a JSON array of {file, line, message}. `message` is the rest of
+# the line after the file:line prefix, trimmed.
+extract_error_markers() {
+  local obs
+  obs=$(cat)
+  local tail
+  tail=$(jq -r '.tail // ""' <<< "$obs")
+  [[ -z "$tail" ]] && { printf "[]"; return 0; }
+
+  # Build the JSON array by parsing each line.
+  local markers='[]'
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    local f ln msg
+    f=""
+    ln=""
+    msg=""
+    # Pattern 1: path:LINE:COL: msg  OR  path:LINE: msg
+    if [[ "$line" =~ ^([^:]+):([0-9]+):([0-9]+):[[:space:]]*(.*)$ ]]; then
+      f="${BASH_REMATCH[1]}"
+      ln="${BASH_REMATCH[2]}"
+      msg="${BASH_REMATCH[4]}"
+    elif [[ "$line" =~ ^([^[:space:]]+):([0-9]+):[[:space:]]*(.*)$ ]]; then
+      f="${BASH_REMATCH[1]}"
+      ln="${BASH_REMATCH[2]}"
+      msg="${BASH_REMATCH[3]}"
+    elif [[ "$line" =~ File\ \"([^\"]+)\",\ line\ ([0-9]+) ]]; then
+      f="${BASH_REMATCH[1]}"
+      ln="${BASH_REMATCH[2]}"
+      msg=""
+    elif [[ "$line" =~ at[[:space:]].*\(([^:]+):([0-9]+):([0-9]+)\) ]]; then
+      f="${BASH_REMATCH[1]}"
+      ln="${BASH_REMATCH[2]}"
+      msg=""
+    fi
+    if [[ -n "$f" && -n "$ln" ]]; then
+      # Drop obvious non-path noise (e.g., "http://example.com:80" gets f=http)
+      # Heuristic: file must contain "/" OR "." (extension)
+      if [[ "$f" == *"/"* || "$f" == *"."* ]]; then
+        markers=$(jq -c --arg f "$f" --argjson l "$ln" --arg m "$msg" \
+          '. + [{file: $f, line: $l, message: $m}]' <<< "$markers")
+      fi
+    fi
+  done <<< "$tail"
+  printf '%s' "$markers"
+}
+
+# build_analysis_context(observation_json, [extra_hints])
+# Emits a markdown-ish plain-text block suitable for handing to an LLM
+# Analyze stage. Structure:
+#
+#   ## Observation: <name>
+#   **exit**: <n>   **duration**: <s>s   **lines**: <n>
+#   ### Error markers
+#   - file:line: message
+#   - ...
+#   ### Output tail
+#   <last N lines>
+#
+# If no markers parsed, the section reads "(none parsed — rely on tail)".
+build_analysis_context() {
+  local obs
+  obs=$(cat)
+  local markers
+  markers=$(printf '%s' "$obs" | extract_error_markers)
+  local name cmd exit_code duration tail_block lines n_markers
+  name=$(jq -r '.name // "anonymous"' <<< "$obs")
+  cmd=$(jq -r '.cmd // ""' <<< "$obs")
+  exit_code=$(jq -r '.exit // 0' <<< "$obs")
+  duration=$(jq -r '.duration // 0' <<< "$obs")
+  lines=$(jq -r '.lines // 0' <<< "$obs")
+  tail_block=$(jq -r '.tail // ""' <<< "$obs")
+  n_markers=$(printf '%s' "$markers" | jq 'length')
+
+  {
+    printf "## Observation: %s\n" "$name"
+    printf "**cmd**: \`%s\`\n" "$cmd"
+    printf "**exit**: %s  **duration**: %ss  **lines**: %s\n\n" "$exit_code" "$duration" "$lines"
+    printf "### Error markers (%s)\n" "$n_markers"
+    if (( n_markers == 0 )); then
+      printf "_(none parsed — rely on output tail)_\n"
+    else
+      printf '%s' "$markers" | jq -r '.[] | "- `\(.file):\(.line)` — \(.message // "(no message)")"'
+    fi
+    printf "\n### Output tail\n"
+    printf '```\n%s\n```\n' "$tail_block"
+  }
+}
+
+# should_repair(observation_json)
+# Exit 0 (YES, repair) iff exit != 0 AND at least one recognizable error
+# marker was parsed. Exit 1 otherwise.
+# Rationale: if exit==0 we passed. If exit!=0 but no markers, the failure
+# is opaque — the LLM has no grounding, better to mark the story failed
+# directly than send it into a low-signal repair loop.
+should_repair() {
+  local obs
+  obs=$(cat)
+  local exit_code markers_len
+  exit_code=$(jq -r '.exit // 0' <<< "$obs")
+  markers_len=$(printf '%s' "$obs" | extract_error_markers | jq 'length')
+  if [[ "$exit_code" -ne 0 && "$markers_len" -gt 0 ]]; then
+    return 0
+  fi
+  return 1
+}
+
+# ------------------------------------------------------------------------------
+# CLI entry
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  set -euo pipefail
+  subcmd="${1:-}"
+  shift || true
+  case "$subcmd" in
+    observe)  observe "$@" ;;
+    markers)  extract_error_markers ;;
+    context)  build_analysis_context "$@" ;;
+    should-repair) should_repair ;;
+    *)
+      cat >&2 <<USAGE
+Usage: bash lib/tracecoder.sh <subcmd> [args...]
+  observe CMD [NAME]           — run + capture observation as JSON
+  markers       < observation  — parse error markers into JSON array
+  context [hints] < observation — emit LLM-ready analysis prompt
+  should-repair < observation  — exit 0 if repairable failure
+USAGE
+      exit 2
+      ;;
+  esac
+fi

--- a/tests/test_tracecoder.sh
+++ b/tests/test_tracecoder.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# Phase 27 / P3.8 — tracecoder observe/extract/context tests.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR/.."
+PASS=0
+FAIL=0
+TOTAL=0
+
+assert() {
+  local name="$1" expected="$2" actual="$3"
+  TOTAL=$((TOTAL + 1))
+  if [[ "$expected" == "$actual" ]]; then
+    echo "  PASS: $name"; PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $name (expected [$expected] got [$actual])"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# shellcheck disable=SC1091
+source "$REPO_ROOT/lib/tracecoder.sh"
+
+echo "=== Phase 27 TraceCoder tests ==="
+
+# Test 1: observe captures exit + stdout+stderr merged + duration
+echo ""
+echo "Test 1: observe a passing command"
+obs=$(observe "echo hello" "greeting")
+assert "exit=0" "0" "$(jq -r '.exit' <<< "$obs")"
+assert "name=greeting" "greeting" "$(jq -r '.name' <<< "$obs")"
+tail=$(jq -r '.tail' <<< "$obs")
+case "$tail" in *hello*) echo "  PASS: tail contains hello"; PASS=$((PASS + 1));;
+                *) echo "  FAIL: tail=[$tail]"; FAIL=$((FAIL + 1));;
+esac
+TOTAL=$((TOTAL + 1))
+
+# Test 2: observe captures non-zero exit
+echo ""
+echo "Test 2: observe a failing command"
+obs=$(observe "false" "fails")
+assert "exit=1" "1" "$(jq -r '.exit' <<< "$obs")"
+
+# Test 3: observe merges stdout and stderr into tail
+echo ""
+echo "Test 3: observe merges stderr"
+obs=$(observe "echo out; echo err 1>&2" "mixed")
+tail=$(jq -r '.tail' <<< "$obs")
+case "$tail" in *"out"*"err"*) echo "  PASS: both streams in tail"; PASS=$((PASS + 1));;
+                *) echo "  FAIL: tail=[$tail]"; FAIL=$((FAIL + 1));;
+esac
+TOTAL=$((TOTAL + 1))
+
+# Test 4: extract_error_markers — tsc-style file:line:col: msg
+echo ""
+echo "Test 4: extract tsc-style markers"
+obs_json=$(jq -cn '{tail: "src/app.ts:42:9: error: Cannot find name foo"}')
+markers=$(printf '%s' "$obs_json" | extract_error_markers)
+count=$(printf '%s' "$markers" | jq 'length')
+assert "1 marker parsed" "1" "$count"
+assert "file=src/app.ts" "src/app.ts" "$(printf '%s' "$markers" | jq -r '.[0].file')"
+assert "line=42" "42" "$(printf '%s' "$markers" | jq -r '.[0].line')"
+msg=$(printf '%s' "$markers" | jq -r '.[0].message')
+case "$msg" in *"Cannot find name foo"*) echo "  PASS: message captured"; PASS=$((PASS + 1));;
+                *) echo "  FAIL: msg=[$msg]"; FAIL=$((FAIL + 1));;
+esac
+TOTAL=$((TOTAL + 1))
+
+# Test 5: extract — python-style `File "foo.py", line N`
+echo ""
+echo "Test 5: extract python traceback"
+obs_json=$(jq -cn '{tail: "File \"src/main.py\", line 18, in handler"}')
+markers=$(printf '%s' "$obs_json" | extract_error_markers)
+count=$(printf '%s' "$markers" | jq 'length')
+assert "1 marker parsed" "1" "$count"
+assert "python file" "src/main.py" "$(printf '%s' "$markers" | jq -r '.[0].file')"
+assert "python line" "18" "$(printf '%s' "$markers" | jq -r '.[0].line')"
+
+# Test 6: extract — node stack trace `at fn (path:L:C)`
+echo ""
+echo "Test 6: extract node stack"
+obs_json=$(jq -cn '{tail: "    at Object.handler (dist/server.js:100:5)"}')
+markers=$(printf '%s' "$obs_json" | extract_error_markers)
+count=$(printf '%s' "$markers" | jq 'length')
+assert "node stack parsed" "1" "$count"
+assert "node file" "dist/server.js" "$(printf '%s' "$markers" | jq -r '.[0].file')"
+assert "node line" "100" "$(printf '%s' "$markers" | jq -r '.[0].line')"
+
+# Test 7: extract — multiple markers + ignores URLs
+echo ""
+echo "Test 7: multiple markers + URL noise filtering"
+tail_text='src/a.ts:10:1: error: bad
+src/b.ts:20:2: error: worse
+see https://example.com:80/path for more'
+obs_json=$(jq -cn --arg t "$tail_text" '{tail: $t}')
+markers=$(printf '%s' "$obs_json" | extract_error_markers)
+count=$(printf '%s' "$markers" | jq 'length')
+assert "2 real markers (URL filtered)" "2" "$count"
+
+# Test 8: extract — empty tail returns []
+echo ""
+echo "Test 8: empty tail"
+obs_json='{"tail":""}'
+markers=$(printf '%s' "$obs_json" | extract_error_markers)
+assert "empty tail -> []" "[]" "$markers"
+
+# Test 9: build_analysis_context produces structured markdown
+echo ""
+echo "Test 9: build_analysis_context shape"
+obs=$(observe "bash -c 'echo error >&2; exit 1'" "compile")
+ctx=$(printf '%s' "$obs" | build_analysis_context)
+case "$ctx" in *"## Observation: compile"*) echo "  PASS: header present"; PASS=$((PASS + 1));;
+                *) echo "  FAIL: no header"; FAIL=$((FAIL + 1));;
+esac
+TOTAL=$((TOTAL + 1))
+case "$ctx" in *"**exit**: 1"*) echo "  PASS: exit code visible"; PASS=$((PASS + 1));;
+                *) echo "  FAIL: no exit"; FAIL=$((FAIL + 1));;
+esac
+TOTAL=$((TOTAL + 1))
+case "$ctx" in *"### Output tail"*) echo "  PASS: tail section present"; PASS=$((PASS + 1));;
+                *) echo "  FAIL: no tail section"; FAIL=$((FAIL + 1));;
+esac
+TOTAL=$((TOTAL + 1))
+
+# Test 10: build_analysis_context includes markers section
+echo ""
+echo "Test 10: context includes markers"
+# Craft an observation with recognizable errors
+obs_json=$(jq -cn --arg t "src/x.ts:5:3: error: oops" \
+  '{name: "tsc", cmd: "tsc", exit: 1, duration: 1, lines: 1, tail: $t}')
+ctx=$(printf '%s' "$obs_json" | build_analysis_context)
+case "$ctx" in *"src/x.ts"*"5"*"oops"*) echo "  PASS: marker rendered in context"; PASS=$((PASS + 1));;
+                *) echo "  FAIL: marker not rendered"; FAIL=$((FAIL + 1));;
+esac
+TOTAL=$((TOTAL + 1))
+
+# Test 11: should_repair — pass on failure with markers
+echo ""
+echo "Test 11: should_repair semantics"
+# Failure + markers → repair
+obs_json=$(jq -cn '{exit: 1, tail: "src/x.ts:5:3: error: oops"}')
+printf '%s' "$obs_json" | should_repair
+assert "failure + markers -> 0" "0" "$?"
+# Pass → no repair
+obs_json=$(jq -cn '{exit: 0, tail: "all passed"}')
+printf '%s' "$obs_json" | should_repair
+assert "pass -> no repair (1)" "1" "$?"
+# Failure but no markers → no repair (opaque, mark failed directly)
+obs_json=$(jq -cn '{exit: 1, tail: "segfault"}')
+printf '%s' "$obs_json" | should_repair
+assert "opaque failure -> no repair (1)" "1" "$?"
+
+# Test 12: observe handles long output
+echo ""
+echo "Test 12: tail truncates to TRACECODER_TAIL_LINES"
+cmd='for i in $(seq 1 200); do echo line_$i; done'
+obs=$(TRACECODER_TAIL_LINES=10 observe "$cmd" "noisy")
+tail=$(jq -r '.tail' <<< "$obs")
+tail_lines=$(printf '%s' "$tail" | awk 'END{print NR}')
+assert "tail is 10 lines" "10" "$tail_lines"
+# First line of tail should be line_191 (last 10 of 200)
+first=$(printf '%s' "$tail" | head -1)
+assert "tail starts at line_191" "line_191" "$first"
+
+# Test 13: CLI subcommands
+echo ""
+echo "Test 13: CLI subcommands"
+cli_obs=$(bash "$REPO_ROOT/lib/tracecoder.sh" observe "echo hi" "cli")
+cli_exit=$(printf '%s' "$cli_obs" | jq -r '.exit')
+assert "CLI observe exit=0" "0" "$cli_exit"
+cli_markers=$(printf '{"tail":"src/x.ts:1:1: error: e"}' \
+  | bash "$REPO_ROOT/lib/tracecoder.sh" markers | jq 'length')
+assert "CLI markers count=1" "1" "$cli_markers"
+cli_repair=$(printf '{"exit":1,"tail":"src/x.ts:1:1: error: e"}' \
+  | bash "$REPO_ROOT/lib/tracecoder.sh" should-repair ; echo $?)
+assert "CLI should-repair exits 0" "0" "$cli_repair"
+
+echo ""
+echo "=== Results: $PASS/$TOTAL passed, $FAIL failed ==="
+exit $((FAIL > 0 ? 1 : 0))


### PR DESCRIPTION
Sixth P3 wedge. Decomposes the failure-triage loop into three explicit stages so the Analyze pass operates on parsed structured evidence rather than raw logs, and Repair always re-validates via fresh Observe.

## lib/tracecoder.sh

| Function | Purpose |
|----------|---------|
| `observe CMD [NAME]` | Run command, capture exit/duration/tail as JSON |
| `extract_error_markers` | Parse tsc / python / node error patterns into `[{file, line, message}, ...]` |
| `build_analysis_context` | Package markers + tail as LLM-ready markdown |
| `should_repair` | Exit 0 iff failure has ≥1 recognizable marker (opaque failures skip the loop) |

Tail length tunable via `TRACECODER_TAIL_LINES` (default 40).

## Tests

29 new tests across observe/extract/context/should-repair/CLI. 356 total across 12 related suites, all green.

## Follow-ups deferred

- Wiring into orchestrator repair path — replaces the single-pass verify block
- String-safe comment stripper (flagged in post-hoc review of #35/#36) — not applied here since compiler error lines rarely embed string literals

## Test plan

- [x] All 29 tracecoder tests pass
- [x] No regressions in 11 adjacent test suites (ambiguity, conflict-grade, constitution, deep-review, dogfood-e2e, far-filter, hyclone, orchestrator-wiring, reaper, trajectory, watchdog)
- [x] CLI subcommands verified (`observe`, `markers`, `should-repair`)
- [ ] Wire into orchestrator (separate PR)