### PR TITLE
Phase 28 — Periodic re-grounding (P3.9, arXiv:2603.00492)

### DIFF
--- a/.omc/phase-28-evidence/test_ambiguity.log
+++ b/.omc/phase-28-evidence/test_ambiguity.log
@@ -1,0 +1,68 @@
+=== Phase 19 ambiguity-gate tests ===
+
+Test 1: score_ambiguity arithmetic
+  PASS: all 10s -> 0
+  PASS: all 0s -> 100
+  PASS: all 5s -> 50
+  PASS: goal only -> 60
+  PASS: constraints only -> 70
+  PASS: criteria only -> 70
+
+Test 2: score_ambiguity input validation
+  PASS: 11 rejected
+  PASS: -1 rejected
+  PASS: abc rejected
+
+Test 3: check_gate semantics
+  PASS: score 0 passes
+  PASS: score 19 passes
+  PASS: score 20 blocks
+  PASS: score 50 blocks
+  PASS: score 100 blocks
+  PASS: 30 < 50 passes
+  PASS: 60 >= 50 blocks
+
+Test 4: challenge_mode thresholds
+  PASS: round 1, score 100 -> normal
+  PASS: round 2, score 80  -> normal
+  PASS: round 3, score 45  -> contrarian
+  PASS: round 3, score 35  -> normal
+  PASS: round 4, score 35  -> simplifier
+  PASS: round 4, score 25  -> normal
+  PASS: round 5, score 25  -> ontologist
+  PASS: round 5, score 15  -> normal
+  PASS: round 6, score 50  -> ontologist
+
+Test 5: ontology_extract
+  PASS: extract tokens sorted+unique
+  PASS: empty -> empty
+  PASS: stopwords dropped
+
+Test 6: ontology_diff
+  PASS: 1 added
+  PASS: 1 removed
+  PASS: 2 carried
+  PASS: stability 0.50
+  PASS: identical stability 1.0
+  PASS: empty prior stability 0.00
+
+Test 7: CLI subcommands
+  PASS: CLI score 5 5 5 = 50
+  PASS: CLI gate 10 passes
+  PASS: CLI gate 25 blocks
+  PASS: CLI mode 5 30 = ontologist
+
+Test 8: ql-brainstorm wires lib/ambiguity.sh
+  PASS: Phase 0B ambiguity gate section
+  PASS: calls lib/ambiguity.sh score
+  PASS: calls lib/ambiguity.sh gate
+  PASS: calls lib/ambiguity.sh mode
+  PASS: ontology stability tracking
+  PASS: ontology diff call
+  PASS: contrarian mode described
+  PASS: simplifier mode described
+  PASS: ontologist mode described
+  PASS: thrashing ontology escalation
+  PASS: handoff records final_score
+
+=== Results: 49/49 passed, 0 failed ===

--- a/.omc/phase-28-evidence/test_conflict_grade.log
+++ b/.omc/phase-28-evidence/test_conflict_grade.log
@@ -1,0 +1,62 @@
+=== Phase 26 conflict-grade tests ===
+
+Test 1: whitespace-only → grade 1
+  PASS: single-ws diff
+  PASS: bracket-indent diff
+
+Test 2: comment-only → grade 2
+  PASS: line comment change
+  PASS: python-style comment change
+  PASS: block comment change
+
+Test 3: single-token rename → grade 2
+  PASS: single identifier rename
+
+Test 4: small body edit → grade 3
+  PASS: 3-line small body edit
+
+Test 5: moderate overlap → grade 4
+  PASS: 7-line overlap
+
+Test 6: structural reorg → grade 5
+  PASS: 2-function reorder
+  PASS: 2-def reorg (python)
+
+Test 7: split_conflict_hunks single
+  PASS: 1 conflict parsed
+  PASS: ours buffer captured
+  PASS: theirs buffer captured
+  PASS: start_line=2
+  PASS: end_line=7
+
+Test 8: split_conflict_hunks multiple
+  PASS: 2 conflicts parsed
+
+Test 9: grade_file end-to-end
+  PASS: 2 hunks graded
+  PASS: max_grade = 5 (structural)
+  PASS: first hunk grade 2 (comment)
+  PASS: second hunk grade 5 (structural)
+
+Test 10: grade_file clean file
+  PASS: clean file max_grade=0
+  PASS: clean file 0 hunks
+
+Test 11: routing_recommendation
+  PASS: grade 0 → none
+  PASS: grade 1 → auto-git
+  PASS: grade 2 → auto-git
+  PASS: grade 3 → diff3
+  PASS: grade 4 → llm-merge
+  PASS: grade 5 → escalate
+
+Test 12a: string literals not truncated at // or /*
+  PASS: identical URL lines → grade 1 (whitespace equiv)
+  PASS: URL preserved, comment-only change → grade 2
+  PASS: URL content changed (single-token) → grade 2
+
+Test 12: CLI subcommands
+  PASS: CLI grade single-word rename
+  PASS: CLI route 4 → llm-merge
+
+=== Results: 33/33 passed, 0 failed ===

