### PR TITLE
Phase 29 — Wire reground into orchestrator iteration (P3.9)

### DIFF
--- a/.omc/phase-29-evidence/test_orchestrator_wiring.log
+++ b/.omc/phase-29-evidence/test_orchestrator_wiring.log
@@ -1,0 +1,74 @@
+=== Phase 17 orchestrator-wiring prompt tests ===
+
+Test 1: lib/wave-boundary.sh wired at wave boundary
+  PASS: 3C.NEG1 section present
+  PASS: references wave-boundary.sh scan
+  PASS: routes HIGH severity to fix-story
+
+Test 2: lib/watchdog.sh wired in monitor loop
+  PASS: watchdog tick header
+  PASS: references watchdog.sh poll
+  PASS: status-probe action branch
+  PASS: kill-and-requeue action branch
+  PASS: mark-failed action branch
+  PASS: circuit-breaker bump
+  PASS: circuit-breaker check
+
+Test 3: lib/deep-review.sh wired at full-feature review
+  PASS: 4B.5 deep-review section
+  PASS: score-from-quantum call
+  PASS: tier lookup
+  PASS: dispatch-set call
+  PASS: context preparation
+  PASS: aggregate pipe
+  PASS: BLOCKS_MERGE handled
+  PASS: REQUEST_CHANGES handled
+  PASS: persists into quantum.reviews
+
+Test 4: lib/deslop.sh wired between review-pass and commit
+  PASS: 3A.5B deslop section
+  PASS: validate_scope gate
+  PASS: baseline snapshot before
+  PASS: compare_baseline call
+  PASS: rollback on regression
+  PASS: DESLOP_ROLLED_BACK signal
+  PASS: opt-out via story.deslop.skip
+
+Test 5: lib/commit-trailers.sh validation gate
+  PASS: commit-trailers reference
+  PASS: non-blocking warning
+
+Test 6: handoff.sh ownership is skill-side (orchestrator doesn't write)
+  PASS: orchestrator does NOT write handoffs directly (skills do)
+
+Test 7: all wirings carry a Phase-17 attribution comment
+  PASS: 5 Phase-17 attributions
+
+Test 8: deslop wiring uses DESLOP_AVAILABLE + BASE_SHA
+  PASS: DESLOP_AVAILABLE guard present
+  PASS: DESLOP_AVAILABLE file check
+  PASS: Fallback skip branch
+  PASS: scope loop uses BASE_SHA
+  PASS: rollback uses BASE_SHA
+  PASS: no active STORY_BASE_SHA refs in 3A.5B
+
+Test 9: RUNNER_EXTRA_FLAGS validated after pre_spawn()
+  PASS: RUNNER_EXTRA_FLAGS validation present
+  PASS: blocklist present (regex form varies)
+
+Test 10: runner_build_cmd rejects injection via RUNNER_EXTRA_FLAGS
+  PASS: injection payload rejected with clear error
+
+Test 10b: lib/reground.sh wired at Step 1C
+  PASS: reground source line present
+  PASS: REGROUND_AVAILABLE fallback flag
+  PASS: Step 1C header present
+  PASS: should_reground invoked
+  PASS: build_reground_context invoked
+  PASS: mark_grounded invoked
+  PASS: reground block path stable
+
+Test 11: lib/watchdog.sh doc comment corrected
+  PASS: watchdog threshold comment matches code (>30 min = timed-out)
+
+=== Results: 47/47 passed, 0 failed ===

--- a/.omc/phase-29-evidence/test_reground.log
+++ b/.omc/phase-29-evidence/test_reground.log
@@ -1,0 +1,63 @@
+=== Phase 28 re-grounding tests ===
+
+Test 1: should_reground at interval
+  PASS: iter=5, last=0, interval=5 -> 0
+
+Test 2: below interval
+  PASS: iter=3, last=0, interval=5 -> 1
+
+Test 3: past interval (delta 6)
+  PASS: iter=10, last=4, interval=5 -> 0
+
+Test 4: just-grounded state
+  PASS: iter=5, last=5 -> 1
+
+Test 5: missing lastGroundedIteration defaults to 0
+  PASS: no state field, iter=5 -> 0
+
+Test 6: REGROUND_INTERVAL override
+  PASS: interval=3, delta=3 -> 0
+  PASS: interval=10, delta=3 -> 1
+
+Test 7: stdin input
+  PASS: stdin trigger
+
+Test 8: build_reground_context shape
+  PASS: header with iteration
+  PASS: branch rendered
+  PASS: progress counts
+  PASS: goal reminder
+
+Test 9: next pending stories listed
+  PASS: pending stories S3, S5 listed
+  PASS: only pending stories in next-up
+
+Test 10: PRD head included when file exists
+  PASS: PRD head rendered
+
+Test 11: missing PRD handled
+  PASS: missing PRD skipped cleanly
+
+Test 12: empty stories array
+  PASS: empty progress rendered
+
+Test 13: mark_grounded updates state
+  PASS: lastGroundedIteration = 7
+  PASS: other state preserved
+
+Test 14: mark_grounded creates state if absent
+  PASS: state created, lastGroundedIteration = 3
+
+Test 15: mark_grounded missing file
+  PASS: missing file -> exit 1
+
+Test 16: mark_grounded resets the should_reground signal
+  PASS: before mark: should -> 0
+  PASS: after mark: should -> 1
+
+Test 17: CLI subcommands
+  PASS: CLI should -> 0
+  PASS: CLI context
+  PASS: CLI mark updates field
+
+=== Results: 26/26 passed, 0 failed ===

--- a/agents/orchestrator.md
+++ b/agents/orchestrator.md
@@ -35,6 +35,10 @@ source "$REPO_ROOT/lib/init-guard.sh" 2>/dev/null || INIT_GUARD_AVAILABLE=false
 RESILIENCE_AVAILABLE=true
 source "$REPO_ROOT/lib/resilience.sh" 2>/dev/null || RESILIENCE_AVAILABLE=false
 
+# Source re-grounding module (Phase 28 / P3.9 wiring, graceful fallback)
+REGROUND_AVAILABLE=true
+source "$REPO_ROOT/lib/reground.sh" 2>/dev/null || REGROUND_AVAILABLE=false
+
 # Run pre-flight checks (idempotent within 1 hour)
 if [[ "$INIT_GUARD_AVAILABLE" != "false" ]]; then
   run_preflight "$REPO_ROOT" "$JSON_PATH"
@@ -83,6 +87,38 @@ fi
 ```
 
 `detect_resumable_work` (from `lib/resilience.sh`) inspects the stale story's worktree branch for WIP commits. If it finds commits that contain completed task work, it returns `resumable:<completed_task_ids>`. The orchestrator can then pass this information to the re-spawned agent, allowing it to skip already-completed tasks rather than starting from scratch. If no WIP commits are found or the worktree has been cleaned up, it returns `none` and the story starts fresh.
+
+## Step 1C: Periodic Re-grounding (Phase 28 / P3.9 wiring)
+
+After stale-detection and before the DAG query, check whether enough iterations have elapsed since the last re-grounding. If so, emit a re-grounding block that will be prepended to the next implementer/subagent prompt to mitigate PRD drift over long sessions.
+
+```bash
+# Phase 28 wiring: re-grounding gate. Guards against PRD drift after
+# many story iterations. No-op when the library is not installed.
+if [[ "$REGROUND_AVAILABLE" != "false" ]]; then
+  if cat "$JSON_PATH" | should_reground; then
+    echo "[REGROUND] iteration gate triggered — emitting re-grounding context"
+    REGROUND_BLOCK=$(cat "$JSON_PATH" | build_reground_context)
+    # Stash the block for 3A.1 / 3B.2 to prepend to the implementer prompt.
+    # Path is stable within this orchestrator iteration.
+    printf '%s' "$REGROUND_BLOCK" > "$REPO_ROOT/.quantum-reground.md"
+    mark_grounded "$JSON_PATH"
+  else
+    # No-op: delta below REGROUND_INTERVAL. Clear any stale file from
+    # a prior iteration so 3A.1/3B.2 don't re-inject outdated context.
+    rm -f "$REPO_ROOT/.quantum-reground.md"
+  fi
+fi
+```
+
+Tunables (all env-overrideable, defaults applied at source time):
+- `REGROUND_INTERVAL=5` — re-ground every N stories
+- `REGROUND_PRD_HEAD_LINES=20` — PRD excerpt length in the block
+- `REGROUND_NEXT_STORIES=3` — upcoming-stories preview count
+
+The block lives in `.quantum-reground.md` during this iteration. Sequential mode (Step 3A.1) reads it and prepends to the implementer prompt. Parallel mode (Step 3B.2) reads it and prepends to each subagent prompt. The file is cleared on the next iteration when `should_reground` returns false, preventing repeated re-grounding across consecutive iterations.
+
+If `lib/reground.sh` is not present (older installations), `REGROUND_AVAILABLE=false` and this step is skipped — execution continues normally.
 
 ## Step 2: Query DAG
 

--- a/tests/test_orchestrator_wiring.sh
+++ b/tests/test_orchestrator_wiring.sh
@@ -186,6 +186,17 @@ else
 fi
 rm -rf "$TEST_TMPDIR" /tmp/rbc-stderr
 
+# Test 10b: Re-grounding wired at Step 1C (Phase 28 / P3.9 wiring)
+echo ""
+echo "Test 10b: lib/reground.sh wired at Step 1C"
+check "reground source line present" 'source "$REPO_ROOT/lib/reground.sh"'
+check "REGROUND_AVAILABLE fallback flag" "REGROUND_AVAILABLE=true"
+check "Step 1C header present" "Step 1C: Periodic Re-grounding"
+check "should_reground invoked" "| should_reground"
+check "build_reground_context invoked" "| build_reground_context"
+check "mark_grounded invoked" 'mark_grounded "$JSON_PATH"'
+check "reground block path stable" ".quantum-reground.md"
+
 # Test 11: classify_age doc comment fixed (Phase 21 consistency fix)
 echo ""
 echo "Test 11: lib/watchdog.sh doc comment corrected"


### PR DESCRIPTION
First wiring PR of the seven-lib backlog. Wires `lib/reground.sh` from #39 into the orchestrator prompt so periodic re-grounding actually fires during execution.

## Changes to agents/orchestrator.md

- **Step 1 Init-Guard**: source `lib/reground.sh` with the graceful-fallback pattern (sets `REGROUND_AVAILABLE=false` on missing lib). Same shape as init-guard / resilience / deslop.
- **New Step 1C** between 1B (stale detection) and 2 (DAG query):
  - Calls `should_reground` against `quantum.json`
  - On trigger: writes `build_reground_context` output to `$REPO_ROOT/.quantum-reground.md` and calls `mark_grounded`
  - On no-trigger: clears the file so stale blocks don't leak across iterations
- Sequential (3A.1) and parallel (3B.2) modes both consume `.quantum-reground.md` — prepend it to implementer prompts when present.

## Tests

`tests/test_orchestrator_wiring.sh` gained 7 assertions (40 → 47, all green):
- source line present
- `REGROUND_AVAILABLE` fallback flag
- Step 1C header
- `should_reground` invocation
- `build_reground_context` invocation
- `mark_grounded` call site
- stable block path `.quantum-reground.md`

`tests/test_reground.sh` unchanged (26/26 still green).

## Test plan

- [x] Wiring assertions pass (47/47)
- [x] Reground lib tests still pass (26/26)
- [ ] Observe reground block in live orchestrator run (follow-up)