### PR TITLE
Phase 31 — Skeleton-first extraction / SSAT (P3.1, arXiv:2303.06689)

### DIFF
--- a/.omc/phase-31-evidence/test_conflict_grade.log
+++ b/.omc/phase-31-evidence/test_conflict_grade.log
@@ -1,0 +1,62 @@
+=== Phase 26 conflict-grade tests ===
+
+Test 1: whitespace-only → grade 1
+  PASS: single-ws diff
+  PASS: bracket-indent diff
+
+Test 2: comment-only → grade 2
+  PASS: line comment change
+  PASS: python-style comment change
+  PASS: block comment change
+
+Test 3: single-token rename → grade 2
+  PASS: single identifier rename
+
+Test 4: small body edit → grade 3
+  PASS: 3-line small body edit
+
+Test 5: moderate overlap → grade 4
+  PASS: 7-line overlap
+
+Test 6: structural reorg → grade 5
+  PASS: 2-function reorder
+  PASS: 2-def reorg (python)
+
+Test 7: split_conflict_hunks single
+  PASS: 1 conflict parsed
+  PASS: ours buffer captured
+  PASS: theirs buffer captured
+  PASS: start_line=2
+  PASS: end_line=7
+
+Test 8: split_conflict_hunks multiple
+  PASS: 2 conflicts parsed
+
+Test 9: grade_file end-to-end
+  PASS: 2 hunks graded
+  PASS: max_grade = 5 (structural)
+  PASS: first hunk grade 2 (comment)
+  PASS: second hunk grade 5 (structural)
+
+Test 10: grade_file clean file
+  PASS: clean file max_grade=0
+  PASS: clean file 0 hunks
+
+Test 11: routing_recommendation
+  PASS: grade 0 → none
+  PASS: grade 1 → auto-git
+  PASS: grade 2 → auto-git
+  PASS: grade 3 → diff3
+  PASS: grade 4 → llm-merge
+  PASS: grade 5 → escalate
+
+Test 12a: string literals not truncated at // or /*
+  PASS: identical URL lines → grade 1 (whitespace equiv)
+  PASS: URL preserved, comment-only change → grade 2
+  PASS: URL content changed (single-token) → grade 2
+
+Test 12: CLI subcommands
+  PASS: CLI grade single-word rename
+  PASS: CLI route 4 → llm-merge
+
+=== Results: 33/33 passed, 0 failed ===

--- a/.omc/phase-31-evidence/test_hyclone.log
+++ b/.omc/phase-31-evidence/test_hyclone.log
@@ -1,0 +1,60 @@
+=== Phase 25 HyClone Stage-1 tests ===
+
+Test 1: alpha_normalize basics
+  PASS: whitespace-only renames x
+  PASS: extra whitespace collapsed
+  PASS: multiple identifiers numbered
+
+Test 2: repeated identifiers reuse placeholder
+  PASS: repeated identifier reuses placeholder
+
+Test 3: keywords preserved
+  PASS: keywords preserved
+
+Test 4: comments stripped
+  PASS: line comment // stripped
+  PASS: line comment # stripped
+  PASS: block comment stripped
+
+Test 5: string literals preserved
+  PASS: double-quoted string preserved
+  PASS: single-quoted string preserved
+
+Test 6: clone fingerprints match
+  PASS: different names → same fingerprint
+  PASS: different whitespace → same fingerprint
+
+Test 7: semantic difference → different fingerprints
+  PASS: operator difference changes fingerprint
+  PASS: while vs if different
+
+Test 8: find_clones detects a clone pair
+  PASS: finds 1 clone group
+  PASS: group has 2 members
+  PASS: fnA in clone group
+  PASS: fnB in clone group
+  PASS: fnC NOT in clone group
+
+Test 9: find_clones with all unique functions
+  PASS: no clone groups
+
+Test 10: find_clones with triple
+  PASS: 3-way clone grouped
+  PASS: triple has 3 members
+
+Test 11: CLI subcommands
+  PASS: CLI normalize
+  PASS: CLI fingerprint is 64 hex chars
+
+Test 12: comment markers inside string literals not treated as comments
+  PASS: URL preserved, trailing double-slash stripped
+  PASS: regex preserved, trailing hash stripped
+  PASS: block markers in string do not consume rest
+  PASS: escaped quotes do not terminate string
+  PASS: different URLs -> different fingerprints (Stage-2 would catch)
+
+Test 13: empty input handling
+  PASS: empty normalize -> empty
+  PASS: empty find_clones -> []
+
+=== Results: 31/31 passed, 0 failed ===