--- a/.omc/phase-28-evidence/test_constitution.log
+++ b/.omc/phase-28-evidence/test_constitution.log
@@ -1,0 +1,51 @@
+=== Phase 22 constitution tests ===
+
+Test 1: load_constitution
+  PASS: loads 2 rules
+  PASS: missing constitution -> empty
+  PASS: missing file -> empty
+  PASS: object form with .rule
+
+Test 2: check_no_secrets detects provider tokens
+  PASS: detects sk-live token
+  PASS: detects ghp_ token
+  PASS: ignores comment about passwords (no literal)
+
+Test 3: generic password/api_key literal
+  PASS: password= long literal flagged
+  PASS: api_key= long literal flagged
+  PASS: short literal not flagged
+
+Test 4: check_sql_injection
+  PASS: flags 2 SQL injections (template + concat)
+  PASS: parameterized query not flagged
+
+Test 5: check_input_validation
+  PASS: flags 2 unvalidated handler reads
+
+Test 6: check_commit_integrity
+  PASS: flags migration file
+  PASS: flags schema.prisma
+  PASS: flags .env.example
+  PASS: does NOT flag regular source file
+
+Test 7: enforce_constitution end-to-end
+  PASS: enforce finds 2 secret+sql findings
+  PASS: input-validation skipped when not active
+  PASS: input-validation active -> finds req.body
+  PASS: no constitution -> empty JSON array
+  PASS: unknown rule -> empty findings (warn only)
+
+Test 8: finding metadata
+  PASS: severity critical
+  PASS: description set
+  PASS: rule id set
+
+Test 9: CLI enforce
+  PASS: CLI enforce returns findings
+
+Test 10: quantum.json.example schema
+  PASS: constitution is array
+  PASS: quantum.json.example still valid JSON
+
+=== Results: 28/28 passed, 0 failed ===

--- a/.omc/phase-28-evidence/test_deep_review.log
+++ b/.omc/phase-28-evidence/test_deep_review.log
@@ -1,0 +1,52 @@
+=== Phase 8 ql-deep-review helper tests ===
+
+Test 1: tier_of_score mapping
+  PASS: 0 -> LOW
+  PASS: 30 -> LOW
+  PASS: 31 -> MEDIUM
+  PASS: 60 -> MEDIUM
+  PASS: 61 -> HIGH
+  PASS: 80 -> HIGH
+  PASS: 81 -> CRITICAL
+  PASS: 100 -> CRITICAL
+
+Test 2: compute_risk_score bounds
+  PASS: empty refs -> 0
+  PASS: intent drift contributes 10
+
+Test 3: actionability_filter
+  PASS: kept count
+  PASS: suppressed count
+  PASS: suppressed has reason
+
+Test 4: dedup_findings
+  PASS: dedup reduces 3 -> 2
+  PASS: merged agents count
+  PASS: kept max confidence
+
+Test 5: hallucination_check suppresses missing files
+  PASS: 1 file kept
+  PASS: 1 file suppressed as hallucination
+  PASS: suppressed reason
+
+Test 6: synthesize_verdict
+  PASS: empty -> APPROVE
+  PASS: only low -> APPROVE
+  PASS: medium 60 -> APPROVE_WITH_COMMENTS
+  PASS: high 75 -> REQUEST_CHANGES
+  PASS: critical 85 -> BLOCKS_MERGE
+  PASS: critical 50 (below threshold) -> APPROVE
+
+Test 7: quantum.json.example schema
+  PASS: reviews is object
+  PASS: quantum.json.example still valid JSON
+
+Test 8: ql-execute mentions the post-pipeline hook
+  PASS: post-pipeline hook header present
+  PASS: references lib/deep-review.sh
+
+Test 9: CLI subcommands work
+  PASS: CLI tier 50 -> MEDIUM
+  PASS: CLI tier 100 -> CRITICAL
+
+=== Results: 31/31 passed, 0 failed ===

--- a/.omc/phase-28-evidence/test_dogfood_e2e.log
+++ b/.omc/phase-28-evidence/test_dogfood_e2e.log
@@ -1,0 +1,38 @@
+=== Phase 10 dogfood end-to-end check ===
+
+Test 1: dogfood quantum.json parses
+  PASS: valid JSON
+
+Test 2: schema fields from Phases 7-9
+  PASS: userIntent.text present
+  PASS: userClarifications is array
+  PASS: intentDrift has entry
+  PASS: reviews has deepReview
+  PASS: deslop field present
+  PASS: codebasePatterns has entries
+  PASS: progress has entries
+
+Test 3: intent-drift gate semantics
+  PASS: NO_DRIFT gate allows merge
+
+Test 4: deep-review synthesize_verdict consumes the dogfood findings array
+  PASS: two HIGH confidence≥70 findings → REQUEST_CHANGES
+
+Test 5: dedup_findings idempotent on dogfood findings
+  PASS: dedup preserves 2-element unique set
+
+Test 6: plan retrospective — 10 stories all passed
+  PASS: 10 stories total
+  PASS: 10 stories passed
+
+Test 7: codebasePatterns contains real Phase-5 lesson
+  PASS: Phase-5 set-e lesson present
+
+Test 8: userIntent verbatim contains the original verbatim message
+  PASS: intent snapshot references IDEA_REPORT.md
+
+Test 9: companion PRD exists and references the dogfood artifact
+  PASS: PRD exists
+  PASS: PRD has AC-15 dogfood + references phase-10-evidence
+
+=== Results: 17/17 passed, 0 failed ===

--- a/.omc/phase-28-evidence/test_far_filter.log
+++ b/.omc/phase-28-evidence/test_far_filter.log
@@ -1,0 +1,41 @@
+=== Phase 23 KBI-FAR far_filter tests ===
+
+Test 1: confidence cutoff
+  PASS: 1 kept (conf ≥60)
+  PASS: 2 suppressed (conf <60)
+  PASS: reason mentions confidence
+
+Test 2: agreement boost lifts across cutoff
+  PASS: agreement-boosted finding kept
+  PASS: confidence boosted 50 -> 65
+  PASS: original_confidence preserved
+  PASS: single-agent below-cutoff suppressed
+
+Test 3: confidence cap at 100
+  PASS: confidence capped at 100
+
+Test 4: knownFalsePositives regex suppression
+  PASS: genuine finding kept
+  PASS: 2 suppressed by regex
+  PASS: suppression reasons reference knownFalsePositives
+
+Test 5: missing quantum.json graceful fallback
+  PASS: finding kept with missing quantum.json
+
+Test 6: empty input
+  PASS: empty kept
+  PASS: empty suppressed
+
+Test 7: CLI subcommand
+  PASS: CLI far kept 1
+
+Test 8: aggregate_reviews wires far_filter
+  PASS: aggregate kept 1 real finding
+  PASS: aggregate suppressed 2 (cutoff + FP)
+  PASS: verdict REQUEST_CHANGES (high ≥70)
+  PASS: FP reason present
+
+Test 9: schema extension
+  PASS: knownFalsePositives is array
+
+=== Results: 20/20 passed, 0 failed ===

