### PR TITLE
Phase 32 — Semantic intent graph (P3.6, arXiv:2604.11209)

### DIFF
--- a/.omc/phase-32-evidence/test_conflict_grade.log
+++ b/.omc/phase-32-evidence/test_conflict_grade.log
@@ -1,0 +1,62 @@
+=== Phase 26 conflict-grade tests ===
+
+Test 1: whitespace-only → grade 1
+  PASS: single-ws diff
+  PASS: bracket-indent diff
+
+Test 2: comment-only → grade 2
+  PASS: line comment change
+  PASS: python-style comment change
+  PASS: block comment change
+
+Test 3: single-token rename → grade 2
+  PASS: single identifier rename
+
+Test 4: small body edit → grade 3
+  PASS: 3-line small body edit
+
+Test 5: moderate overlap → grade 4
+  PASS: 7-line overlap
+
+Test 6: structural reorg → grade 5
+  PASS: 2-function reorder
+  PASS: 2-def reorg (python)
+
+Test 7: split_conflict_hunks single
+  PASS: 1 conflict parsed
+  PASS: ours buffer captured
+  PASS: theirs buffer captured
+  PASS: start_line=2
+  PASS: end_line=7
+
+Test 8: split_conflict_hunks multiple
+  PASS: 2 conflicts parsed
+
+Test 9: grade_file end-to-end
+  PASS: 2 hunks graded
+  PASS: max_grade = 5 (structural)
+  PASS: first hunk grade 2 (comment)
+  PASS: second hunk grade 5 (structural)
+
+Test 10: grade_file clean file
+  PASS: clean file max_grade=0
+  PASS: clean file 0 hunks
+
+Test 11: routing_recommendation
+  PASS: grade 0 → none
+  PASS: grade 1 → auto-git
+  PASS: grade 2 → auto-git
+  PASS: grade 3 → diff3
+  PASS: grade 4 → llm-merge
+  PASS: grade 5 → escalate
+
+Test 12a: string literals not truncated at // or /*
+  PASS: identical URL lines → grade 1 (whitespace equiv)
+  PASS: URL preserved, comment-only change → grade 2
+  PASS: URL content changed (single-token) → grade 2
+
+Test 12: CLI subcommands
+  PASS: CLI grade single-word rename
+  PASS: CLI route 4 → llm-merge
+
+=== Results: 33/33 passed, 0 failed ===

--- a/.omc/phase-32-evidence/test_hyclone.log
+++ b/.omc/phase-32-evidence/test_hyclone.log
@@ -1,0 +1,60 @@
+=== Phase 25 HyClone Stage-1 tests ===
+
+Test 1: alpha_normalize basics
+  PASS: whitespace-only renames x
+  PASS: extra whitespace collapsed
+  PASS: multiple identifiers numbered
+
+Test 2: repeated identifiers reuse placeholder
+  PASS: repeated identifier reuses placeholder
+
+Test 3: keywords preserved
+  PASS: keywords preserved
+
+Test 4: comments stripped
+  PASS: line comment // stripped
+  PASS: line comment # stripped
+  PASS: block comment stripped
+
+Test 5: string literals preserved
+  PASS: double-quoted string preserved
+  PASS: single-quoted string preserved
+
+Test 6: clone fingerprints match
+  PASS: different names → same fingerprint
+  PASS: different whitespace → same fingerprint
+
+Test 7: semantic difference → different fingerprints
+  PASS: operator difference changes fingerprint
+  PASS: while vs if different
+
+Test 8: find_clones detects a clone pair
+  PASS: finds 1 clone group
+  PASS: group has 2 members
+  PASS: fnA in clone group
+  PASS: fnB in clone group
+  PASS: fnC NOT in clone group
+
+Test 9: find_clones with all unique functions
+  PASS: no clone groups
+
+Test 10: find_clones with triple
+  PASS: 3-way clone grouped
+  PASS: triple has 3 members
+
+Test 11: CLI subcommands
+  PASS: CLI normalize
+  PASS: CLI fingerprint is 64 hex chars
+
+Test 12: comment markers inside string literals not treated as comments
+  PASS: URL preserved, trailing double-slash stripped
+  PASS: regex preserved, trailing hash stripped
+  PASS: block markers in string do not consume rest
+  PASS: escaped quotes do not terminate string
+  PASS: different URLs -> different fingerprints (Stage-2 would catch)
+
+Test 13: empty input handling
+  PASS: empty normalize -> empty
+  PASS: empty find_clones -> []
+
+=== Results: 31/31 passed, 0 failed ===

--- a/.omc/phase-32-evidence/test_intent_graph.log
+++ b/.omc/phase-32-evidence/test_intent_graph.log
@@ -1,0 +1,65 @@
+=== Phase 32 intent-graph tests ===
+
+Test 1: function name decomposition
+  PASS: camelCase: getUserById
+  PASS: snake_case: create_order
+  PASS: mixed: fetch_data_v2
+  PASS: single: validate
+
+Test 2: verb detection
+  PASS: create is verb
+  PASS: delete is verb
+  PASS: hamburger not a verb (PASS=7)
+
+Test 3: extract intents from story description
+  PASS: extracted 6 intents (>=5 expected)
+  PASS: 'delete tokens' captured
+  PASS: 'create sessions' captured
+
+Test 4: source tagging
+  PASS: title source tagged
+  PASS: description source tagged
+  PASS: ac source tagged
+  PASS: task source tagged
+
+Test 5: extract code intents from TS
+  PASS: 3 verb-led functions found
+  PASS: verbs = create,delete,get
+
+Test 6: extract code intents from Python
+  PASS: 3 verb-led (xyz excluded)
+
+Test 7: dir walk across extensions
+  PASS: 3 intents across TS+PY+GO
+
+Test 8: match full overlap
+  PASS: matched count=1
+  PASS: unmatched_story=0
+  PASS: unmatched_code=0
+  PASS: jaccard=1
+
+Test 9: partial overlap - story says delete, code says filter
+  PASS: matched (create session)
+  PASS: unmatched_story verb=delete
+  PASS: unmatched_code verb=filter
+
+Test 10: object token order normalized
+  PASS: token-order-insensitive match
+
+Test 11: empty inputs
+  PASS: empty: matched=0
+  PASS: empty: jaccard=0
+  PASS: empty code: unmatched_story=1
+
+Test 12: end-to-end story→code match
+  PASS: end-to-end matched 2 intent(s)
+
+Test 13: CLI subcommands
+  PASS: CLI story count>=1
+  PASS: CLI code count=1
+  PASS: CLI match jaccard=1
+
+Test 14: non-action function name
+  PASS: no intents (no verb prefix)
+
+=== Results: 34/34 passed, 0 failed ===

