### PR TITLE
fix: string-safe comment stripping in hyclone + conflict-grade

### DIFF
--- a/lib/conflict-grade.sh
+++ b/lib/conflict-grade.sh
@@ -56,7 +56,9 @@ _strip_ws() {
 
 # _strip_comments(text)
 # Remove line comments (# and //) and block comments (/* ... */) for
-# grade-2 detection (comment-only change).
+# grade-2 detection (comment-only change). String literals are preserved
+# verbatim so `//` or `/*` inside "http://x" or "/regex/" is not treated
+# as a comment marker.
 _strip_comments() {
   local text="${1:-}"
   printf '%s' "$text" | awk '
@@ -65,11 +67,27 @@ _strip_comments() {
       line = $0
       out = ""
       i = 1
+      in_string = ""
       while (i <= length(line)) {
         c2 = substr(line, i, 2)
         c  = substr(line, i, 1)
-        if (in_block) {
+        if (in_string != "") {
+          out = out c
+          if (c == "\\" && i + 1 <= length(line)) {
+            out = out substr(line, i+1, 1)
+            i += 2
+          } else if (c == in_string) {
+            in_string = ""
+            i += 1
+          } else {
+            i += 1
+          }
+        } else if (in_block) {
           if (c2 == "*/") { in_block = 0; i += 2 } else { i += 1 }
+        } else if (c == "\"" || c == "'\''") {
+          in_string = c
+          out = out c
+          i += 1
         } else if (c2 == "/*") {
           in_block = 1; i += 2
         } else if (c2 == "//" || c == "#") {

--- a/lib/hyclone.sh
+++ b/lib/hyclone.sh
@@ -89,8 +89,9 @@ _is_keyword() {
 alpha_normalize() {
   local text="${1:-}"
   [[ -z "$text" ]] && { printf ""; return 0; }
-  # Step 1-2: strip comments. Use sed for line comments. Block comments:
-  # use awk state machine since portable sed doesn't do multiline.
+  # Step 1-2: strip comments with string-state tracking so `//`, `/*`, or
+  # `#` inside a string literal (e.g. "http://x", "/regex/") is preserved.
+  # Without string tracking the naive stripper truncates URLs/regexes/paths.
   local stripped
   stripped=$(printf '%s' "$text" | awk '
     BEGIN { in_block = 0 }
@@ -98,11 +99,28 @@ alpha_normalize() {
       line = $0
       out = ""
       i = 1
+      in_string = ""
       while (i <= length(line)) {
         c  = substr(line, i, 1)
         c2 = substr(line, i, 2)
-        if (in_block) {
+        if (in_string != "") {
+          # Inside a string — copy through; handle backslash escape
+          out = out c
+          if (c == "\\" && i + 1 <= length(line)) {
+            out = out substr(line, i+1, 1)
+            i += 2
+          } else if (c == in_string) {
+            in_string = ""
+            i += 1
+          } else {
+            i += 1
+          }
+        } else if (in_block) {
           if (c2 == "*/") { in_block = 0; i += 2 } else { i += 1 }
+        } else if (c == "\"" || c == "'\''") {
+          in_string = c
+          out = out c
+          i += 1
         } else if (c2 == "/*") {
           in_block = 1; i += 2
         } else if (c2 == "//" || c == "#") {

--- a/tests/test_conflict_grade.sh
+++ b/tests/test_conflict_grade.sh
@@ -187,6 +187,19 @@ assert "grade 3 → diff3"     "diff3"     "$(routing_recommendation 3)"
 assert "grade 4 → llm-merge" "llm-merge" "$(routing_recommendation 4)"
 assert "grade 5 → escalate"  "escalate"  "$(routing_recommendation 5)"
 
+# Test 12a: `//` and `/*` inside string literals preserved by _strip_comments
+echo ""
+echo "Test 12a: string literals not truncated at // or /*"
+# URL in string is NOT a comment — both sides identical → grade 2 (code identical post-strip)
+g=$(grade_hunk_text 'let url = "http://example.com"' 'let url = "http://example.com"')
+assert "identical URL lines → grade 1 (whitespace equiv)" "1" "$g"
+# Genuine comment change on line with URL string
+g=$(grade_hunk_text 'let url = "http://example.com" // old' 'let url = "http://example.com" // new')
+assert "URL preserved, comment-only change → grade 2" "2" "$g"
+# Different URLs → single-word rename → grade 2 (not higher)
+g=$(grade_hunk_text 'let url = "http://a.com/api"' 'let url = "http://b.net/api"')
+assert "URL content changed (single-token) → grade 2" "2" "$g"
+
 # Test 12: CLI subcommands
 echo ""
 echo "Test 12: CLI subcommands"

--- a/tests/test_hyclone.sh
+++ b/tests/test_hyclone.sh
@@ -161,9 +161,41 @@ else
   echo "  FAIL: CLI fp length [${#cli_fp}]"; FAIL=$((FAIL + 1))
 fi
 
-# Test 12: empty input -> empty output
+# Test 12: strings containing comment markers are preserved
+# (The aggressive whitespace-strip post-process collapses spaces adjacent
+# to non-word chars even inside strings — acceptable for clone-detection
+# since "a b" and "a  b" should map to the same fingerprint.)
 echo ""
-echo "Test 12: empty input handling"
+echo "Test 12: comment markers inside string literals not treated as comments"
+# URL in double-quoted string
+n=$(alpha_normalize 'let url = "http://example.com" // real comment')
+assert "URL preserved, trailing double-slash stripped" 'let _v0="http://example.com"' "$n"
+# Regex-like in single-quoted string
+n=$(alpha_normalize "let re = '/foo/bar/' # trailing")
+assert "regex preserved, trailing hash stripped" "let _v0='/foo/bar/'" "$n"
+# Block-comment start inside string should NOT enter block-comment state
+# (spaces adjacent to punctuation collapse — that's the aggressive strip,
+# not the comment bug we're fixing; the important check is the content
+# after */ survives.)
+n=$(alpha_normalize 'let s = "/* not a comment */"')
+assert "block markers in string do not consume rest" 'let _v0="/*not a comment*/"' "$n"
+# Escaped quote inside string does not end string
+n=$(alpha_normalize 'let s = "he said \"hi\" // nope"')
+assert "escaped quotes do not terminate string" 'let _v0="he said\"hi\"//nope"' "$n"
+# Two snippets with same logic but different URL strings should produce
+# different fingerprints (the URLs themselves differ post-strip).
+f1=$(fingerprint 'fetch("http://a.com/api")')
+f2=$(fingerprint 'fetch("http://b.net/api")')
+TOTAL=$((TOTAL + 1))
+if [[ "$f1" != "$f2" ]]; then
+  echo "  PASS: different URLs -> different fingerprints (Stage-2 would catch)"; PASS=$((PASS + 1))
+else
+  echo "  FAIL: different URLs collided"; FAIL=$((FAIL + 1))
+fi
+
+# Test 13: empty input -> empty output
+echo ""
+echo "Test 13: empty input handling"
 n=$(alpha_normalize "")
 assert "empty normalize -> empty" "" "$n"
 out=$(find_clones "[]")


### PR DESCRIPTION
Review follow-up for #35 + #36. The first awk pass in both `lib/hyclone.sh` and `lib/conflict-grade.sh` walked chars without tracking string state, so `//`, `/*`, or `#` inside a string literal (e.g. `"http://x"`, `'/regex/'`) was treated as a comment marker — silently truncating the string.

## Fix

Ported the string-state machine already present in the hyclone **tokenizer** (second awk pass) up into the **comment-stripper** (first awk pass). While inside a string: copy chars through, honor `\` backslash escape, exit on matching quote.

Applied to both files.

## Tests

| Suite | Before | After | Delta |
|-------|-------:|------:|------:|
| `test_hyclone.sh` | 26 | 31 | +5 |
| `test_conflict_grade.sh` | 30 | 33 | +3 |

New assertions cover URL preservation, regex in single-quoted string, block-markers inside strings, escaped quotes, and URL-content fingerprint distinctness.

## Not addressed (deferred to later cleanup pass)

- `grep -c \|\| echo 0` recurrence in `lib/trajectory.sh` (cosmetic — works due to downstream `tr -d`)
- Dead `_is_keyword` function in `lib/hyclone.sh` (unused)

## Test plan

- [x] `test_hyclone.sh` 31/31 pass
- [x] `test_conflict_grade.sh` 33/33 pass
- [x] No regressions in adjacent suites