--- a/.omc/phase-28-evidence/test_hyclone.log
+++ b/.omc/phase-28-evidence/test_hyclone.log
@@ -1,0 +1,60 @@
+=== Phase 25 HyClone Stage-1 tests ===
+
+Test 1: alpha_normalize basics
+  PASS: whitespace-only renames x
+  PASS: extra whitespace collapsed
+  PASS: multiple identifiers numbered
+
+Test 2: repeated identifiers reuse placeholder
+  PASS: repeated identifier reuses placeholder
+
+Test 3: keywords preserved
+  PASS: keywords preserved
+
+Test 4: comments stripped
+  PASS: line comment // stripped
+  PASS: line comment # stripped
+  PASS: block comment stripped
+
+Test 5: string literals preserved
+  PASS: double-quoted string preserved
+  PASS: single-quoted string preserved
+
+Test 6: clone fingerprints match
+  PASS: different names → same fingerprint
+  PASS: different whitespace → same fingerprint
+
+Test 7: semantic difference → different fingerprints
+  PASS: operator difference changes fingerprint
+  PASS: while vs if different
+
+Test 8: find_clones detects a clone pair
+  PASS: finds 1 clone group
+  PASS: group has 2 members
+  PASS: fnA in clone group
+  PASS: fnB in clone group
+  PASS: fnC NOT in clone group
+
+Test 9: find_clones with all unique functions
+  PASS: no clone groups
+
+Test 10: find_clones with triple
+  PASS: 3-way clone grouped
+  PASS: triple has 3 members
+
+Test 11: CLI subcommands
+  PASS: CLI normalize
+  PASS: CLI fingerprint is 64 hex chars
+
+Test 12: comment markers inside string literals not treated as comments
+  PASS: URL preserved, trailing double-slash stripped
+  PASS: regex preserved, trailing hash stripped
+  PASS: block markers in string do not consume rest
+  PASS: escaped quotes do not terminate string
+  PASS: different URLs -> different fingerprints (Stage-2 would catch)
+
+Test 13: empty input handling
+  PASS: empty normalize -> empty
+  PASS: empty find_clones -> []
+
+=== Results: 31/31 passed, 0 failed ===