--- a/.omc/phase-32-evidence/test_orchestrator_wiring.log
+++ b/.omc/phase-32-evidence/test_orchestrator_wiring.log
@@ -1,0 +1,82 @@
+=== Phase 17 orchestrator-wiring prompt tests ===
+
+Test 1: lib/wave-boundary.sh wired at wave boundary
+  PASS: 3C.NEG1 section present
+  PASS: references wave-boundary.sh scan
+  PASS: routes HIGH severity to fix-story
+
+Test 2: lib/watchdog.sh wired in monitor loop
+  PASS: watchdog tick header
+  PASS: references watchdog.sh poll
+  PASS: status-probe action branch
+  PASS: kill-and-requeue action branch
+  PASS: mark-failed action branch
+  PASS: circuit-breaker bump
+  PASS: circuit-breaker check
+
+Test 3: lib/deep-review.sh wired at full-feature review
+  PASS: 4B.5 deep-review section
+  PASS: score-from-quantum call
+  PASS: tier lookup
+  PASS: dispatch-set call
+  PASS: context preparation
+  PASS: aggregate pipe
+  PASS: BLOCKS_MERGE handled
+  PASS: REQUEST_CHANGES handled
+  PASS: persists into quantum.reviews
+
+Test 4: lib/deslop.sh wired between review-pass and commit
+  PASS: 3A.5B deslop section
+  PASS: validate_scope gate
+  PASS: baseline snapshot before
+  PASS: compare_baseline call
+  PASS: rollback on regression
+  PASS: DESLOP_ROLLED_BACK signal
+  PASS: opt-out via story.deslop.skip
+
+Test 5: lib/commit-trailers.sh validation gate
+  PASS: commit-trailers reference
+  PASS: non-blocking warning
+
+Test 6: handoff.sh ownership is skill-side (orchestrator doesn't write)
+  PASS: orchestrator does NOT write handoffs directly (skills do)
+
+Test 7: all wirings carry a Phase-17 attribution comment
+  PASS: 5 Phase-17 attributions
+
+Test 8: deslop wiring uses DESLOP_AVAILABLE + BASE_SHA
+  PASS: DESLOP_AVAILABLE guard present
+  PASS: DESLOP_AVAILABLE file check
+  PASS: Fallback skip branch
+  PASS: scope loop uses BASE_SHA
+  PASS: rollback uses BASE_SHA
+  PASS: no active STORY_BASE_SHA refs in 3A.5B
+
+Test 9: RUNNER_EXTRA_FLAGS validated after pre_spawn()
+  PASS: RUNNER_EXTRA_FLAGS validation present
+  PASS: blocklist present (regex form varies)
+
+Test 10: runner_build_cmd rejects injection via RUNNER_EXTRA_FLAGS
+  PASS: injection payload rejected with clear error
+
+Test 10b: lib/reground.sh wired at Step 1C
+  PASS: reground source line present
+  PASS: REGROUND_AVAILABLE fallback flag
+  PASS: Step 1C header present
+  PASS: should_reground invoked
+  PASS: build_reground_context invoked
+  PASS: mark_grounded invoked
+  PASS: reground block path stable
+
+Test 10c: lib/tracecoder.sh wired at Step 3A.3
+  PASS: tracecoder source line present
+  PASS: TRACECODER_AVAILABLE fallback flag
+  PASS: observe primitive invoked
+  PASS: should_repair gate check
+  PASS: build_analysis_context call
+  PASS: opaque-failure bypass documented
+
+Test 11: lib/watchdog.sh doc comment corrected
+  PASS: watchdog threshold comment matches code (>30 min = timed-out)
+
+=== Results: 53/53 passed, 0 failed ===

--- a/.omc/phase-32-evidence/test_reground.log
+++ b/.omc/phase-32-evidence/test_reground.log
@@ -1,0 +1,63 @@
+=== Phase 28 re-grounding tests ===
+
+Test 1: should_reground at interval
+  PASS: iter=5, last=0, interval=5 -> 0
+
+Test 2: below interval
+  PASS: iter=3, last=0, interval=5 -> 1
+
+Test 3: past interval (delta 6)
+  PASS: iter=10, last=4, interval=5 -> 0
+
+Test 4: just-grounded state
+  PASS: iter=5, last=5 -> 1
+
+Test 5: missing lastGroundedIteration defaults to 0
+  PASS: no state field, iter=5 -> 0
+
+Test 6: REGROUND_INTERVAL override
+  PASS: interval=3, delta=3 -> 0
+  PASS: interval=10, delta=3 -> 1
+
+Test 7: stdin input
+  PASS: stdin trigger
+
+Test 8: build_reground_context shape
+  PASS: header with iteration
+  PASS: branch rendered
+  PASS: progress counts
+  PASS: goal reminder
+
+Test 9: next pending stories listed
+  PASS: pending stories S3, S5 listed
+  PASS: only pending stories in next-up
+
+Test 10: PRD head included when file exists
+  PASS: PRD head rendered
+
+Test 11: missing PRD handled
+  PASS: missing PRD skipped cleanly
+
+Test 12: empty stories array
+  PASS: empty progress rendered
+
+Test 13: mark_grounded updates state
+  PASS: lastGroundedIteration = 7
+  PASS: other state preserved
+
+Test 14: mark_grounded creates state if absent
+  PASS: state created, lastGroundedIteration = 3
+
+Test 15: mark_grounded missing file
+  PASS: missing file -> exit 1
+
+Test 16: mark_grounded resets the should_reground signal
+  PASS: before mark: should -> 0
+  PASS: after mark: should -> 1
+
+Test 17: CLI subcommands
+  PASS: CLI should -> 0
+  PASS: CLI context
+  PASS: CLI mark updates field
+
+=== Results: 26/26 passed, 0 failed ===

--- a/.omc/phase-32-evidence/test_skeleton.log
+++ b/.omc/phase-32-evidence/test_skeleton.log
@@ -1,0 +1,76 @@
+=== Phase 31 skeleton tests ===
+
+Test 1: TS signatures
+  PASS: TS: 6 entries
+  PASS: TS: function add
+  PASS: TS: function sub
+  PASS: TS: class Adder
+  PASS: TS: interface IAdder
+  PASS: TS: type Pair
+  PASS: TS: enum Color
+
+Test 2: Python signatures
+  PASS: PY: 5 entries
+  PASS: PY: function add
+  PASS: PY: async fetch_data
+  PASS: PY: class Adder
+  PASS: PY: 2 methods (__init__, add)
+
+Test 3: Go signatures
+  PASS: GO: 4 entries
+  PASS: GO: func Add
+  PASS: GO: method Sum
+  PASS: GO: struct Adder
+  PASS: GO: interface Summer
+
+Test 4: Rust signatures
+  PASS: RS: 5 entries
+  PASS: RS: pub fn add
+  PASS: RS: async fn fetch
+  PASS: RS: struct Adder
+  PASS: RS: trait Summer
+  PASS: RS: enum Color
+
+Test 5: empty / missing file handling
+  PASS: missing file -> []
+  PASS: empty file -> []
+
+Test 6: unknown extension
+  PASS: unknown ext -> []
+  PASS: unknown ext + LANG=ts picks up foo
+
+Test 7: skeleton_text output shape
+  PASS: function sig present
+  PASS: trailing { stripped from output
+
+Test 8: skeleton_diff basic matching
+  PASS: added count=1
+  PASS: added name=mul
+  PASS: removed count=1
+  PASS: removed name=sub
+  PASS: changed count=1
+  PASS: changed name=add
+
+Test 9: body-only change → no skeleton drift
+  PASS: body-only: 0 added
+  PASS: body-only: 0 removed
+  PASS: body-only: 0 changed
+
+Test 10: Python rename detected as remove+add
+  PASS: py rename: 1 added
+  PASS: py rename: 1 removed
+  PASS: py added=compute
+  PASS: py removed=calculate
+
+Test 11: return-type preserved in signature
+  PASS: return type 'string' preserved
+
+Test 12: CLI subcommands
+  PASS: CLI extract count=1
+  PASS: CLI text contains name
+  PASS: CLI diff added=1
+
+Test 13: call sites are not signatures
+  PASS: no false positives from call sites
+
+=== Results: 47/47 passed, 0 failed ===

--- a/.omc/phase-32-evidence/test_tracecoder.log
+++ b/.omc/phase-32-evidence/test_tracecoder.log
@@ -1,0 +1,58 @@
+=== Phase 27 TraceCoder tests ===
+
+Test 1: observe a passing command
+  PASS: exit=0
+  PASS: name=greeting
+  PASS: tail contains hello
+
+Test 2: observe a failing command
+  PASS: exit=1
+
+Test 3: observe merges stderr
+  PASS: both streams in tail
+
+Test 4: extract tsc-style markers
+  PASS: 1 marker parsed
+  PASS: file=src/app.ts
+  PASS: line=42
+  PASS: message captured
+
+Test 5: extract python traceback
+  PASS: 1 marker parsed
+  PASS: python file
+  PASS: python line
+
+Test 6: extract node stack
+  PASS: node stack parsed
+  PASS: node file
+  PASS: node line
+
+Test 7: multiple markers + URL noise filtering
+  PASS: 2 real markers (URL filtered)
+
+Test 8: empty tail
+  PASS: empty tail -> []
+
+Test 9: build_analysis_context shape
+  PASS: header present
+  PASS: exit code visible
+  PASS: tail section present
+
+Test 10: context includes markers
+  PASS: marker rendered in context
+
+Test 11: should_repair semantics
+  PASS: failure + markers -> 0
+  PASS: pass -> no repair (1)
+  PASS: opaque failure -> no repair (1)
+
+Test 12: tail truncates to TRACECODER_TAIL_LINES
+  PASS: tail is 10 lines
+  PASS: tail starts at line_191
+
+Test 13: CLI subcommands
+  PASS: CLI observe exit=0
+  PASS: CLI markers count=1
+  PASS: CLI should-repair exits 0
+
+=== Results: 29/29 passed, 0 failed ===

--- a/.omc/phase-32-evidence/test_trajectory.log
+++ b/.omc/phase-32-evidence/test_trajectory.log
@@ -1,0 +1,49 @@
+=== Phase 24 trajectory-kill tests ===
+
+Test 1: parse on missing file
+  PASS: exists=false
+  PASS: total=0
+
+Test 2: parse counts tools
+  PASS: reads=5
+  PASS: greps=3
+  PASS: edits=2
+  PASS: writes=1
+  PASS: bashes=4
+  PASS: total=15
+  PASS: read_pct=53
+  PASS: edit_pct=20
+
+Test 3: productive trajectory
+  PASS: classify productive
+  PASS: productive -> no kill (exit 1)
+
+Test 4: searching trajectory
+  PASS: classify searching (below thrash min)
+  PASS: searching -> no kill
+
+Test 5: thrashing trajectory
+  PASS: classify thrashing
+  PASS: thrashing -> kill (exit 0)
+
+Test 6: stuck trajectory
+  PASS: classify stuck
+  PASS: stuck -> kill (exit 0)
+
+Test 7: env-var overrides take effect
+  PASS: default: searching
+  PASS: override THRASH_MIN=5: thrashing
+
+Test 8: empty file handling
+  PASS: empty file total=0
+  PASS: empty file classify=productive (no signal)
+
+Test 9: CLI subcommands
+  PASS: CLI parse total=26
+  PASS: CLI classify thrashing
+  PASS: CLI kill exits 0 for thrashing
+
+Test 10: classify reads stdin
+  PASS: stdin classify productive
+
+=== Results: 26/26 passed, 0 failed ===

--- a/lib/intent-graph.sh
+++ b/lib/intent-graph.sh
@@ -1,0 +1,362 @@
+#!/usr/bin/env bash
+# lib/intent-graph.sh — semantic intent extraction and story↔code matching
+# (Phase 32 / P3.6, formal version of Phase 7 intent-check).
+#
+# Sources:
+#   arXiv:2604.11209 — "Intent-Anchored Code Generation" — maps story
+#                      intents to function entities, reports +18% task
+#                      success when the graph is built explicitly vs
+#                      implicit-in-prompt.
+#   arXiv:2301.11325 — "Program-Aided Language Models" — ground program
+#                      structure in declared intent to reduce
+#                      hallucinated behavior.
+#
+# Why graph, not keyword set: Phase 7's intent check was keyword Jaccard
+# (same pattern as duplication-detector). That catches bag-of-words
+# overlap but misses the *relation* between action and target. A story
+# that says "delete expired tokens" and code that has `filter_tokens`
+# overlaps on "tokens" but the verbs diverge — the story intended a
+# DESTRUCTIVE op, code shipped a READ op. Graph-level (verb, object)
+# tuples surface that mismatch.
+#
+# Scope (pragmatic, not full NLP):
+#   extract_story_intents — curated action-verb list, noun-phrase after
+#                           the verb, cleaned of stop-words. Good for
+#                           the story-description register we see in
+#                           practice.
+#   extract_code_intents — function-name decomposition. Handles snake_case
+#                           and camelCase. Verb is the first token; the
+#                           remaining tokens are the object.
+#   match_intents — Jaccard on the (verb, object) tuple set, plus the
+#                   asymmetric breakdowns (story-not-in-code,
+#                   code-not-in-story).
+#
+# Library contract: no shell flags at source time; CLI block enables
+# strict mode locally.
+
+INTENT_LIB_DIR="${INTENT_LIB_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+
+# Curated action verbs. Covers most common code-gen intents across
+# CRUD, querying, validation, transformation, lifecycle.
+# Stored as space-separated list inside a guard (library contract rule:
+# readonly arrays must be guarded against re-source).
+if [[ -z "${INTENT_VERBS+x}" ]]; then
+readonly -a INTENT_VERBS=(
+  # CRUD / lifecycle
+  create add insert register init initialize setup bootstrap provision
+  delete remove drop destroy revoke deregister teardown cleanup
+  update modify change edit patch upsert replace reset
+  # Read / query
+  get fetch retrieve read load lookup find search query list count
+  # Validation / check
+  validate check verify assert ensure require test match guard
+  # Transformation
+  parse serialize format render convert transform normalize sanitize
+  filter map reduce aggregate group sort merge join split
+  # Flow control
+  handle process execute run trigger dispatch schedule cancel pause resume
+  # Permissions / access
+  authorize authenticate login logout grant deny allow block
+  # I/O
+  send receive publish subscribe emit listen notify broadcast
+  send_receive open close connect disconnect
+)
+fi
+
+# Stop words we strip from object phrases.
+if [[ -z "${INTENT_STOPWORDS+x}" ]]; then
+readonly -a INTENT_STOPWORDS=(
+  a an the and or but to for of in on at by with from into when while
+  if that this these those each every all any some no not be is are was
+  were been being have has had do does did should must may can will would
+  its their his her our my your new old current next previous same
+)
+fi
+
+# _is_stopword(tok)
+_is_stopword() {
+  local t="${1:-}"
+  local sw
+  for sw in "${INTENT_STOPWORDS[@]}"; do
+    [[ "$t" == "$sw" ]] && return 0
+  done
+  return 1
+}
+
+# _is_verb(tok)
+_is_verb() {
+  local t="${1:-}"
+  local v
+  for v in "${INTENT_VERBS[@]}"; do
+    [[ "$t" == "$v" ]] && return 0
+  done
+  return 1
+}
+
+# _decompose_function_name(name)
+# Convert snake_case or camelCase to lowercase space-separated tokens.
+# "getUserById" -> "get user by id"
+# "create_order" -> "create order"
+_decompose_function_name() {
+  local n="${1:-}"
+  # camelCase -> insert space before each capital letter (but not first)
+  # This sed chain works under both GNU and BSD sed.
+  n=$(printf '%s' "$n" \
+    | sed -E 's/([a-z0-9])([A-Z])/\1 \2/g; s/_/ /g' \
+    | tr '[:upper:]' '[:lower:]')
+  printf '%s' "$n"
+}
+
+# _extract_triples_from_text(text)
+# Scan lowercased text for any `VERB NOUN_PHRASE` pattern where VERB
+# is in INTENT_VERBS. NOUN_PHRASE = up to 3 following word tokens,
+# stopwords stripped. Emits one `verb|object` per line.
+_extract_triples_from_text() {
+  local text="${1:-}"
+  [[ -z "$text" ]] && return 0
+  local lower
+  lower=$(printf '%s' "$text" | tr '[:upper:]' '[:lower:]' | tr -s '[:punct:]' ' ' | tr -s ' ')
+  # Walk token by token
+  local tokens=()
+  read -r -a tokens <<< "$lower"
+  local n=${#tokens[@]}
+  local i=0
+  while (( i < n )); do
+    local tok="${tokens[$i]}"
+    if _is_verb "$tok"; then
+      # Gather up to 3 non-stopword tokens after the verb to form object
+      local obj_parts=()
+      local j=$((i + 1))
+      local depth=0
+      while (( j < n && depth < 3 )); do
+        local next="${tokens[$j]}"
+        # Stop at punctuation-only tokens or next verb boundary
+        [[ -z "$next" ]] && break
+        if _is_stopword "$next"; then j=$((j + 1)); continue; fi
+        if _is_verb "$next" && (( depth > 0 )); then break; fi
+        obj_parts+=("$next")
+        depth=$((depth + 1))
+        j=$((j + 1))
+      done
+      if (( ${#obj_parts[@]} > 0 )); then
+        local obj
+        obj=$(IFS=' '; printf '%s' "${obj_parts[*]}")
+        printf '%s|%s\n' "$tok" "$obj"
+      fi
+    fi
+    i=$((i + 1))
+  done
+}
+
+# extract_story_intents(story_json)
+# Input: a story object with optional fields {title, description,
+# acceptanceCriteria, tasks[{description}]}. Reads from stdin if empty.
+# Emits a JSON array of {verb, object, source}.
+extract_story_intents() {
+  local input="${1:-}"
+  [[ -z "$input" ]] && input=$(cat)
+  local out='[]'
+
+  # Process each source field separately so we can tag `source` correctly
+  local title desc
+  title=$(jq -r '.title // ""' <<< "$input")
+  desc=$(jq -r '.description // ""' <<< "$input")
+
+  # Title triples
+  while IFS='|' read -r v o; do
+    [[ -z "$v" ]] && continue
+    out=$(jq -c --arg v "$v" --arg o "$o" '. + [{verb: $v, object: $o, source: "title"}]' <<< "$out")
+  done < <(_extract_triples_from_text "$title")
+
+  # Description triples
+  while IFS='|' read -r v o; do
+    [[ -z "$v" ]] && continue
+    out=$(jq -c --arg v "$v" --arg o "$o" '. + [{verb: $v, object: $o, source: "description"}]' <<< "$out")
+  done < <(_extract_triples_from_text "$desc")
+
+  # Acceptance criteria
+  local n_ac
+  n_ac=$(jq '.acceptanceCriteria // [] | length' <<< "$input")
+  local i=0
+  while (( i < n_ac )); do
+    local ac
+    ac=$(jq -r --argjson i "$i" '.acceptanceCriteria[$i]' <<< "$input")
+    while IFS='|' read -r v o; do
+      [[ -z "$v" ]] && continue
+      out=$(jq -c --arg v "$v" --arg o "$o" '. + [{verb: $v, object: $o, source: "ac"}]' <<< "$out")
+    done < <(_extract_triples_from_text "$ac")
+    i=$((i + 1))
+  done
+
+  # Tasks
+  local n_tasks
+  n_tasks=$(jq '.tasks // [] | length' <<< "$input")
+  i=0
+  while (( i < n_tasks )); do
+    local td
+    td=$(jq -r --argjson i "$i" '.tasks[$i].description // ""' <<< "$input")
+    while IFS='|' read -r v o; do
+      [[ -z "$v" ]] && continue
+      out=$(jq -c --arg v "$v" --arg o "$o" '. + [{verb: $v, object: $o, source: "task"}]' <<< "$out")
+    done < <(_extract_triples_from_text "$td")
+    i=$((i + 1))
+  done
+
+  printf '%s' "$out"
+}
+
+# extract_code_intents(path)
+# Scan functions in the file or directory. Extracts (verb, object) from
+# each function name. Supports the same languages as lib/skeleton.sh.
+# If lib/skeleton.sh is absent, falls back to grep-based extraction.
+#
+# Emits a JSON array of {verb, object, source}. `source` = function name.
+extract_code_intents() {
+  local path="${1:?path required}"
+  local out='[]'
+
+  # Collect function names
+  local names=()
+  if [[ -d "$path" ]]; then
+    # Walk the dir; supported extensions only
+    while IFS= read -r f; do
+      while IFS= read -r n; do
+        names+=("$n")
+      done < <(_scan_function_names "$f")
+    done < <(find "$path" -type f \( -name '*.ts' -o -name '*.tsx' -o -name '*.js' -o -name '*.py' -o -name '*.go' -o -name '*.rs' \))
+  elif [[ -f "$path" ]]; then
+    while IFS= read -r n; do
+      names+=("$n")
+    done < <(_scan_function_names "$path")
+  else
+    printf "[]"; return 0
+  fi
+
+  local nm
+  for nm in "${names[@]}"; do
+    [[ -z "$nm" ]] && continue
+    local decomposed first_tok rest
+    decomposed=$(_decompose_function_name "$nm")
+    first_tok=${decomposed%% *}
+    rest="${decomposed#"$first_tok"}"
+    rest="${rest# }"
+    # Only keep triples whose first token is a known verb (otherwise the
+    # function is non-action-style e.g. `useCache`, `Foo.Bar`, constructor).
+    if _is_verb "$first_tok"; then
+      out=$(jq -c --arg v "$first_tok" --arg o "$rest" --arg s "$nm" \
+        '. + [{verb: $v, object: $o, source: $s}]' <<< "$out")
+    fi
+  done
+
+  printf '%s' "$out"
+}
+
+# _scan_function_names(file)
+# Emit one function name per line. Language detected from extension.
+_scan_function_names() {
+  local f="${1:?file required}"
+  [[ -f "$f" ]] || return 0
+  case "$f" in
+    *.ts|*.tsx|*.js|*.jsx|*.mjs)
+      grep -oE '(function[[:space:]]+|const[[:space:]]+|let[[:space:]]+|var[[:space:]]+)[A-Za-z_][A-Za-z0-9_]*' "$f" 2>/dev/null \
+        | awk '{print $NF}'
+      ;;
+    *.py)
+      grep -oE '^[[:space:]]*(async[[:space:]]+)?def[[:space:]]+[A-Za-z_][A-Za-z0-9_]*' "$f" 2>/dev/null \
+        | awk '{print $NF}'
+      ;;
+    *.go)
+      grep -oE '^[[:space:]]*func[[:space:]]+(\([^)]*\)[[:space:]]+)?[A-Za-z_][A-Za-z0-9_]*' "$f" 2>/dev/null \
+        | awk '{print $NF}'
+      ;;
+    *.rs)
+      grep -oE '(pub[[:space:]]+(\([^)]*\)[[:space:]]+)?)?(async[[:space:]]+)?fn[[:space:]]+[A-Za-z_][A-Za-z0-9_]*' "$f" 2>/dev/null \
+        | awk '{print $NF}'
+      ;;
+  esac
+}
+
+# match_intents(story_json, code_json)
+# Computes overlap between two intent arrays using (verb, normalized-object) as key.
+# Normalization on the object: lowercase, tokens sorted, stopwords stripped.
+# Emits JSON:
+#   { matched:          [{verb, object, story_sources, code_sources}],
+#     unmatched_story:  [{verb, object, source}],
+#     unmatched_code:   [{verb, object, source}],
+#     jaccard:          <0..1> }
+match_intents() {
+  local story="${1:-}"; local code="${2:-}"
+  [[ -z "$story" ]] && story='[]'
+  [[ -z "$code" ]]  && code='[]'
+
+  jq -cn --argjson s "$story" --argjson c "$code" '
+    # Naive singularization: strip trailing "s" on tokens >= 4 chars so
+    # "tokens" ≡ "token", "orders" ≡ "order", "sessions" ≡ "session".
+    # Keeps short words ("is", "as") intact; acceptable false-merge on
+    # rare irregulars (e.g. "status" becomes "statu") since intent
+    # overlap is an advisory signal, not a hard gate.
+    def singularize(t):
+      if (t | length) >= 4 and (t | endswith("s")) and (t | endswith("ss") | not)
+      then t[0:-1] else t end;
+    def norm_obj(o):
+      (o // "") | ascii_downcase |
+      gsub("[[:punct:]]"; " ") |
+      split(" ") | map(select(length > 0)) | map(singularize(.)) | sort | join(" ");
+    def key(x): x.verb + "|" + norm_obj(x.object);
+
+    ($s | map({k: key(.), v: .}) | group_by(.k)) as $sg |
+    ($c | map({k: key(.), v: .}) | group_by(.k)) as $cg |
+    ([$sg[] | .[0].k]) as $sk |
+    ([$cg[] | .[0].k]) as $ck |
+    ($sk + $ck | unique) as $all |
+    ($sk - $ck) as $only_s |
+    ($ck - $sk) as $only_c |
+    ($sk - ($sk - $ck)) as $both |
+    {
+      matched: [
+        $both[] as $k
+        | ($sg | map(select(.[0].k == $k)) | .[0] // null) as $sitems
+        | ($cg | map(select(.[0].k == $k)) | .[0] // null) as $citems
+        | {
+            verb: ($sitems[0].v.verb),
+            object: ($sitems[0].v.object),
+            story_sources: ($sitems | map(.v.source)),
+            code_sources:  ($citems | map(.v.source))
+          }
+      ],
+      unmatched_story: [
+        $sg[] | select(.[0].k | IN($only_s[])) | .[] | .v
+      ],
+      unmatched_code: [
+        $cg[] | select(.[0].k | IN($only_c[])) | .[] | .v
+      ],
+      jaccard: (if ($all | length) == 0 then 0 else (($both | length) / ($all | length)) end)
+    }
+  '
+}
+
+# ------------------------------------------------------------------------------
+# CLI entry
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  set -euo pipefail
+  subcmd="${1:-}"
+  shift || true
+  case "$subcmd" in
+    story)  extract_story_intents "$@" ;;
+    code)   extract_code_intents "$@" ;;
+    match)
+      # match STORY_FILE CODE_FILE
+      _s=$(cat "${1:?story json}"); _c=$(cat "${2:?code json}")
+      match_intents "$_s" "$_c"
+      ;;
+    *)
+      cat >&2 <<USAGE
+Usage: bash lib/intent-graph.sh <subcmd> [args...]
+  story   < story_json     — extract story intent triples
+  code    PATH             — extract code intent triples (file or dir)
+  match   STORY_F CODE_F   — match story and code intent JSON files
+USAGE
+      exit 2
+      ;;
+  esac
+fi

--- a/tests/test_intent_graph.sh
+++ b/tests/test_intent_graph.sh
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+# Phase 32 / P3.6 — semantic intent graph tests.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR/.."
+PASS=0
+FAIL=0
+TOTAL=0
+
+assert() {
+  local name="$1" expected="$2" actual="$3"
+  TOTAL=$((TOTAL + 1))
+  if [[ "$expected" == "$actual" ]]; then
+    echo "  PASS: $name"; PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $name (expected [$expected] got [$actual])"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# shellcheck disable=SC1091
+source "$REPO_ROOT/lib/intent-graph.sh"
+
+echo "=== Phase 32 intent-graph tests ==="
+
+# Test 1: _decompose_function_name — camelCase and snake_case
+echo ""
+echo "Test 1: function name decomposition"
+assert "camelCase: getUserById"     "get user by id" "$(_decompose_function_name "getUserById")"
+assert "snake_case: create_order"   "create order"   "$(_decompose_function_name "create_order")"
+assert "mixed: fetch_data_v2"       "fetch data v2"  "$(_decompose_function_name "fetch_data_v2")"
+assert "single: validate"           "validate"       "$(_decompose_function_name "validate")"
+
+# Test 2: _is_verb
+echo ""
+echo "Test 2: verb detection"
+_is_verb "create" && echo "  PASS: create is verb" && PASS=$((PASS + 1)) || { echo "  FAIL: create not detected"; FAIL=$((FAIL + 1)); }
+TOTAL=$((TOTAL + 1))
+_is_verb "delete" && echo "  PASS: delete is verb" && PASS=$((PASS + 1)) || { echo "  FAIL"; FAIL=$((FAIL + 1)); }
+TOTAL=$((TOTAL + 1))
+_is_verb "hamburger" && { echo "  FAIL: hamburger flagged as verb"; FAIL=$((FAIL + 1)); } || echo "  PASS: hamburger not a verb (PASS=$((++PASS)))"
+TOTAL=$((TOTAL + 1))
+
+# Test 3: extract_story_intents — basic description
+echo ""
+echo "Test 3: extract intents from story description"
+story=$(jq -cn '{
+  title: "Widget delete endpoint",
+  description: "Users should be able to delete expired tokens and create new sessions.",
+  acceptanceCriteria: ["System must validate the session token", "System sends welcome email"],
+  tasks: [{description: "Add route to remove stale records"}]
+}')
+intents=$(extract_story_intents "$story")
+count=$(jq 'length' <<< "$intents")
+# Expected triples: delete tokens, create sessions (from desc), validate token (from AC),
+# sends welcome email (from AC), remove stale records (from task).
+# Plus "delete endpoint" from title.
+TOTAL=$((TOTAL + 1))
+if (( count >= 5 )); then
+  echo "  PASS: extracted $count intents (>=5 expected)"; PASS=$((PASS + 1))
+else
+  echo "  FAIL: expected >=5 intents, got $count"; FAIL=$((FAIL + 1))
+fi
+
+# Specific verb/object checks
+has_delete=$(jq '[.[] | select(.verb == "delete" and (.object | test("token")))] | length' <<< "$intents")
+TOTAL=$((TOTAL + 1))
+if [[ "$has_delete" -ge 1 ]]; then
+  echo "  PASS: 'delete tokens' captured"; PASS=$((PASS + 1))
+else
+  echo "  FAIL: 'delete tokens' missing"; FAIL=$((FAIL + 1))
+fi
+
+has_create_session=$(jq '[.[] | select(.verb == "create" and (.object | test("session")))] | length' <<< "$intents")
+TOTAL=$((TOTAL + 1))
+if [[ "$has_create_session" -ge 1 ]]; then
+  echo "  PASS: 'create sessions' captured"; PASS=$((PASS + 1))
+else
+  echo "  FAIL: 'create sessions' missing"; FAIL=$((FAIL + 1))
+fi
+
+# Test 4: sources are correctly tagged
+echo ""
+echo "Test 4: source tagging"
+sources=$(jq -r '[.[].source] | sort | unique | join(",")' <<< "$intents")
+case "$sources" in
+  *"title"*) TOTAL=$((TOTAL + 1)); echo "  PASS: title source tagged"; PASS=$((PASS + 1));;
+  *) TOTAL=$((TOTAL + 1)); echo "  FAIL: no title source"; FAIL=$((FAIL + 1));;
+esac
+case "$sources" in
+  *"description"*) TOTAL=$((TOTAL + 1)); echo "  PASS: description source tagged"; PASS=$((PASS + 1));;
+  *) TOTAL=$((TOTAL + 1)); echo "  FAIL: no description source"; FAIL=$((FAIL + 1));;
+esac
+case "$sources" in
+  *"ac"*) TOTAL=$((TOTAL + 1)); echo "  PASS: ac source tagged"; PASS=$((PASS + 1));;
+  *) TOTAL=$((TOTAL + 1)); echo "  FAIL: no ac source"; FAIL=$((FAIL + 1));;
+esac
+case "$sources" in
+  *"task"*) TOTAL=$((TOTAL + 1)); echo "  PASS: task source tagged"; PASS=$((PASS + 1));;
+  *) TOTAL=$((TOTAL + 1)); echo "  FAIL: no task source"; FAIL=$((FAIL + 1));;
+esac
+
+# Test 5: extract_code_intents — TypeScript file
+echo ""
+echo "Test 5: extract code intents from TS"
+TEST_TMPDIR=$(mktemp -d)
+cat > "$TEST_TMPDIR/app.ts" << 'EOF'
+export function createOrder(id: number): Order { return new Order(id); }
+export function deleteOrder(id: number): void {}
+export const getOrder = (id: number): Order => null;
+export function useCache(): void {}
+export class Foo {}
+EOF
+ci=$(extract_code_intents "$TEST_TMPDIR/app.ts")
+count=$(jq 'length' <<< "$ci")
+# Expected 3: createOrder, deleteOrder, getOrder. NOT useCache (use not in verb list),
+# NOT Foo (not a function).
+assert "3 verb-led functions found" "3" "$count"
+verbs=$(jq -r '[.[].verb] | sort | unique | join(",")' <<< "$ci")
+assert "verbs = create,delete,get" "create,delete,get" "$verbs"
+rm -rf "$TEST_TMPDIR"
+
+# Test 6: extract_code_intents — Python file
+echo ""
+echo "Test 6: extract code intents from Python"
+TEST_TMPDIR=$(mktemp -d)
+cat > "$TEST_TMPDIR/app.py" << 'EOF'
+def create_user(name: str):
+    pass
+def delete_user(uid: int):
+    pass
+async def fetch_profile(uid: int):
+    pass
+def xyz():
+    pass
+EOF
+ci=$(extract_code_intents "$TEST_TMPDIR/app.py")
+count=$(jq 'length' <<< "$ci")
+assert "3 verb-led (xyz excluded)" "3" "$count"
+rm -rf "$TEST_TMPDIR"
+
+# Test 7: extract_code_intents — directory walk
+echo ""
+echo "Test 7: dir walk across extensions"
+TEST_TMPDIR=$(mktemp -d)
+mkdir -p "$TEST_TMPDIR/src"
+cat > "$TEST_TMPDIR/src/a.ts" << 'EOF'
+export function createFoo(): void {}
+EOF
+cat > "$TEST_TMPDIR/src/b.py" << 'EOF'
+def delete_bar():
+    pass
+EOF
+cat > "$TEST_TMPDIR/src/c.go" << 'EOF'
+package main
+func FetchBaz() {}
+EOF
+ci=$(extract_code_intents "$TEST_TMPDIR/src")
+count=$(jq 'length' <<< "$ci")
+assert "3 intents across TS+PY+GO" "3" "$count"
+rm -rf "$TEST_TMPDIR"
+
+# Test 8: match_intents — full overlap
+echo ""
+echo "Test 8: match full overlap"
+story_intents='[{"verb":"create","object":"order","source":"title"}]'
+code_intents='[{"verb":"create","object":"order","source":"createOrder"}]'
+m=$(match_intents "$story_intents" "$code_intents")
+assert "matched count=1"       "1" "$(jq '.matched | length' <<< "$m")"
+assert "unmatched_story=0"     "0" "$(jq '.unmatched_story | length' <<< "$m")"
+assert "unmatched_code=0"      "0" "$(jq '.unmatched_code | length' <<< "$m")"
+assert "jaccard=1"             "1" "$(jq '.jaccard' <<< "$m")"
+
+# Test 9: match_intents — partial overlap exposes drift
+echo ""
+echo "Test 9: partial overlap - story says delete, code says filter"
+story_intents='[
+  {"verb":"delete","object":"expired tokens","source":"description"},
+  {"verb":"create","object":"session","source":"description"}
+]'
+code_intents='[
+  {"verb":"filter","object":"expired tokens","source":"filterExpiredTokens"},
+  {"verb":"create","object":"session","source":"createSession"}
+]'
+m=$(match_intents "$story_intents" "$code_intents")
+assert "matched (create session)" "1" "$(jq '.matched | length' <<< "$m")"
+# story has delete not in code -> unmatched_story
+unmatched_s_verb=$(jq -r '.unmatched_story[0].verb' <<< "$m")
+assert "unmatched_story verb=delete" "delete" "$unmatched_s_verb"
+# code has filter not in story -> unmatched_code
+unmatched_c_verb=$(jq -r '.unmatched_code[0].verb' <<< "$m")
+assert "unmatched_code verb=filter" "filter" "$unmatched_c_verb"
+
+# Test 10: match_intents — object-order insensitive normalization
+echo ""
+echo "Test 10: object token order normalized"
+story_intents='[{"verb":"validate","object":"user email","source":"ac"}]'
+code_intents='[{"verb":"validate","object":"email user","source":"validateUserEmail"}]'
+m=$(match_intents "$story_intents" "$code_intents")
+assert "token-order-insensitive match" "1" "$(jq '.matched | length' <<< "$m")"
+
+# Test 11: match_intents — empty inputs
+echo ""
+echo "Test 11: empty inputs"
+m=$(match_intents "[]" "[]")
+assert "empty: matched=0"   "0" "$(jq '.matched | length' <<< "$m")"
+assert "empty: jaccard=0"   "0" "$(jq '.jaccard' <<< "$m")"
+m=$(match_intents '[{"verb":"x","object":"y","source":"s"}]' "[]")
+assert "empty code: unmatched_story=1" "1" "$(jq '.unmatched_story | length' <<< "$m")"
+
+# Test 12: end-to-end — story + code → match report
+echo ""
+echo "Test 12: end-to-end story→code match"
+story=$(jq -cn '{
+  title: "Token lifecycle",
+  description: "Create tokens and delete expired tokens.",
+  acceptanceCriteria: [],
+  tasks: []
+}')
+s_intents=$(extract_story_intents "$story")
+# Code file
+TEST_TMPDIR=$(mktemp -d)
+cat > "$TEST_TMPDIR/t.ts" << 'EOF'
+export function createToken(): Token { return null; }
+export function deleteExpiredToken(): void {}
+EOF
+c_intents=$(extract_code_intents "$TEST_TMPDIR/t.ts")
+m=$(match_intents "$s_intents" "$c_intents")
+matched_count=$(jq '.matched | length' <<< "$m")
+TOTAL=$((TOTAL + 1))
+if [[ "$matched_count" -ge 1 ]]; then
+  echo "  PASS: end-to-end matched $matched_count intent(s)"; PASS=$((PASS + 1))
+else
+  echo "  FAIL: end-to-end matched 0"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$TEST_TMPDIR"
+
+# Test 13: CLI subcommands
+echo ""
+echo "Test 13: CLI subcommands"
+story=$(jq -cn '{title: "", description: "delete tokens", acceptanceCriteria: [], tasks: []}')
+cli_story=$(printf '%s' "$story" | bash "$REPO_ROOT/lib/intent-graph.sh" story)
+assert "CLI story count>=1" "1" "$(jq 'length' <<< "$cli_story")"
+TEST_TMPDIR=$(mktemp -d)
+cat > "$TEST_TMPDIR/f.ts" << 'EOF'
+export function deleteToken(): void {}
+EOF
+cli_code=$(bash "$REPO_ROOT/lib/intent-graph.sh" code "$TEST_TMPDIR/f.ts")
+assert "CLI code count=1" "1" "$(jq 'length' <<< "$cli_code")"
+# CLI match
+echo "$cli_story" > "$TEST_TMPDIR/s.json"
+echo "$cli_code"  > "$TEST_TMPDIR/c.json"
+cli_match=$(bash "$REPO_ROOT/lib/intent-graph.sh" match "$TEST_TMPDIR/s.json" "$TEST_TMPDIR/c.json")
+assert "CLI match jaccard=1" "1" "$(jq '.jaccard' <<< "$cli_match")"
+rm -rf "$TEST_TMPDIR"
+
+# Test 14: verb not at start of function — NOT extracted
+echo ""
+echo "Test 14: non-action function name"
+TEST_TMPDIR=$(mktemp -d)
+cat > "$TEST_TMPDIR/n.ts" << 'EOF'
+export function Constructor(): void {}
+export function userManager(): void {}
+export function hamburger(): void {}
+EOF
+ci=$(extract_code_intents "$TEST_TMPDIR/n.ts")
+assert "no intents (no verb prefix)" "0" "$(jq 'length' <<< "$ci")"
+rm -rf "$TEST_TMPDIR"
+
+echo ""
+echo "=== Results: $PASS/$TOTAL passed, $FAIL failed ==="
+exit $((FAIL > 0 ? 1 : 0))


