### PR TITLE
Phase 30 — Wire tracecoder into orchestrator repair loop (P3.8)

### DIFF
--- a/.omc/phase-30-evidence/test_orchestrator_wiring.log
+++ b/.omc/phase-30-evidence/test_orchestrator_wiring.log
@@ -1,0 +1,82 @@
+=== Phase 17 orchestrator-wiring prompt tests ===
+
+Test 1: lib/wave-boundary.sh wired at wave boundary
+  PASS: 3C.NEG1 section present
+  PASS: references wave-boundary.sh scan
+  PASS: routes HIGH severity to fix-story
+
+Test 2: lib/watchdog.sh wired in monitor loop
+  PASS: watchdog tick header
+  PASS: references watchdog.sh poll
+  PASS: status-probe action branch
+  PASS: kill-and-requeue action branch
+  PASS: mark-failed action branch
+  PASS: circuit-breaker bump
+  PASS: circuit-breaker check
+
+Test 3: lib/deep-review.sh wired at full-feature review
+  PASS: 4B.5 deep-review section
+  PASS: score-from-quantum call
+  PASS: tier lookup
+  PASS: dispatch-set call
+  PASS: context preparation
+  PASS: aggregate pipe
+  PASS: BLOCKS_MERGE handled
+  PASS: REQUEST_CHANGES handled
+  PASS: persists into quantum.reviews
+
+Test 4: lib/deslop.sh wired between review-pass and commit
+  PASS: 3A.5B deslop section
+  PASS: validate_scope gate
+  PASS: baseline snapshot before
+  PASS: compare_baseline call
+  PASS: rollback on regression
+  PASS: DESLOP_ROLLED_BACK signal
+  PASS: opt-out via story.deslop.skip
+
+Test 5: lib/commit-trailers.sh validation gate
+  PASS: commit-trailers reference
+  PASS: non-blocking warning
+
+Test 6: handoff.sh ownership is skill-side (orchestrator doesn't write)
+  PASS: orchestrator does NOT write handoffs directly (skills do)
+
+Test 7: all wirings carry a Phase-17 attribution comment
+  PASS: 5 Phase-17 attributions
+
+Test 8: deslop wiring uses DESLOP_AVAILABLE + BASE_SHA
+  PASS: DESLOP_AVAILABLE guard present
+  PASS: DESLOP_AVAILABLE file check
+  PASS: Fallback skip branch
+  PASS: scope loop uses BASE_SHA
+  PASS: rollback uses BASE_SHA
+  PASS: no active STORY_BASE_SHA refs in 3A.5B
+
+Test 9: RUNNER_EXTRA_FLAGS validated after pre_spawn()
+  PASS: RUNNER_EXTRA_FLAGS validation present
+  PASS: blocklist present (regex form varies)
+
+Test 10: runner_build_cmd rejects injection via RUNNER_EXTRA_FLAGS
+  PASS: injection payload rejected with clear error
+
+Test 10b: lib/reground.sh wired at Step 1C
+  PASS: reground source line present
+  PASS: REGROUND_AVAILABLE fallback flag
+  PASS: Step 1C header present
+  PASS: should_reground invoked
+  PASS: build_reground_context invoked
+  PASS: mark_grounded invoked
+  PASS: reground block path stable
+
+Test 10c: lib/tracecoder.sh wired at Step 3A.3
+  PASS: tracecoder source line present
+  PASS: TRACECODER_AVAILABLE fallback flag
+  PASS: observe primitive invoked
+  PASS: should_repair gate check
+  PASS: build_analysis_context call
+  PASS: opaque-failure bypass documented
+
+Test 11: lib/watchdog.sh doc comment corrected
+  PASS: watchdog threshold comment matches code (>30 min = timed-out)
+
+=== Results: 53/53 passed, 0 failed ===

--- a/.omc/phase-30-evidence/test_tracecoder.log
+++ b/.omc/phase-30-evidence/test_tracecoder.log
@@ -1,0 +1,58 @@
+=== Phase 27 TraceCoder tests ===
+
+Test 1: observe a passing command
+  PASS: exit=0
+  PASS: name=greeting
+  PASS: tail contains hello
+
+Test 2: observe a failing command
+  PASS: exit=1
+
+Test 3: observe merges stderr
+  PASS: both streams in tail
+
+Test 4: extract tsc-style markers
+  PASS: 1 marker parsed
+  PASS: file=src/app.ts
+  PASS: line=42
+  PASS: message captured
+
+Test 5: extract python traceback
+  PASS: 1 marker parsed
+  PASS: python file
+  PASS: python line
+
+Test 6: extract node stack
+  PASS: node stack parsed
+  PASS: node file
+  PASS: node line
+
+Test 7: multiple markers + URL noise filtering
+  PASS: 2 real markers (URL filtered)
+
+Test 8: empty tail
+  PASS: empty tail -> []
+
+Test 9: build_analysis_context shape
+  PASS: header present
+  PASS: exit code visible
+  PASS: tail section present
+
+Test 10: context includes markers
+  PASS: marker rendered in context
+
+Test 11: should_repair semantics
+  PASS: failure + markers -> 0
+  PASS: pass -> no repair (1)
+  PASS: opaque failure -> no repair (1)
+
+Test 12: tail truncates to TRACECODER_TAIL_LINES
+  PASS: tail is 10 lines
+  PASS: tail starts at line_191
+
+Test 13: CLI subcommands
+  PASS: CLI observe exit=0
+  PASS: CLI markers count=1
+  PASS: CLI should-repair exits 0
+
+=== Results: 29/29 passed, 0 failed ===

--- a/agents/orchestrator.md
+++ b/agents/orchestrator.md
@@ -39,6 +39,10 @@ source "$REPO_ROOT/lib/resilience.sh" 2>/dev/null || RESILIENCE_AVAILABLE=false
 REGROUND_AVAILABLE=true
 source "$REPO_ROOT/lib/reground.sh" 2>/dev/null || REGROUND_AVAILABLE=false
 
+# Source tracecoder module (Phase 27 / P3.8 wiring, graceful fallback)
+TRACECODER_AVAILABLE=true
+source "$REPO_ROOT/lib/tracecoder.sh" 2>/dev/null || TRACECODER_AVAILABLE=false
+
 # Run pre-flight checks (idempotent within 1 hour)
 if [[ "$INIT_GUARD_AVAILABLE" != "false" ]]; then
   run_preflight "$REPO_ROOT" "$JSON_PATH"
@@ -203,12 +207,57 @@ After each task: update `task.status` to `"passed"` or `"failed"` in quantum.jso
 On task failure: stop, proceed to error handling (Step 3A.7).
 
 ### 3A.3: Quality Checks
-After all tasks pass, run:
+After all tasks pass, run the three quality gates — each wrapped in the tracecoder `observe` primitive so the failure path has structured evidence to reason over:
 1. Typecheck (tsc --noEmit, pyright, mypy, etc.)
 2. Lint (eslint, ruff, etc.)
 3. Full test suite (npm test, pytest, etc.)
 
-If any check fails: ONE focused fix attempt, re-run. If still fails -> mark story failed.
+On failure, follow the Observe-Analyze-Repair loop (Phase 27 / P3.8 wiring) instead of a blind retry:
+
+```bash
+# Phase 27 wiring: tracecoder-guided quality-gate repair loop.
+# Benefit over a single-pass verify: the repair step reasons on parsed
+# error markers (file:line extraction), not raw log bytes; and an
+# opaque failure (non-zero exit, no recognizable markers) bypasses the
+# low-signal loop entirely — better to fail the story fast than burn a
+# retry on a signal the LLM can't ground.
+if [[ "$TRACECODER_AVAILABLE" != "false" ]]; then
+  for gate in typecheck lint test; do
+    # Observe: run the gate and capture exit/duration/tail as JSON
+    OBS=$(observe "${GATE_CMD[$gate]}" "$gate")
+    EXIT=$(jq -r '.exit' <<< "$OBS")
+    if (( EXIT == 0 )); then continue; fi
+
+    # Should we even try to repair? Only if exit!=0 AND >=1 marker parsed
+    if ! printf '%s' "$OBS" | should_repair; then
+      echo "[TRACECODER] $gate failed opaquely (no parsable markers) — marking failed, no repair loop" >&2
+      mark_story_failed "$STORY_ID" "$gate" "opaque failure: $(jq -r '.tail' <<< "$OBS" | head -1)"
+      break
+    fi
+
+    # Analyze: build the LLM-ready context (markers + tail)
+    CTX=$(printf '%s' "$OBS" | build_analysis_context)
+
+    # Repair: ONE focused fix informed by the context block, then re-observe
+    apply_focused_fix "$CTX"
+    OBS2=$(observe "${GATE_CMD[$gate]}" "$gate-retry")
+    if (( $(jq -r '.exit' <<< "$OBS2") != 0 )); then
+      mark_story_failed "$STORY_ID" "$gate" "repair attempt did not resolve: $(jq -r '.tail' <<< "$OBS2" | head -1)"
+      break
+    fi
+  done
+else
+  # Graceful fallback when lib/tracecoder.sh isn't installed: legacy
+  # single-pass "one focused fix attempt" path.
+  # If any check fails: ONE focused fix attempt, re-run. If still fails -> mark story failed.
+  :
+fi
+```
+
+Why this shape:
+- **Structured evidence beats raw logs.** `extract_error_markers` turns a log tail into `[{file, line, message}]` so the focused-fix step reasons at the right granularity.
+- **Opaque failures exit fast.** A segfault or a runner crash with no `file:line:` marker gives the repair step nothing to ground on — waste a retry and you're no closer. Better to surface the story as failed and let the retry-reset path try a cleaner spawn.
+- **One retry budget.** Still at most one repair attempt per gate. The budget isn't the change; the analysis quality is.
 
 ### 3A.4: Integration Wiring Check
 Before running reviews, verify the story's new code is actually connected:

--- a/tests/test_orchestrator_wiring.sh
+++ b/tests/test_orchestrator_wiring.sh
@@ -197,6 +197,16 @@ check "build_reground_context invoked" "| build_reground_context"
 check "mark_grounded invoked" 'mark_grounded "$JSON_PATH"'
 check "reground block path stable" ".quantum-reground.md"
 
+# Test 10c: TraceCoder wired at Step 3A.3 quality-gate failure path (Phase 27 / P3.8)
+echo ""
+echo "Test 10c: lib/tracecoder.sh wired at Step 3A.3"
+check "tracecoder source line present" 'source "$REPO_ROOT/lib/tracecoder.sh"'
+check "TRACECODER_AVAILABLE fallback flag" "TRACECODER_AVAILABLE=true"
+check "observe primitive invoked" 'OBS=$(observe "${GATE_CMD'
+check "should_repair gate check" "| should_repair"
+check "build_analysis_context call" "| build_analysis_context"
+check "opaque-failure bypass documented" "opaque failure"
+
 # Test 11: classify_age doc comment fixed (Phase 21 consistency fix)
 echo ""
 echo "Test 11: lib/watchdog.sh doc comment corrected"


### PR DESCRIPTION
Second wiring PR. Replaces the single-pass 'ONE focused fix attempt' in Step 3A.3 with an Observe-Analyze-Repair loop driven by `lib/tracecoder.sh` (#37).

## Flow change

**Before:** quality gate fails → one blind retry → mark failed.

**After:** `observe` the gate → `should_repair`? If no (opaque) → mark failed fast. If yes → `build_analysis_context` from parsed markers → focused fix → re-observe.

## Why

- **Structured evidence > raw logs.** `extract_error_markers` gives `[{file, line, message}]`; the fix step reasons at that granularity, not on log bytes.
- **Opaque failures bypass the loop.** A segfault with no `file:line:` marker gives nothing to ground on — retrying burns budget for no signal. Better to fail the story fast.
- **Retry budget unchanged.** One repair attempt per gate. The budget isn't what changes — the analysis quality is.

## Fallback

`TRACECODER_AVAILABLE=false` when `lib/tracecoder.sh` absent → legacy single-pass path. Same graceful-fallback pattern as init-guard, resilience, deslop, reground.

## Tests

`tests/test_orchestrator_wiring.sh`: 47 → 53 (+6 assertions).
`tests/test_tracecoder.sh`: unchanged (29/29 green).

## Test plan

- [x] Wiring assertions pass (53/53)
- [x] TraceCoder lib tests still pass (29/29)
- [ ] Observe the repair loop in a live orchestrator run (follow-up)