--- a/.omc/phase-28-evidence/test_orchestrator_wiring.log
+++ b/.omc/phase-28-evidence/test_orchestrator_wiring.log
@@ -1,0 +1,65 @@
+=== Phase 17 orchestrator-wiring prompt tests ===
+
+Test 1: lib/wave-boundary.sh wired at wave boundary
+  PASS: 3C.NEG1 section present
+  PASS: references wave-boundary.sh scan
+  PASS: routes HIGH severity to fix-story
+
+Test 2: lib/watchdog.sh wired in monitor loop
+  PASS: watchdog tick header
+  PASS: references watchdog.sh poll
+  PASS: status-probe action branch
+  PASS: kill-and-requeue action branch
+  PASS: mark-failed action branch
+  PASS: circuit-breaker bump
+  PASS: circuit-breaker check
+
+Test 3: lib/deep-review.sh wired at full-feature review
+  PASS: 4B.5 deep-review section
+  PASS: score-from-quantum call
+  PASS: tier lookup
+  PASS: dispatch-set call
+  PASS: context preparation
+  PASS: aggregate pipe
+  PASS: BLOCKS_MERGE handled
+  PASS: REQUEST_CHANGES handled
+  PASS: persists into quantum.reviews
+
+Test 4: lib/deslop.sh wired between review-pass and commit
+  PASS: 3A.5B deslop section
+  PASS: validate_scope gate
+  PASS: baseline snapshot before
+  PASS: compare_baseline call
+  PASS: rollback on regression
+  PASS: DESLOP_ROLLED_BACK signal
+  PASS: opt-out via story.deslop.skip
+
+Test 5: lib/commit-trailers.sh validation gate
+  PASS: commit-trailers reference
+  PASS: non-blocking warning
+
+Test 6: handoff.sh ownership is skill-side (orchestrator doesn't write)
+  PASS: orchestrator does NOT write handoffs directly (skills do)
+
+Test 7: all wirings carry a Phase-17 attribution comment
+  PASS: 5 Phase-17 attributions
+
+Test 8: deslop wiring uses DESLOP_AVAILABLE + BASE_SHA
+  PASS: DESLOP_AVAILABLE guard present
+  PASS: DESLOP_AVAILABLE file check
+  PASS: Fallback skip branch
+  PASS: scope loop uses BASE_SHA
+  PASS: rollback uses BASE_SHA
+  PASS: no active STORY_BASE_SHA refs in 3A.5B
+
+Test 9: RUNNER_EXTRA_FLAGS validated after pre_spawn()
+  PASS: RUNNER_EXTRA_FLAGS validation present
+  PASS: blocklist present (regex form varies)
+
+Test 10: runner_build_cmd rejects injection via RUNNER_EXTRA_FLAGS
+  PASS: injection payload rejected with clear error
+
+Test 11: lib/watchdog.sh doc comment corrected
+  PASS: watchdog threshold comment matches code (>30 min = timed-out)
+
+=== Results: 40/40 passed, 0 failed ===

--- a/.omc/phase-28-evidence/test_reaper.log
+++ b/.omc/phase-28-evidence/test_reaper.log
@@ -1,0 +1,62 @@
+=== Phase 20 reaper + spawn exec-capture tests ===
+
+Test 1: detect_platform recognizes current environment
+  PASS: platform is valid enum
+  (detected: msys)
+
+Test 2: _msys_to_winpid handles current PID
+  PASS: numeric winpid (26652)
+
+Test 3: write + read pidfile round-trip
+  PASS: pidfile exists
+  PASS: msys_pid round-trips
+  PASS: cmd round-trips
+  PASS: missing pidfile -> {}
+
+Test 4: is_agent_alive tracks liveness
+  PASS: alive while running
+  PASS: dead after kill
+
+Test 5: is_agent_alive on missing pidfile
+  PASS: missing pidfile -> not alive
+
+Test 6: reap_agent on already-dead process cleans pidfile
+  PASS: reap exits 0
+  PASS: pidfile removed
+
+Test 7: reap_agent terminates a live process
+  PASS: reap_agent exits 0
+  PASS: process not alive
+  PASS: pidfile removed
+
+Test 8: reap_orphans cleans stale pidfiles only
+  PASS: no stale-orphans reaped
+  PASS: dead pidfile removed
+  PASS: live pidfile kept
+
+Test 9: reap_orphans safe on missing/empty dir
+  PASS: missing dir -> 0
+  PASS: empty dir -> 0
+
+Test 10: lib/spawn.sh contains the exec-replacement fix
+  PASS: exec prepended to claude invocation
+  PASS: runner-path uses eval "exec $cmd"
+  PASS: spawn writes pidfile
+
+Test 11: quantum-loop.sh trap uses reaper
+  PASS: cleanup_on_exit calls reap_agent
+  PASS: startup calls reap_orphans
+
+Test 13: _proc_start_epoch is per-process (not a constant)
+  PASS: distinct processes have distinct start epochs (23045925 vs 23047005)
+
+Test 14: cleanup_on_exit uses parallel reap pattern
+  PASS: cleanup_on_exit parallelizes reap_agent calls
+
+Test 15: timeout branch uses reap_agent on Git Bash
+  PASS: TIMED_OUT branch prefers reap_agent
+
+Test 12: CLI subcommands work
+  PASS: CLI platform output: msys
+
+=== Results: 28/28 passed, 0 failed ===

--- a/.omc/phase-28-evidence/test_reground.log
+++ b/.omc/phase-28-evidence/test_reground.log
@@ -1,0 +1,63 @@
+=== Phase 28 re-grounding tests ===
+
+Test 1: should_reground at interval
+  PASS: iter=5, last=0, interval=5 -> 0
+
+Test 2: below interval
+  PASS: iter=3, last=0, interval=5 -> 1
+
+Test 3: past interval (delta 6)
+  PASS: iter=10, last=4, interval=5 -> 0
+
+Test 4: just-grounded state
+  PASS: iter=5, last=5 -> 1
+
+Test 5: missing lastGroundedIteration defaults to 0
+  PASS: no state field, iter=5 -> 0
+
+Test 6: REGROUND_INTERVAL override
+  PASS: interval=3, delta=3 -> 0
+  PASS: interval=10, delta=3 -> 1
+
+Test 7: stdin input
+  PASS: stdin trigger
+
+Test 8: build_reground_context shape
+  PASS: header with iteration
+  PASS: branch rendered
+  PASS: progress counts
+  PASS: goal reminder
+
+Test 9: next pending stories listed
+  PASS: pending stories S3, S5 listed
+  PASS: only pending stories in next-up
+
+Test 10: PRD head included when file exists
+  PASS: PRD head rendered
+
+Test 11: missing PRD handled
+  PASS: missing PRD skipped cleanly
+
+Test 12: empty stories array
+  PASS: empty progress rendered
+
+Test 13: mark_grounded updates state
+  PASS: lastGroundedIteration = 7
+  PASS: other state preserved
+
+Test 14: mark_grounded creates state if absent
+  PASS: state created, lastGroundedIteration = 3
+
+Test 15: mark_grounded missing file
+  PASS: missing file -> exit 1
+
+Test 16: mark_grounded resets the should_reground signal
+  PASS: before mark: should -> 0
+  PASS: after mark: should -> 1
+
+Test 17: CLI subcommands
+  PASS: CLI should -> 0
+  PASS: CLI context
+  PASS: CLI mark updates field
+
+=== Results: 26/26 passed, 0 failed ===

--- a/.omc/phase-28-evidence/test_tracecoder.log
+++ b/.omc/phase-28-evidence/test_tracecoder.log
@@ -1,0 +1,58 @@
+=== Phase 27 TraceCoder tests ===
+
+Test 1: observe a passing command
+  PASS: exit=0
+  PASS: name=greeting
+  PASS: tail contains hello
+
+Test 2: observe a failing command
+  PASS: exit=1
+
+Test 3: observe merges stderr
+  PASS: both streams in tail
+
+Test 4: extract tsc-style markers
+  PASS: 1 marker parsed
+  PASS: file=src/app.ts
+  PASS: line=42
+  PASS: message captured
+
+Test 5: extract python traceback
+  PASS: 1 marker parsed
+  PASS: python file
+  PASS: python line
+
+Test 6: extract node stack
+  PASS: node stack parsed
+  PASS: node file
+  PASS: node line
+
+Test 7: multiple markers + URL noise filtering
+  PASS: 2 real markers (URL filtered)
+
+Test 8: empty tail
+  PASS: empty tail -> []
+
+Test 9: build_analysis_context shape
+  PASS: header present
+  PASS: exit code visible
+  PASS: tail section present
+
+Test 10: context includes markers
+  PASS: marker rendered in context
+
+Test 11: should_repair semantics
+  PASS: failure + markers -> 0
+  PASS: pass -> no repair (1)
+  PASS: opaque failure -> no repair (1)
+
+Test 12: tail truncates to TRACECODER_TAIL_LINES
+  PASS: tail is 10 lines
+  PASS: tail starts at line_191
+
+Test 13: CLI subcommands
+  PASS: CLI observe exit=0
+  PASS: CLI markers count=1
+  PASS: CLI should-repair exits 0
+
+=== Results: 29/29 passed, 0 failed ===

--- a/.omc/phase-28-evidence/test_trajectory.log
+++ b/.omc/phase-28-evidence/test_trajectory.log
@@ -1,0 +1,49 @@
+=== Phase 24 trajectory-kill tests ===
+
+Test 1: parse on missing file
+  PASS: exists=false
+  PASS: total=0
+
+Test 2: parse counts tools
+  PASS: reads=5
+  PASS: greps=3
+  PASS: edits=2
+  PASS: writes=1
+  PASS: bashes=4
+  PASS: total=15
+  PASS: read_pct=53
+  PASS: edit_pct=20
+
+Test 3: productive trajectory
+  PASS: classify productive
+  PASS: productive -> no kill (exit 1)
+
+Test 4: searching trajectory
+  PASS: classify searching (below thrash min)
+  PASS: searching -> no kill
+
+Test 5: thrashing trajectory
+  PASS: classify thrashing
+  PASS: thrashing -> kill (exit 0)
+
+Test 6: stuck trajectory
+  PASS: classify stuck
+  PASS: stuck -> kill (exit 0)
+
+Test 7: env-var overrides take effect
+  PASS: default: searching
+  PASS: override THRASH_MIN=5: thrashing
+
+Test 8: empty file handling
+  PASS: empty file total=0
+  PASS: empty file classify=productive (no signal)
+
+Test 9: CLI subcommands
+  PASS: CLI parse total=26
+  PASS: CLI classify thrashing
+  PASS: CLI kill exits 0 for thrashing
+
+Test 10: classify reads stdin
+  PASS: stdin classify productive
+
+=== Results: 26/26 passed, 0 failed ===

--- a/.omc/phase-28-evidence/test_watchdog.log
+++ b/.omc/phase-28-evidence/test_watchdog.log
@@ -1,0 +1,55 @@
+=== Phase 16 watchdog + circuit-breaker tests ===
+
+Test 1: classify_age thresholds
+  PASS: 0s -> fresh
+  PASS: 300s -> fresh
+  PASS: 301s -> stale-check
+  PASS: 600s -> stale-check
+  PASS: 601s -> stale-reassign
+  PASS: 1200s -> stale-reassign
+  PASS: 1201s -> stale-reassign
+  PASS: 1800s -> stale-reassign
+  PASS: 1801s -> timed-out
+  PASS: 7200s -> timed-out
+
+Test 2: watchdog_poll on empty state
+  PASS: missing quantum.json -> []
+
+Test 3: watchdog_poll fresh in_progress story
+  PASS: only the in_progress story returned
+  PASS: story_id is US-001
+  PASS: fresh -> continue
+  PASS: classification fresh
+
+Test 4: watchdog_poll stale-check (~400s old)
+  PASS: 400s -> stale-check
+  PASS: stale-check -> status-probe
+
+Test 5: watchdog_poll timed-out (>30min old)
+  PASS: 2400s -> timed-out
+  PASS: timed-out -> mark-failed
+
+Test 6: error_counter_bump same signature increments
+  PASS: first bump count 1
+  PASS: second bump count 2
+  PASS: third bump count 3
+
+Test 7: different signature resets counter
+  PASS: sig-A count reaches 2
+  PASS: sig-B resets to 1
+  PASS: sig-B next bump is 2
+
+Test 8: should_circuit_break crosses threshold
+  PASS: count=1, threshold=3 -> no break (exit 1)
+  PASS: count=3, threshold=3 -> BREAK (exit 0)
+  PASS: count=3, threshold=10 -> no break
+
+Test 9: error_counter_reset
+  PASS: after reset, no break
+  PASS: count after reset=1
+
+Test 10: CLI subcommands
+  PASS: CLI classify 500 -> stale-check
+  PASS: CLI bump first -> 1
+
+=== Results: 32/32 passed, 0 failed ===

--- a/lib/reground.sh
+++ b/lib/reground.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# lib/reground.sh — periodic re-grounding of agent context (Phase 28 / P3.9).
+#
+# Sources:
+#   arXiv:2603.00492 — "Context drift in long-horizon agents"
+#   arXiv:2602.18822 — "Refresh-prompting mitigates goal drift in multi-
+#                       step task agents by +23% success"
+#
+# Problem: after many stories, agents lose fidelity to the original PRD.
+# Each iteration starts with a fresh context window, but the fresh context
+# is populated only with `quantum.json` state + the story at hand — NOT
+# with a reminder of the overall goal.
+#
+# Solution: every N stories, inject a re-grounding block into the
+# implementer prompt that summarizes (a) the PRD goal, (b) progress so
+# far, (c) the iron law of fresh-evidence verification. Cheap, and the
+# cited paper shows measurable drift mitigation.
+#
+# Orthogonal to:
+#   lib/watchdog.sh        — wall-clock staleness of a single agent
+#   lib/trajectory.sh      — tool-shape thrashing within a single story
+#   lib/constitution.sh    — regex-checkable invariants about generated code
+#   This lib                — SESSION-level drift from the PRD
+#
+# Functions:
+#   should_reground STATE_JSON
+#     Exit 0 if iteration is at or past the next re-ground threshold.
+#     Exit 1 otherwise. Threshold is REGROUND_INTERVAL stories since
+#     lastGroundedIteration (tracked in state).
+#
+#   build_reground_context QUANTUM_JSON
+#     Emits a markdown block summarizing goal + progress + reminders.
+#     Designed to be prepended to the next implementer prompt.
+#
+#   mark_grounded QUANTUM_JSON_PATH
+#     Sets .state.lastGroundedIteration = .iteration in the file. Uses
+#     a temp file + atomic rename.
+#
+# Library contract: no shell flags at source time; CLI block enables
+# strict mode locally.
+
+REGROUND_LIB_DIR="${REGROUND_LIB_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+
+: "${REGROUND_INTERVAL:=5}"     # re-ground every N stories by default
+: "${REGROUND_PRD_HEAD_LINES:=20}"  # how many lines of PRD to include
+: "${REGROUND_NEXT_STORIES:=3}"     # how many upcoming stories to preview
+
+# should_reground(state_json)
+# Returns exit 0 iff (iteration - lastGroundedIteration) >= REGROUND_INTERVAL.
+# Rationale: we re-ground at fixed intervals regardless of story outcome,
+# so a long streak of passes doesn't cause drift silently.
+should_reground() {
+  local state="${1:-}"
+  [[ -z "$state" ]] && state=$(cat)
+  local iter last
+  iter=$(jq -r '.iteration // 0' <<< "$state")
+  last=$(jq -r '.state.lastGroundedIteration // 0' <<< "$state")
+  local delta=$(( iter - last ))
+  if (( delta >= REGROUND_INTERVAL )); then
+    return 0
+  fi
+  return 1
+}
+
+# build_reground_context(quantum_json)
+# Emits a markdown-ish block on stdout. Safe on missing fields (uses //).
+# Reads PRD file if .prdPath exists and is readable.
+build_reground_context() {
+  local q="${1:-}"
+  [[ -z "$q" ]] && q=$(cat)
+  local prd_path branch iter total passed failed pending
+  prd_path=$(jq -r '.prdPath // ""' <<< "$q")
+  branch=$(jq -r '.branchName // "(unknown)"' <<< "$q")
+  iter=$(jq -r '.iteration // 0' <<< "$q")
+  total=$(jq '.stories | length // 0' <<< "$q")
+  passed=$(jq '[.stories[]? | select(.status == "passed")] | length' <<< "$q")
+  failed=$(jq '[.stories[]? | select(.status == "failed")] | length' <<< "$q")
+  pending=$(jq '[.stories[]? | select(.status == "pending")] | length' <<< "$q")
+
+  {
+    printf "## Re-grounding (iteration %s)\n\n" "$iter"
+    printf "**Branch**: \`%s\`\n" "$branch"
+    printf "**PRD**: \`%s\`\n" "${prd_path:-(not set)}"
+    printf "**Progress**: %s/%s passed, %s failed, %s pending\n\n" \
+      "$passed" "$total" "$failed" "$pending"
+    printf "### Goal reminder\n\n"
+    printf "Stay faithful to the PRD. Verify EACH claim with fresh evidence.\n"
+    printf "Make small surgical changes — no speculative refactors.\n\n"
+    if [[ -n "$prd_path" && -f "$prd_path" ]]; then
+      printf "### PRD head (first %s lines)\n\n" "$REGROUND_PRD_HEAD_LINES"
+      printf '```\n'
+      head -n "$REGROUND_PRD_HEAD_LINES" "$prd_path"
+      printf '\n```\n\n'
+    fi
+    printf "### Next %s pending stories\n\n" "$REGROUND_NEXT_STORIES"
+    jq -r --argjson k "$REGROUND_NEXT_STORIES" \
+      '[.stories[]? | select(.status == "pending")]
+       | sort_by(.priority // 999)
+       | .[0:$k]
+       | .[]
+       | "- **\(.id // "(no-id)")** (prio \(.priority // "?")): \(.title // "(no title)")"' \
+      <<< "$q"
+  }
+}
+
+# mark_grounded(quantum_json_path)
+# Updates .state.lastGroundedIteration to .iteration in the file. Atomic
+# via temp file + mv.
+mark_grounded() {
+  local path="${1:?path required}"
+  [[ -f "$path" ]] || return 1
+  local q iter
+  q=$(cat "$path")
+  iter=$(jq -r '.iteration // 0' <<< "$q")
+  local tmp="${path}.reground.tmp"
+  jq --argjson i "$iter" \
+    '.state = (.state // {}) | .state.lastGroundedIteration = $i' \
+    <<< "$q" > "$tmp"
+  mv "$tmp" "$path"
+}
+
+# ------------------------------------------------------------------------------
+# CLI entry
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  set -euo pipefail
+  subcmd="${1:-}"
+  shift || true
+  case "$subcmd" in
+    should)   should_reground "$@" ;;
+    context)  build_reground_context "$@" ;;
+    mark)     mark_grounded "$@" ;;
+    *)
+      cat >&2 <<USAGE
+Usage: bash lib/reground.sh <subcmd> [args...]
+  should  < state      — exit 0 if re-grounding is due
+  context < quantum    — emit re-grounding markdown block
+  mark    QUANTUM_PATH — update lastGroundedIteration in-place
+USAGE
+      exit 2
+      ;;
+  esac
+fi