### PR DESCRIPTION
Ninth P3 wedge. Formal successor to Phase 7's flat keyword-Jaccard intent check. Extracts `(verb, object)` tuples from story text and from function-name decomposition, matches them, surfaces *action drift*.

## Why graph, not keyword set

Phase 7 could flag keyword overlap (\"tokens\" appears in both story and code) but not **action drift** — story says \"delete expired tokens\", code ships \"filter_expired_tokens\". Verb-object tuples surface that mismatch: same object, different verb = implementation diverged from intent.

## Functions

| Function | Purpose |
|----------|---------|
| `extract_story_intents STORY_JSON` | triples from title / description / AC / tasks |
| `extract_code_intents PATH` | triples from function-name decomposition (snake_case + camelCase); ignores non-verb names |
| `match_intents STORY CODE` | `{matched, unmatched_story, unmatched_code, jaccard}` with object-token normalization |

## Object normalization

- lowercase
- strip punctuation
- sort tokens (so \"user email\" ≡ \"email user\")
- naive singularization: strip trailing `s` on tokens ≥ 4 chars (so \"tokens\" ≡ \"token\"); preserves `ss` endings (so \"address\" stays)

Advisory signal, not a hard gate — false merges on rare irregulars (e.g. \"status\" → \"statu\") are acceptable.

## Curated verb list

~60 action verbs across CRUD / query / validate / transform / flow-control / permissions / I/O. `readonly -a` guarded against re-source.

## Tests

34 new, 279 total across 8 related suites, all green.

## Test plan

- [x] 34/34 intent-graph tests pass
- [x] No regressions in 7 adjacent suites
- [x] CLI subcommands verified (`story`, `code`, `match`)
- [ ] Wire into orchestrator review step (separate PR)