--- a/.omc/phase-31-evidence/test_orchestrator_wiring.log
+++ b/.omc/phase-31-evidence/test_orchestrator_wiring.log
@@ -1,0 +1,82 @@
+=== Phase 17 orchestrator-wiring prompt tests ===
+
+Test 1: lib/wave-boundary.sh wired at wave boundary
+  PASS: 3C.NEG1 section present
+  PASS: references wave-boundary.sh scan
+  PASS: routes HIGH severity to fix-story
+
+Test 2: lib/watchdog.sh wired in monitor loop
+  PASS: watchdog tick header
+  PASS: references watchdog.sh poll
+  PASS: status-probe action branch
+  PASS: kill-and-requeue action branch
+  PASS: mark-failed action branch
+  PASS: circuit-breaker bump
+  PASS: circuit-breaker check
+
+Test 3: lib/deep-review.sh wired at full-feature review
+  PASS: 4B.5 deep-review section
+  PASS: score-from-quantum call
+  PASS: tier lookup
+  PASS: dispatch-set call
+  PASS: context preparation
+  PASS: aggregate pipe
+  PASS: BLOCKS_MERGE handled
+  PASS: REQUEST_CHANGES handled
+  PASS: persists into quantum.reviews
+
+Test 4: lib/deslop.sh wired between review-pass and commit
+  PASS: 3A.5B deslop section
+  PASS: validate_scope gate
+  PASS: baseline snapshot before
+  PASS: compare_baseline call
+  PASS: rollback on regression
+  PASS: DESLOP_ROLLED_BACK signal
+  PASS: opt-out via story.deslop.skip
+
+Test 5: lib/commit-trailers.sh validation gate
+  PASS: commit-trailers reference
+  PASS: non-blocking warning
+
+Test 6: handoff.sh ownership is skill-side (orchestrator doesn't write)
+  PASS: orchestrator does NOT write handoffs directly (skills do)
+
+Test 7: all wirings carry a Phase-17 attribution comment
+  PASS: 5 Phase-17 attributions
+
+Test 8: deslop wiring uses DESLOP_AVAILABLE + BASE_SHA
+  PASS: DESLOP_AVAILABLE guard present
+  PASS: DESLOP_AVAILABLE file check
+  PASS: Fallback skip branch
+  PASS: scope loop uses BASE_SHA
+  PASS: rollback uses BASE_SHA
+  PASS: no active STORY_BASE_SHA refs in 3A.5B
+
+Test 9: RUNNER_EXTRA_FLAGS validated after pre_spawn()
+  PASS: RUNNER_EXTRA_FLAGS validation present
+  PASS: blocklist present (regex form varies)
+
+Test 10: runner_build_cmd rejects injection via RUNNER_EXTRA_FLAGS
+  PASS: injection payload rejected with clear error
+
+Test 10b: lib/reground.sh wired at Step 1C
+  PASS: reground source line present
+  PASS: REGROUND_AVAILABLE fallback flag
+  PASS: Step 1C header present
+  PASS: should_reground invoked
+  PASS: build_reground_context invoked
+  PASS: mark_grounded invoked
+  PASS: reground block path stable
+
+Test 10c: lib/tracecoder.sh wired at Step 3A.3
+  PASS: tracecoder source line present
+  PASS: TRACECODER_AVAILABLE fallback flag
+  PASS: observe primitive invoked
+  PASS: should_repair gate check
+  PASS: build_analysis_context call
+  PASS: opaque-failure bypass documented
+
+Test 11: lib/watchdog.sh doc comment corrected
+  PASS: watchdog threshold comment matches code (>30 min = timed-out)
+
+=== Results: 53/53 passed, 0 failed ===

--- a/.omc/phase-31-evidence/test_reground.log
+++ b/.omc/phase-31-evidence/test_reground.log
@@ -1,0 +1,63 @@
+=== Phase 28 re-grounding tests ===
+
+Test 1: should_reground at interval
+  PASS: iter=5, last=0, interval=5 -> 0
+
+Test 2: below interval
+  PASS: iter=3, last=0, interval=5 -> 1
+
+Test 3: past interval (delta 6)
+  PASS: iter=10, last=4, interval=5 -> 0
+
+Test 4: just-grounded state
+  PASS: iter=5, last=5 -> 1
+
+Test 5: missing lastGroundedIteration defaults to 0
+  PASS: no state field, iter=5 -> 0
+
+Test 6: REGROUND_INTERVAL override
+  PASS: interval=3, delta=3 -> 0
+  PASS: interval=10, delta=3 -> 1
+
+Test 7: stdin input
+  PASS: stdin trigger
+
+Test 8: build_reground_context shape
+  PASS: header with iteration
+  PASS: branch rendered
+  PASS: progress counts
+  PASS: goal reminder
+
+Test 9: next pending stories listed
+  PASS: pending stories S3, S5 listed
+  PASS: only pending stories in next-up
+
+Test 10: PRD head included when file exists
+  PASS: PRD head rendered
+
+Test 11: missing PRD handled
+  PASS: missing PRD skipped cleanly
+
+Test 12: empty stories array
+  PASS: empty progress rendered
+
+Test 13: mark_grounded updates state
+  PASS: lastGroundedIteration = 7
+  PASS: other state preserved
+
+Test 14: mark_grounded creates state if absent
+  PASS: state created, lastGroundedIteration = 3
+
+Test 15: mark_grounded missing file
+  PASS: missing file -> exit 1
+
+Test 16: mark_grounded resets the should_reground signal
+  PASS: before mark: should -> 0
+  PASS: after mark: should -> 1
+
+Test 17: CLI subcommands
+  PASS: CLI should -> 0
+  PASS: CLI context
+  PASS: CLI mark updates field
+
+=== Results: 26/26 passed, 0 failed ===

--- a/.omc/phase-31-evidence/test_skeleton.log
+++ b/.omc/phase-31-evidence/test_skeleton.log
@@ -1,0 +1,76 @@
+=== Phase 31 skeleton tests ===
+
+Test 1: TS signatures
+  PASS: TS: 6 entries
+  PASS: TS: function add
+  PASS: TS: function sub
+  PASS: TS: class Adder
+  PASS: TS: interface IAdder
+  PASS: TS: type Pair
+  PASS: TS: enum Color
+
+Test 2: Python signatures
+  PASS: PY: 5 entries
+  PASS: PY: function add
+  PASS: PY: async fetch_data
+  PASS: PY: class Adder
+  PASS: PY: 2 methods (__init__, add)
+
+Test 3: Go signatures
+  PASS: GO: 4 entries
+  PASS: GO: func Add
+  PASS: GO: method Sum
+  PASS: GO: struct Adder
+  PASS: GO: interface Summer
+
+Test 4: Rust signatures
+  PASS: RS: 5 entries
+  PASS: RS: pub fn add
+  PASS: RS: async fn fetch
+  PASS: RS: struct Adder
+  PASS: RS: trait Summer
+  PASS: RS: enum Color
+
+Test 5: empty / missing file handling
+  PASS: missing file -> []
+  PASS: empty file -> []
+
+Test 6: unknown extension
+  PASS: unknown ext -> []
+  PASS: unknown ext + LANG=ts picks up foo
+
+Test 7: skeleton_text output shape
+  PASS: function sig present
+  PASS: trailing { stripped from output
+
+Test 8: skeleton_diff basic matching
+  PASS: added count=1
+  PASS: added name=mul
+  PASS: removed count=1
+  PASS: removed name=sub
+  PASS: changed count=1
+  PASS: changed name=add
+
+Test 9: body-only change → no skeleton drift
+  PASS: body-only: 0 added
+  PASS: body-only: 0 removed
+  PASS: body-only: 0 changed
+
+Test 10: Python rename detected as remove+add
+  PASS: py rename: 1 added
+  PASS: py rename: 1 removed
+  PASS: py added=compute
+  PASS: py removed=calculate
+
+Test 11: return-type preserved in signature
+  PASS: return type 'string' preserved
+
+Test 12: CLI subcommands
+  PASS: CLI extract count=1
+  PASS: CLI text contains name
+  PASS: CLI diff added=1
+
+Test 13: call sites are not signatures
+  PASS: no false positives from call sites
+
+=== Results: 47/47 passed, 0 failed ===

--- a/.omc/phase-31-evidence/test_tracecoder.log
+++ b/.omc/phase-31-evidence/test_tracecoder.log
@@ -1,0 +1,58 @@
+=== Phase 27 TraceCoder tests ===
+
+Test 1: observe a passing command
+  PASS: exit=0
+  PASS: name=greeting
+  PASS: tail contains hello
+
+Test 2: observe a failing command
+  PASS: exit=1
+
+Test 3: observe merges stderr
+  PASS: both streams in tail
+
+Test 4: extract tsc-style markers
+  PASS: 1 marker parsed
+  PASS: file=src/app.ts
+  PASS: line=42
+  PASS: message captured
+
+Test 5: extract python traceback
+  PASS: 1 marker parsed
+  PASS: python file
+  PASS: python line
+
+Test 6: extract node stack
+  PASS: node stack parsed
+  PASS: node file
+  PASS: node line
+
+Test 7: multiple markers + URL noise filtering
+  PASS: 2 real markers (URL filtered)
+
+Test 8: empty tail
+  PASS: empty tail -> []
+
+Test 9: build_analysis_context shape
+  PASS: header present
+  PASS: exit code visible
+  PASS: tail section present
+
+Test 10: context includes markers
+  PASS: marker rendered in context
+
+Test 11: should_repair semantics
+  PASS: failure + markers -> 0
+  PASS: pass -> no repair (1)
+  PASS: opaque failure -> no repair (1)
+
+Test 12: tail truncates to TRACECODER_TAIL_LINES
+  PASS: tail is 10 lines
+  PASS: tail starts at line_191
+
+Test 13: CLI subcommands
+  PASS: CLI observe exit=0
+  PASS: CLI markers count=1
+  PASS: CLI should-repair exits 0
+
+=== Results: 29/29 passed, 0 failed ===

--- a/.omc/phase-31-evidence/test_trajectory.log
+++ b/.omc/phase-31-evidence/test_trajectory.log
@@ -1,0 +1,49 @@
+=== Phase 24 trajectory-kill tests ===
+
+Test 1: parse on missing file
+  PASS: exists=false
+  PASS: total=0
+
+Test 2: parse counts tools
+  PASS: reads=5
+  PASS: greps=3
+  PASS: edits=2
+  PASS: writes=1
+  PASS: bashes=4
+  PASS: total=15
+  PASS: read_pct=53
+  PASS: edit_pct=20
+
+Test 3: productive trajectory
+  PASS: classify productive
+  PASS: productive -> no kill (exit 1)
+
+Test 4: searching trajectory
+  PASS: classify searching (below thrash min)
+  PASS: searching -> no kill
+
+Test 5: thrashing trajectory
+  PASS: classify thrashing
+  PASS: thrashing -> kill (exit 0)
+
+Test 6: stuck trajectory
+  PASS: classify stuck
+  PASS: stuck -> kill (exit 0)
+
+Test 7: env-var overrides take effect
+  PASS: default: searching
+  PASS: override THRASH_MIN=5: thrashing
+
+Test 8: empty file handling
+  PASS: empty file total=0
+  PASS: empty file classify=productive (no signal)
+
+Test 9: CLI subcommands
+  PASS: CLI parse total=26
+  PASS: CLI classify thrashing
+  PASS: CLI kill exits 0 for thrashing
+
+Test 10: classify reads stdin
+  PASS: stdin classify productive
+
+=== Results: 26/26 passed, 0 failed ===

--- a/lib/skeleton.sh
+++ b/lib/skeleton.sh
@@ -1,0 +1,292 @@
+#!/usr/bin/env bash
+# lib/skeleton.sh — skeleton-first / SSAT primitives (Phase 31 / P3.1).
+#
+# Sources:
+#   arXiv:2303.06689 — Self-planning code generation: plan the API
+#                      surface (signatures, types, exports) before
+#                      generating bodies. Reported +11pp pass-rate on
+#                      HumanEval vs. direct generation.
+#   arXiv:2307.15337 — Skeleton-of-Thought: generate structure first,
+#                      then expand each node. Orthogonal shape, same
+#                      principle: shape-before-content.
+#
+# Why this primitive:
+#   Most generation failures in an agent loop are not bug-level (the
+#   body is subtly wrong); they are shape-level (the function doesn't
+#   exist, or its signature drifted from what the caller expects, or
+#   a new interface is missing a declared method). Skeleton-first lets
+#   the orchestrator validate the API surface cheaply before burning
+#   a retry on body-level work.
+#
+# Supported languages (extension-dispatched):
+#   .ts .tsx .js .jsx .mjs — TypeScript / JavaScript
+#   .py                    — Python
+#   .go                    — Go
+#   .rs                    — Rust
+#
+# Out of scope (add when we have dogfood pressure):
+#   C / C++ — regex fragile on pointer declarations and macros
+#   Java   — modifier permutations explode the regex set
+#   Lua / Perl / Scala / Kotlin — no current dogfood demand
+#
+# Functions:
+#   extract_skeleton FILE [LANG]
+#     Emits a JSON array: [{kind, name, signature, line}, ...]
+#     kind ∈ {function, method, class, interface, type, struct, enum, trait}
+#
+#   skeleton_text FILE [LANG]
+#     Emits plain-text skeleton: one signature per line in source order.
+#     Not syntactically valid as code — a readable API surface view,
+#     suitable for diff-ing. Use extract_skeleton for programmatic use.
+#
+#   skeleton_diff BEFORE_FILE AFTER_FILE [LANG]
+#     Matches entries by (kind, name). Emits JSON:
+#       { "added":   [{kind, name, signature, line}, ...],
+#         "removed": [{kind, name, signature, line}, ...],
+#         "changed": [{kind, name, before_sig, after_sig}] }
+#     Rename detection is out of scope (appears as remove + add).
+#
+# Library contract: no shell flags at source time; CLI block enables
+# strict mode locally.
+
+SKELETON_LIB_DIR="${SKELETON_LIB_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+
+# _detect_lang(file)
+# Return a normalized language tag based on the file extension.
+# Echoes one of: ts | py | go | rs | unknown
+_detect_lang() {
+  local f="${1:-}"
+  case "$f" in
+    *.ts|*.tsx|*.js|*.jsx|*.mjs) printf "ts" ;;
+    *.py)                        printf "py" ;;
+    *.go)                        printf "go" ;;
+    *.rs)                        printf "rs" ;;
+    *)                           printf "unknown" ;;
+  esac
+}
+
+# _strip_body_tail(signature)
+# Trim the opening-brace / colon that starts a body from a signature
+# line so the emitted signature ends at the declaration boundary.
+# Example: "function foo(a: int): string {" -> "function foo(a: int): string"
+_strip_body_tail() {
+  local s="${1:-}"
+  # Windows CRLF survives `read -r` — strip trailing CR before matching.
+  s="${s%$'\r'}"
+  # Drop trailing "{}" (inline empty body), " {" (body start), or ":"
+  # (Python sig end). Each strip is conditional on suffix match.
+  s="${s%\{\}}"
+  s="${s% }"
+  s="${s%"{"}"
+  s="${s% }"
+  s="${s%:}"
+  s="${s% }"
+  printf '%s' "$s"
+}
+
+# _extract_ts(file)
+# Emit one JSON object per detected signature for TS/JS source.
+_extract_ts() {
+  local f="${1:?file required}"
+  awk '
+    function emit(kind, name, sig, line) {
+      gsub(/\\/, "\\\\", sig); gsub(/"/, "\\\"", sig)
+      gsub(/\\/, "\\\\", name); gsub(/"/, "\\\"", name)
+      printf "{\"kind\":\"%s\",\"name\":\"%s\",\"signature\":\"%s\",\"line\":%d}\n",
+        kind, name, sig, line
+    }
+    # function foo(...)[: T] {
+    match($0, /^[[:space:]]*(export[[:space:]]+)?(default[[:space:]]+)?(async[[:space:]]+)?function[[:space:]]+([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*\(/, m) {
+      emit("function", m[4], $0, NR); next
+    }
+    # export const foo = (...) => or export const foo = async (...) =>
+    match($0, /^[[:space:]]*(export[[:space:]]+)?(const|let|var)[[:space:]]+([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*[:=][[:space:]]*(async[[:space:]]+)?\(/, m) {
+      emit("function", m[3], $0, NR); next
+    }
+    # class / abstract class Foo
+    match($0, /^[[:space:]]*(export[[:space:]]+)?(default[[:space:]]+)?(abstract[[:space:]]+)?class[[:space:]]+([A-Za-z_][A-Za-z0-9_]*)/, m) {
+      emit("class", m[4], $0, NR); next
+    }
+    # interface Foo
+    match($0, /^[[:space:]]*(export[[:space:]]+)?interface[[:space:]]+([A-Za-z_][A-Za-z0-9_]*)/, m) {
+      emit("interface", m[2], $0, NR); next
+    }
+    # type Foo = ...
+    match($0, /^[[:space:]]*(export[[:space:]]+)?type[[:space:]]+([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*=/, m) {
+      emit("type", m[2], $0, NR); next
+    }
+    # enum Foo
+    match($0, /^[[:space:]]*(export[[:space:]]+)?(const[[:space:]]+)?enum[[:space:]]+([A-Za-z_][A-Za-z0-9_]*)/, m) {
+      emit("enum", m[3], $0, NR); next
+    }
+  ' "$f"
+}
+
+# _extract_py(file)
+_extract_py() {
+  local f="${1:?file required}"
+  awk '
+    function emit(kind, name, sig, line) {
+      gsub(/\\/, "\\\\", sig); gsub(/"/, "\\\"", sig)
+      printf "{\"kind\":\"%s\",\"name\":\"%s\",\"signature\":\"%s\",\"line\":%d}\n",
+        kind, name, sig, line
+    }
+    # def foo(...) [-> T]:
+    match($0, /^[[:space:]]*(async[[:space:]]+)?def[[:space:]]+([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*\(/, m) {
+      # Heuristic: if the def is indented, call it a method; otherwise function.
+      leading = $0; sub(/[^ \t].*$/, "", leading)
+      kind = (length(leading) > 0) ? "method" : "function"
+      emit(kind, m[2], $0, NR); next
+    }
+    # class Foo:  or class Foo(Base):
+    match($0, /^[[:space:]]*class[[:space:]]+([A-Za-z_][A-Za-z0-9_]*)/, m) {
+      emit("class", m[1], $0, NR); next
+    }
+  ' "$f"
+}
+
+# _extract_go(file)
+_extract_go() {
+  local f="${1:?file required}"
+  awk '
+    function emit(kind, name, sig, line) {
+      gsub(/\\/, "\\\\", sig); gsub(/"/, "\\\"", sig)
+      printf "{\"kind\":\"%s\",\"name\":\"%s\",\"signature\":\"%s\",\"line\":%d}\n",
+        kind, name, sig, line
+    }
+    # func name(...)  or  func (r *Recv) name(...)
+    match($0, /^[[:space:]]*func[[:space:]]+(\([^)]*\)[[:space:]]+)?([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*\(/, m) {
+      kind = (m[1] != "") ? "method" : "function"
+      emit(kind, m[2], $0, NR); next
+    }
+    # type Name struct | interface | func
+    match($0, /^[[:space:]]*type[[:space:]]+([A-Za-z_][A-Za-z0-9_]*)[[:space:]]+(struct|interface|func)/, m) {
+      emit(m[2], m[1], $0, NR); next
+    }
+  ' "$f"
+}
+
+# _extract_rs(file)
+_extract_rs() {
+  local f="${1:?file required}"
+  awk '
+    function emit(kind, name, sig, line) {
+      gsub(/\\/, "\\\\", sig); gsub(/"/, "\\\"", sig)
+      printf "{\"kind\":\"%s\",\"name\":\"%s\",\"signature\":\"%s\",\"line\":%d}\n",
+        kind, name, sig, line
+    }
+    # [pub] [async] fn name
+    match($0, /^[[:space:]]*(pub([[:space:]]*\([^)]*\))?[[:space:]]+)?(async[[:space:]]+)?fn[[:space:]]+([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*[<(]/, m) {
+      emit("function", m[4], $0, NR); next
+    }
+    # [pub] struct|enum|trait|type Name
+    match($0, /^[[:space:]]*(pub([[:space:]]*\([^)]*\))?[[:space:]]+)?(struct|enum|trait|type)[[:space:]]+([A-Za-z_][A-Za-z0-9_]*)/, m) {
+      emit(m[3], m[4], $0, NR); next
+    }
+  ' "$f"
+}
+
+# extract_skeleton(file, [lang])
+# Dispatches to the language-specific extractor. Emits a JSON array.
+extract_skeleton() {
+  local f="${1:?file required}"
+  local lang="${2:-}"
+  [[ -f "$f" ]] || { printf "[]"; return 0; }
+  [[ -z "$lang" ]] && lang=$(_detect_lang "$f")
+
+  local items
+  case "$lang" in
+    ts)      items=$(_extract_ts "$f") ;;
+    py)      items=$(_extract_py "$f") ;;
+    go)      items=$(_extract_go "$f") ;;
+    rs)      items=$(_extract_rs "$f") ;;
+    *)       printf "[]"; return 0 ;;
+  esac
+
+  # Each line from the extractors is a JSON object. Wrap into an array
+  # (handles empty input → []).
+  if [[ -z "$items" ]]; then
+    printf "[]"
+    return 0
+  fi
+  # Normalize trailing newline: some awk builds emit one per record, some
+  # squash the final one. Use jq -s to slurp into an array regardless.
+  printf '%s\n' "$items" | jq -sc '
+    map({
+      kind: .kind,
+      name: .name,
+      signature: (.signature | ltrimstr(" ") | rtrimstr("\r")),
+      line: .line
+    })
+  '
+}
+
+# skeleton_text(file, [lang])
+# Emits plain-text view: one raw signature per line in source order,
+# with body tails (" {" / trailing ":" ) trimmed for readability.
+skeleton_text() {
+  local f="${1:?file required}"
+  local lang="${2:-}"
+  local skel
+  skel=$(extract_skeleton "$f" "$lang")
+  [[ "$skel" == "[]" ]] && return 0
+
+  printf '%s' "$skel" | jq -r '.[] | .signature' | while IFS= read -r sig; do
+    _strip_body_tail "$sig"
+    printf '\n'
+  done
+}
+
+# skeleton_diff(before_file, after_file, [lang])
+# Matches by (kind, name). Emits JSON:
+#   { "added": [...], "removed": [...], "changed": [{kind, name, before_sig, after_sig}] }
+skeleton_diff() {
+  local before="${1:?before required}"
+  local after="${2:?after required}"
+  local lang="${3:-}"
+  [[ -z "$lang" && -f "$after" ]] && lang=$(_detect_lang "$after")
+  [[ -z "$lang" && -f "$before" ]] && lang=$(_detect_lang "$before")
+  local b a
+  b=$(extract_skeleton "$before" "$lang")
+  a=$(extract_skeleton "$after"  "$lang")
+
+  jq -cn --argjson b "$b" --argjson a "$a" '
+    def key(x): x.kind + "|" + x.name;
+    ($b | map({(key(.)): .}) | add // {}) as $bi |
+    ($a | map({(key(.)): .}) | add // {}) as $ai |
+    {
+      added:   [ $a[] | select((key(.)) as $k | ($bi[$k] | not)) ],
+      removed: [ $b[] | select((key(.)) as $k | ($ai[$k] | not)) ],
+      changed: [
+        $a[] | select((key(.)) as $k | $bi[$k] != null) |
+        . as $aitem |
+        ($bi[key($aitem)]) as $bitem |
+        select($bitem.signature != $aitem.signature) |
+        {kind: $aitem.kind, name: $aitem.name,
+         before_sig: $bitem.signature, after_sig: $aitem.signature}
+      ]
+    }
+  '
+}
+
+# ------------------------------------------------------------------------------
+# CLI entry
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  set -euo pipefail
+  subcmd="${1:-}"
+  shift || true
+  case "$subcmd" in
+    extract) extract_skeleton "$@" ;;
+    text)    skeleton_text "$@" ;;
+    diff)    skeleton_diff "$@" ;;
+    *)
+      cat >&2 <<USAGE
+Usage: bash lib/skeleton.sh <subcmd> [args...]
+  extract FILE [LANG]       — JSON array of signatures
+  text    FILE [LANG]       — plain-text skeleton (one signature per line)
+  diff    BEFORE AFTER [L]  — JSON {added, removed, changed}
+USAGE
+      exit 2
+      ;;
+  esac
+fi

--- a/tests/test_skeleton.sh
+++ b/tests/test_skeleton.sh
@@ -1,0 +1,324 @@
+#!/usr/bin/env bash
+# Phase 31 / P3.1 — skeleton-first extraction / diff tests.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR/.."
+PASS=0
+FAIL=0
+TOTAL=0
+
+assert() {
+  local name="$1" expected="$2" actual="$3"
+  TOTAL=$((TOTAL + 1))
+  if [[ "$expected" == "$actual" ]]; then
+    echo "  PASS: $name"; PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $name (expected [$expected] got [$actual])"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# shellcheck disable=SC1091
+source "$REPO_ROOT/lib/skeleton.sh"
+
+echo "=== Phase 31 skeleton tests ==="
+
+# Test 1: extract_skeleton — TypeScript functions + class + interface + type
+echo ""
+echo "Test 1: TS signatures"
+TEST_TMPDIR=$(mktemp -d)
+cat > "$TEST_TMPDIR/app.ts" << 'EOF'
+export function add(a: number, b: number): number {
+  return a + b;
+}
+export const sub = (a: number, b: number): number => a - b;
+export class Adder {
+  constructor(private base: number) {}
+}
+export interface IAdder {
+  add(x: number): number;
+}
+export type Pair = [number, number];
+enum Color { Red, Green }
+EOF
+skel=$(extract_skeleton "$TEST_TMPDIR/app.ts")
+assert "TS: 6 entries"     "6"          "$(jq 'length' <<< "$skel")"
+assert "TS: function add"  "function"   "$(jq -r '.[] | select(.name == "add") | .kind' <<< "$skel")"
+assert "TS: function sub"  "function"   "$(jq -r '.[] | select(.name == "sub") | .kind' <<< "$skel")"
+assert "TS: class Adder"   "class"      "$(jq -r '.[] | select(.name == "Adder") | .kind' <<< "$skel")"
+assert "TS: interface IAdder" "interface" "$(jq -r '.[] | select(.name == "IAdder") | .kind' <<< "$skel")"
+assert "TS: type Pair"     "type"       "$(jq -r '.[] | select(.name == "Pair") | .kind' <<< "$skel")"
+assert "TS: enum Color"    "enum"       "$(jq -r '.[] | select(.name == "Color") | .kind' <<< "$skel")"
+rm -rf "$TEST_TMPDIR"
+
+# Test 2: extract_skeleton — Python function + method + class
+echo ""
+echo "Test 2: Python signatures"
+TEST_TMPDIR=$(mktemp -d)
+cat > "$TEST_TMPDIR/app.py" << 'EOF'
+def add(a: int, b: int) -> int:
+    return a + b
+
+async def fetch_data(url: str) -> dict:
+    return {}
+
+class Adder:
+    def __init__(self, base: int) -> None:
+        self.base = base
+
+    def add(self, x: int) -> int:
+        return self.base + x
+EOF
+skel=$(extract_skeleton "$TEST_TMPDIR/app.py")
+assert "PY: 5 entries"    "5"        "$(jq 'length' <<< "$skel")"
+assert "PY: function add"  "function" "$(jq -r '.[] | select(.name == "add" and .kind == "function") | .kind' <<< "$skel")"
+assert "PY: async fetch_data" "function" "$(jq -r '.[] | select(.name == "fetch_data") | .kind' <<< "$skel")"
+assert "PY: class Adder"   "class"    "$(jq -r '.[] | select(.name == "Adder") | .kind' <<< "$skel")"
+# method add is distinguished from top-level function add by kind
+method_count=$(jq '[.[] | select(.kind == "method")] | length' <<< "$skel")
+assert "PY: 2 methods (__init__, add)" "2" "$method_count"
+rm -rf "$TEST_TMPDIR"
+
+# Test 3: extract_skeleton — Go function + method + type
+echo ""
+echo "Test 3: Go signatures"
+TEST_TMPDIR=$(mktemp -d)
+cat > "$TEST_TMPDIR/app.go" << 'EOF'
+package main
+
+func Add(a, b int) int {
+    return a + b
+}
+
+func (r *Adder) Sum() int {
+    return r.base
+}
+
+type Adder struct {
+    base int
+}
+
+type Summer interface {
+    Sum() int
+}
+EOF
+skel=$(extract_skeleton "$TEST_TMPDIR/app.go")
+assert "GO: 4 entries"        "4"          "$(jq 'length' <<< "$skel")"
+assert "GO: func Add"         "function"   "$(jq -r '.[] | select(.name == "Add") | .kind' <<< "$skel")"
+assert "GO: method Sum"       "method"     "$(jq -r '.[] | select(.name == "Sum") | .kind' <<< "$skel")"
+assert "GO: struct Adder"     "struct"     "$(jq -r '.[] | select(.name == "Adder") | .kind' <<< "$skel")"
+assert "GO: interface Summer" "interface"  "$(jq -r '.[] | select(.name == "Summer") | .kind' <<< "$skel")"
+rm -rf "$TEST_TMPDIR"
+
+# Test 4: extract_skeleton — Rust function + struct + trait + enum
+echo ""
+echo "Test 4: Rust signatures"
+TEST_TMPDIR=$(mktemp -d)
+cat > "$TEST_TMPDIR/app.rs" << 'EOF'
+pub fn add(a: i32, b: i32) -> i32 {
+    a + b
+}
+
+async fn fetch(url: &str) -> String {
+    String::new()
+}
+
+pub struct Adder { base: i32 }
+
+pub trait Summer { fn sum(&self) -> i32; }
+
+pub enum Color { Red, Green }
+EOF
+skel=$(extract_skeleton "$TEST_TMPDIR/app.rs")
+assert "RS: 5 entries"     "5"         "$(jq 'length' <<< "$skel")"
+assert "RS: pub fn add"    "function"  "$(jq -r '.[] | select(.name == "add") | .kind' <<< "$skel")"
+assert "RS: async fn fetch" "function" "$(jq -r '.[] | select(.name == "fetch") | .kind' <<< "$skel")"
+assert "RS: struct Adder"  "struct"    "$(jq -r '.[] | select(.name == "Adder") | .kind' <<< "$skel")"
+assert "RS: trait Summer"  "trait"     "$(jq -r '.[] | select(.name == "Summer") | .kind' <<< "$skel")"
+assert "RS: enum Color"    "enum"      "$(jq -r '.[] | select(.name == "Color") | .kind' <<< "$skel")"
+rm -rf "$TEST_TMPDIR"
+
+# Test 5: extract_skeleton — empty / missing file
+echo ""
+echo "Test 5: empty / missing file handling"
+skel=$(extract_skeleton "/nonexistent/foo.ts")
+assert "missing file -> []" "[]" "$skel"
+TEST_TMPDIR=$(mktemp -d)
+: > "$TEST_TMPDIR/empty.ts"
+skel=$(extract_skeleton "$TEST_TMPDIR/empty.ts")
+assert "empty file -> []" "[]" "$skel"
+rm -rf "$TEST_TMPDIR"
+
+# Test 6: extract_skeleton — unknown extension falls back to []
+echo ""
+echo "Test 6: unknown extension"
+TEST_TMPDIR=$(mktemp -d)
+echo "function foo() {}" > "$TEST_TMPDIR/app.xyz"
+skel=$(extract_skeleton "$TEST_TMPDIR/app.xyz")
+assert "unknown ext -> []" "[]" "$skel"
+# But LANG override works
+skel=$(extract_skeleton "$TEST_TMPDIR/app.xyz" "ts")
+assert "unknown ext + LANG=ts picks up foo" "1" "$(jq 'length' <<< "$skel")"
+rm -rf "$TEST_TMPDIR"
+
+# Test 7: skeleton_text — one signature per line, body trimmed
+echo ""
+echo "Test 7: skeleton_text output shape"
+TEST_TMPDIR=$(mktemp -d)
+cat > "$TEST_TMPDIR/a.ts" << 'EOF'
+export function add(a: number): number {
+  return a + 1;
+}
+export class Foo {
+  bar(): void {}
+}
+EOF
+text=$(skeleton_text "$TEST_TMPDIR/a.ts")
+case "$text" in *"function add(a: number): number"*) echo "  PASS: function sig present"; PASS=$((PASS + 1));;
+                *) echo "  FAIL: function sig missing"; FAIL=$((FAIL + 1));;
+esac
+TOTAL=$((TOTAL + 1))
+case "$text" in *"{"*) echo "  FAIL: trailing { not stripped"; FAIL=$((FAIL + 1));;
+                *) echo "  PASS: trailing { stripped from output"; PASS=$((PASS + 1));;
+esac
+TOTAL=$((TOTAL + 1))
+rm -rf "$TEST_TMPDIR"
+
+# Test 8: skeleton_diff — added / removed / changed
+echo ""
+echo "Test 8: skeleton_diff basic matching"
+TEST_TMPDIR=$(mktemp -d)
+cat > "$TEST_TMPDIR/before.ts" << 'EOF'
+export function add(a: number, b: number): number {
+  return a + b;
+}
+export function sub(a: number, b: number): number {
+  return a - b;
+}
+EOF
+cat > "$TEST_TMPDIR/after.ts" << 'EOF'
+export function add(a: number, b: number, c: number): number {
+  return a + b + c;
+}
+export function mul(a: number, b: number): number {
+  return a * b;
+}
+EOF
+diff_out=$(skeleton_diff "$TEST_TMPDIR/before.ts" "$TEST_TMPDIR/after.ts")
+assert "added count=1"   "1"   "$(jq '.added | length' <<< "$diff_out")"
+assert "added name=mul"  "mul" "$(jq -r '.added[0].name' <<< "$diff_out")"
+assert "removed count=1" "1"   "$(jq '.removed | length' <<< "$diff_out")"
+assert "removed name=sub" "sub" "$(jq -r '.removed[0].name' <<< "$diff_out")"
+assert "changed count=1" "1"   "$(jq '.changed | length' <<< "$diff_out")"
+assert "changed name=add" "add" "$(jq -r '.changed[0].name' <<< "$diff_out")"
+rm -rf "$TEST_TMPDIR"
+
+# Test 9: skeleton_diff — body-only change NOT flagged as changed
+echo ""
+echo "Test 9: body-only change → no skeleton drift"
+TEST_TMPDIR=$(mktemp -d)
+cat > "$TEST_TMPDIR/before.ts" << 'EOF'
+export function add(a: number, b: number): number {
+  return a + b;
+}
+EOF
+cat > "$TEST_TMPDIR/after.ts" << 'EOF'
+export function add(a: number, b: number): number {
+  // pedantic comment, but signature identical
+  const result = a + b;
+  return result;
+}
+EOF
+diff_out=$(skeleton_diff "$TEST_TMPDIR/before.ts" "$TEST_TMPDIR/after.ts")
+assert "body-only: 0 added"   "0" "$(jq '.added | length' <<< "$diff_out")"
+assert "body-only: 0 removed" "0" "$(jq '.removed | length' <<< "$diff_out")"
+assert "body-only: 0 changed" "0" "$(jq '.changed | length' <<< "$diff_out")"
+rm -rf "$TEST_TMPDIR"
+
+# Test 10: skeleton_diff — across languages (Python rename)
+echo ""
+echo "Test 10: Python rename detected as remove+add"
+TEST_TMPDIR=$(mktemp -d)
+cat > "$TEST_TMPDIR/before.py" << 'EOF'
+def calculate(x: int) -> int:
+    return x * 2
+EOF
+cat > "$TEST_TMPDIR/after.py" << 'EOF'
+def compute(x: int) -> int:
+    return x * 2
+EOF
+diff_out=$(skeleton_diff "$TEST_TMPDIR/before.py" "$TEST_TMPDIR/after.py")
+assert "py rename: 1 added"   "1" "$(jq '.added | length' <<< "$diff_out")"
+assert "py rename: 1 removed" "1" "$(jq '.removed | length' <<< "$diff_out")"
+assert "py added=compute"     "compute"   "$(jq -r '.added[0].name' <<< "$diff_out")"
+assert "py removed=calculate" "calculate" "$(jq -r '.removed[0].name' <<< "$diff_out")"
+rm -rf "$TEST_TMPDIR"
+
+# Test 11: extract_skeleton — signature includes return type
+echo ""
+echo "Test 11: return-type preserved in signature"
+TEST_TMPDIR=$(mktemp -d)
+cat > "$TEST_TMPDIR/t.ts" << 'EOF'
+export function stringify(n: number): string {
+  return String(n);
+}
+EOF
+skel=$(extract_skeleton "$TEST_TMPDIR/t.ts")
+sig=$(jq -r '.[0].signature' <<< "$skel")
+case "$sig" in *"string"*) echo "  PASS: return type 'string' preserved"; PASS=$((PASS + 1));;
+                *) echo "  FAIL: return type missing from sig: $sig"; FAIL=$((FAIL + 1));;
+esac
+TOTAL=$((TOTAL + 1))
+rm -rf "$TEST_TMPDIR"
+
+# Test 12: CLI subcommands
+echo ""
+echo "Test 12: CLI subcommands"
+TEST_TMPDIR=$(mktemp -d)
+cat > "$TEST_TMPDIR/a.ts" << 'EOF'
+export function only(): void {}
+EOF
+cat > "$TEST_TMPDIR/b.ts" << 'EOF'
+export function only(): void {}
+export function extra(x: number): number { return x; }
+EOF
+cli_ex=$(bash "$REPO_ROOT/lib/skeleton.sh" extract "$TEST_TMPDIR/a.ts")
+assert "CLI extract count=1" "1" "$(jq 'length' <<< "$cli_ex")"
+cli_text=$(bash "$REPO_ROOT/lib/skeleton.sh" text "$TEST_TMPDIR/a.ts")
+case "$cli_text" in *"only"*) echo "  PASS: CLI text contains name"; PASS=$((PASS + 1));;
+                    *) echo "  FAIL: CLI text missing name"; FAIL=$((FAIL + 1));;
+esac
+TOTAL=$((TOTAL + 1))
+cli_diff=$(bash "$REPO_ROOT/lib/skeleton.sh" diff "$TEST_TMPDIR/a.ts" "$TEST_TMPDIR/b.ts")
+assert "CLI diff added=1" "1" "$(jq '.added | length' <<< "$cli_diff")"
+rm -rf "$TEST_TMPDIR"
+
+# Test 13: extract_skeleton — does NOT pick up call sites as signatures
+echo ""
+echo "Test 13: call sites are not signatures"
+TEST_TMPDIR=$(mktemp -d)
+cat > "$TEST_TMPDIR/calls.ts" << 'EOF'
+import { foo } from './foo';
+foo();
+const r = foo();
+EOF
+skel=$(extract_skeleton "$TEST_TMPDIR/calls.ts")
+# `const r = foo()` does NOT match our arrow-function regex (no =>), so
+# it should NOT be extracted as a function declaration.
+sigs=$(jq 'length' <<< "$skel")
+# It's OK if the extractor returns 0. If the regex happens to match
+# `const r = foo()` as const+name+=(, flag this as a false positive.
+TOTAL=$((TOTAL + 1))
+if [[ "$sigs" -eq 0 ]]; then
+  echo "  PASS: no false positives from call sites"; PASS=$((PASS + 1))
+else
+  echo "  FAIL: $sigs entries — check regex precision"; FAIL=$((FAIL + 1))
+  jq '.' <<< "$skel" | head -6 | sed 's/^/    /'
+fi
+rm -rf "$TEST_TMPDIR"
+
+echo ""
+echo "=== Results: $PASS/$TOTAL passed, $FAIL failed ==="
+exit $((FAIL > 0 ? 1 : 0))


### PR DESCRIPTION
Eighth P3 wedge. Signature-level view of code for skeleton-first generation: extract the API surface (functions, methods, classes, interfaces, types, enums, structs, traits) before validating bodies.

## Why

Most generation failures in an agent loop are not bug-level (subtly wrong body); they are **shape-level** (function doesn't exist, signature drifted, interface missing a method). Skeleton-first lets the orchestrator validate the API surface cheaply before burning a retry on body-level work.

Complements existing helpers:

| Lib | Signal time | What |
|-----|------------|------|
| `constitution.sh` | patch content | invariants on code |
| `trajectory.sh` | during gen | tool-shape |
| `tracecoder.sh` | after failure | structured evidence |
| **`skeleton.sh`** | **before gen** | **structured shape** |

## Functions

| Function | Purpose |
|----------|---------|
| `extract_skeleton FILE [LANG]` | JSON array of `{kind, name, signature, line}` |
| `skeleton_text FILE [LANG]` | plain-text skeleton (one sig per line, body trimmed) |
| `skeleton_diff BEFORE AFTER [L]` | JSON `{added, removed, changed}` matched by `(kind, name)` |

## Languages

Extension-dispatched: `.ts .tsx .js .jsx .mjs`, `.py`, `.go`, `.rs`.

Out of scope for now: C/C++ (regex fragile on pointers/macros), Java (modifier permutations), Lua/Perl/Scala/Kotlin (no dogfood demand).

## Windows CRLF fix

`_strip_body_tail` strips trailing `\r` before matching `{` / `{}` / `:` body markers — heredoc-written test files on Git Bash land with CRLF endings and awk's `$0` captures the `\r`.

## Tests

47 new, 245 total across 7 related suites, all green.

## Test plan

- [x] 47/47 skeleton tests pass
- [x] No regressions in 6 adjacent suites
- [x] CLI subcommands verified (`extract`, `text`, `diff`)
- [ ] Wire into orchestrator (separate PR — emit skeleton preview + post-impl drift check)