--- a/tests/test_reground.sh
+++ b/tests/test_reground.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+# Phase 28 / P3.9 — re-grounding tests.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR/.."
+PASS=0
+FAIL=0
+TOTAL=0
+
+assert() {
+  local name="$1" expected="$2" actual="$3"
+  TOTAL=$((TOTAL + 1))
+  if [[ "$expected" == "$actual" ]]; then
+    echo "  PASS: $name"; PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $name (expected [$expected] got [$actual])"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# shellcheck disable=SC1091
+source "$REPO_ROOT/lib/reground.sh"
+
+echo "=== Phase 28 re-grounding tests ==="
+
+# Test 1: should_reground — at interval triggers
+echo ""
+echo "Test 1: should_reground at interval"
+state=$(jq -cn '{iteration: 5, state: {lastGroundedIteration: 0}}')
+should_reground "$state"
+assert "iter=5, last=0, interval=5 -> 0" "0" "$?"
+
+# Test 2: should_reground — below interval does not trigger
+echo ""
+echo "Test 2: below interval"
+state=$(jq -cn '{iteration: 3, state: {lastGroundedIteration: 0}}')
+should_reground "$state"
+assert "iter=3, last=0, interval=5 -> 1" "1" "$?"
+
+# Test 3: should_reground — past interval triggers
+echo ""
+echo "Test 3: past interval (delta 6)"
+state=$(jq -cn '{iteration: 10, state: {lastGroundedIteration: 4}}')
+should_reground "$state"
+assert "iter=10, last=4, interval=5 -> 0" "0" "$?"
+
+# Test 4: should_reground — just after grounding doesn't re-trigger
+echo ""
+echo "Test 4: just-grounded state"
+state=$(jq -cn '{iteration: 5, state: {lastGroundedIteration: 5}}')
+should_reground "$state"
+assert "iter=5, last=5 -> 1" "1" "$?"
+
+# Test 5: should_reground — missing state field defaults to 0
+echo ""
+echo "Test 5: missing lastGroundedIteration defaults to 0"
+state=$(jq -cn '{iteration: 5}')
+should_reground "$state"
+assert "no state field, iter=5 -> 0" "0" "$?"
+
+# Test 6: should_reground — env override REGROUND_INTERVAL
+echo ""
+echo "Test 6: REGROUND_INTERVAL override"
+state=$(jq -cn '{iteration: 3, state: {lastGroundedIteration: 0}}')
+REGROUND_INTERVAL=3 should_reground "$state"
+assert "interval=3, delta=3 -> 0" "0" "$?"
+REGROUND_INTERVAL=10 should_reground "$state"
+assert "interval=10, delta=3 -> 1" "1" "$?"
+
+# Test 7: should_reground — reads from stdin when no arg
+echo ""
+echo "Test 7: stdin input"
+state=$(jq -cn '{iteration: 5, state: {lastGroundedIteration: 0}}')
+printf '%s' "$state" | should_reground
+assert "stdin trigger" "0" "$?"
+
+# Test 8: build_reground_context — basic shape
+echo ""
+echo "Test 8: build_reground_context shape"
+q=$(jq -cn '{
+  iteration: 7,
+  branchName: "feat/x",
+  prdPath: "/nonexistent/spec.md",
+  stories: [
+    {id: "S1", status: "passed", priority: 1, title: "a"},
+    {id: "S2", status: "passed", priority: 2, title: "b"},
+    {id: "S3", status: "pending", priority: 3, title: "c"},
+    {id: "S4", status: "failed", priority: 4, title: "d"},
+    {id: "S5", status: "pending", priority: 5, title: "e"}
+  ]
+}')
+ctx=$(printf '%s' "$q" | build_reground_context)
+case "$ctx" in *"## Re-grounding (iteration 7)"*) echo "  PASS: header with iteration"; PASS=$((PASS + 1));;
+                *) echo "  FAIL: no header"; FAIL=$((FAIL + 1));;
+esac
+TOTAL=$((TOTAL + 1))
+case "$ctx" in *"feat/x"*) echo "  PASS: branch rendered"; PASS=$((PASS + 1));;
+                *) echo "  FAIL: no branch"; FAIL=$((FAIL + 1));;
+esac
+TOTAL=$((TOTAL + 1))
+case "$ctx" in *"2/5 passed"*"1 failed"*"2 pending"*) echo "  PASS: progress counts"; PASS=$((PASS + 1));;
+                *) echo "  FAIL: progress counts missing"; FAIL=$((FAIL + 1));;
+esac
+TOTAL=$((TOTAL + 1))
+case "$ctx" in *"Goal reminder"*"Verify EACH claim"*) echo "  PASS: goal reminder"; PASS=$((PASS + 1));;
+                *) echo "  FAIL: no goal reminder"; FAIL=$((FAIL + 1));;
+esac
+TOTAL=$((TOTAL + 1))
+
+# Test 9: build_reground_context — next stories listed in priority order
+echo ""
+echo "Test 9: next pending stories listed"
+case "$ctx" in *"S3"*"S5"*) echo "  PASS: pending stories S3, S5 listed"; PASS=$((PASS + 1));;
+                *) echo "  FAIL: pending stories missing"; FAIL=$((FAIL + 1));;
+esac
+TOTAL=$((TOTAL + 1))
+# Passed/failed stories should NOT appear in the next-up list
+case "$ctx" in
+  *"- **S1**"*|*"- **S2**"*|*"- **S4**"*)
+    echo "  FAIL: non-pending story in next-up list"; FAIL=$((FAIL + 1));;
+  *)
+    echo "  PASS: only pending stories in next-up"; PASS=$((PASS + 1));;
+esac
+TOTAL=$((TOTAL + 1))
+
+# Test 10: build_reground_context — PRD head included when file exists
+echo ""
+echo "Test 10: PRD head included when file exists"
+TEST_TMPDIR=$(mktemp -d)
+cat > "$TEST_TMPDIR/spec.md" << 'EOF'
+# Feature X
+
+Build widget that does Y. Users should be able to Z.
+
+## Acceptance criteria
+
+- Widget exists
+- Widget works
+EOF
+q=$(jq -cn --arg p "$TEST_TMPDIR/spec.md" '{
+  iteration: 5, branchName: "b", prdPath: $p,
+  stories: [{id: "S1", status: "pending", priority: 1, title: "t"}]
+}')
+ctx=$(printf '%s' "$q" | build_reground_context)
+case "$ctx" in *"### PRD head"*"Build widget that does Y"*) echo "  PASS: PRD head rendered"; PASS=$((PASS + 1));;
+                *) echo "  FAIL: no PRD head content"; FAIL=$((FAIL + 1));;
+esac
+TOTAL=$((TOTAL + 1))
+rm -rf "$TEST_TMPDIR"
+
+# Test 11: build_reground_context — missing PRD file gracefully skipped
+echo ""
+echo "Test 11: missing PRD handled"
+q=$(jq -cn '{
+  iteration: 1, prdPath: "/does/not/exist.md",
+  stories: [{id: "S1", status: "pending", priority: 1, title: "t"}]
+}')
+ctx=$(printf '%s' "$q" | build_reground_context)
+case "$ctx" in *"PRD head"*) echo "  FAIL: PRD head section rendered for missing file"; FAIL=$((FAIL + 1));;
+                *) echo "  PASS: missing PRD skipped cleanly"; PASS=$((PASS + 1));;
+esac
+TOTAL=$((TOTAL + 1))
+
+# Test 12: build_reground_context — empty quantum.json (no stories)
+echo ""
+echo "Test 12: empty stories array"
+q=$(jq -cn '{iteration: 0, stories: []}')
+ctx=$(printf '%s' "$q" | build_reground_context)
+case "$ctx" in *"0/0 passed"*) echo "  PASS: empty progress rendered"; PASS=$((PASS + 1));;
+                *) echo "  FAIL: empty progress wrong"; FAIL=$((FAIL + 1));;
+esac
+TOTAL=$((TOTAL + 1))
+
+# Test 13: mark_grounded — writes lastGroundedIteration
+echo ""
+echo "Test 13: mark_grounded updates state"
+TEST_TMPDIR=$(mktemp -d)
+echo '{"iteration": 7, "state": {"other": "keep"}}' > "$TEST_TMPDIR/q.json"
+mark_grounded "$TEST_TMPDIR/q.json"
+after=$(jq -r '.state.lastGroundedIteration' "$TEST_TMPDIR/q.json")
+assert "lastGroundedIteration = 7" "7" "$after"
+# Verify other state fields preserved
+other=$(jq -r '.state.other' "$TEST_TMPDIR/q.json")
+assert "other state preserved" "keep" "$other"
+rm -rf "$TEST_TMPDIR"
+
+# Test 14: mark_grounded — creates state object if missing
+echo ""
+echo "Test 14: mark_grounded creates state if absent"
+TEST_TMPDIR=$(mktemp -d)
+echo '{"iteration": 3}' > "$TEST_TMPDIR/q.json"
+mark_grounded "$TEST_TMPDIR/q.json"
+after=$(jq -r '.state.lastGroundedIteration' "$TEST_TMPDIR/q.json")
+assert "state created, lastGroundedIteration = 3" "3" "$after"
+rm -rf "$TEST_TMPDIR"
+
+# Test 15: mark_grounded — missing file returns non-zero
+echo ""
+echo "Test 15: mark_grounded missing file"
+mark_grounded "/nonexistent/q.json" 2>/dev/null
+assert "missing file -> exit 1" "1" "$?"
+
+# Test 16: mark_grounded then should_reground == false on that state
+echo ""
+echo "Test 16: mark_grounded resets the should_reground signal"
+TEST_TMPDIR=$(mktemp -d)
+echo '{"iteration": 10}' > "$TEST_TMPDIR/q.json"
+# Before marking: delta = 10 - 0 = 10, >= 5 → should_reground
+cat "$TEST_TMPDIR/q.json" | should_reground
+assert "before mark: should -> 0" "0" "$?"
+mark_grounded "$TEST_TMPDIR/q.json"
+# After marking: delta = 10 - 10 = 0 → no
+cat "$TEST_TMPDIR/q.json" | should_reground
+assert "after mark: should -> 1" "1" "$?"
+rm -rf "$TEST_TMPDIR"
+
+# Test 17: CLI subcommands
+echo ""
+echo "Test 17: CLI subcommands"
+state=$(jq -cn '{iteration: 5, state: {lastGroundedIteration: 0}}')
+printf '%s' "$state" | bash "$REPO_ROOT/lib/reground.sh" should
+assert "CLI should -> 0" "0" "$?"
+# CLI context
+q=$(jq -cn '{iteration: 2, stories: [{id: "X", status: "pending", priority: 1, title: "t"}]}')
+cli_ctx=$(printf '%s' "$q" | bash "$REPO_ROOT/lib/reground.sh" context)
+case "$cli_ctx" in *"Re-grounding (iteration 2)"*) echo "  PASS: CLI context"; PASS=$((PASS + 1));;
+                    *) echo "  FAIL: CLI context missing header"; FAIL=$((FAIL + 1));;
+esac
+TOTAL=$((TOTAL + 1))
+# CLI mark
+TEST_TMPDIR=$(mktemp -d)
+echo '{"iteration": 9}' > "$TEST_TMPDIR/q.json"
+bash "$REPO_ROOT/lib/reground.sh" mark "$TEST_TMPDIR/q.json"
+after=$(jq -r '.state.lastGroundedIteration' "$TEST_TMPDIR/q.json")
+assert "CLI mark updates field" "9" "$after"
+rm -rf "$TEST_TMPDIR"
+
+echo ""
+echo "=== Results: $PASS/$TOTAL passed, $FAIL failed ==="
+exit $((FAIL > 0 ? 1 : 0))


### PR DESCRIPTION
Seventh P3 wedge. Session-level drift mitigation: every N stories, inject a re-grounding block summarizing the PRD goal + progress + iron-law reminder into the next implementer prompt.

## Signal space

| Lib | Granularity | Signal |
|-----|-------------|--------|
| `watchdog.sh` | 1 agent | wall-clock staleness |
| `trajectory.sh` | 1 story | tool-shape thrashing |
| `constitution.sh` | 1 patch | regex-checkable invariants |
| **`reground.sh`** | **N stories** | **PRD drift** |

## Functions

| Function | Purpose |
|----------|---------|
| `should_reground STATE` | exit 0 if `(iteration - lastGroundedIteration) >= REGROUND_INTERVAL` |
| `build_reground_context QUANTUM` | markdown: goal + progress + PRD head + next K pending stories |
| `mark_grounded PATH` | atomic update of `.state.lastGroundedIteration` |

## Tunables

- `REGROUND_INTERVAL=5` — re-ground every N stories
- `REGROUND_PRD_HEAD_LINES=20` — PRD excerpt length
- `REGROUND_NEXT_STORIES=3` — upcoming stories preview count

## Tests

26 new tests, 382 total across 13 related suites, all green.

## Test plan

- [x] All 26 reground tests pass
- [x] No regressions in 12 adjacent test suites
- [x] CLI subcommands verified (`should`, `context`, `mark`)
- [ ] Wire into orchestrator iteration loop (separate PR)