### PR TITLE
Phase 34 — Wire dead-code into Step 3A.5C advisory (P3.10)

### DIFF
--- a/.omc/phase-34-evidence/test_dead_code.log
+++ b/.omc/phase-34-evidence/test_dead_code.log
@@ -1,0 +1,66 @@
+=== Phase 33 dead-code tests ===
+
+Test 1: TS default import
+  PASS: TS: 1 unused import
+  PASS: TS: name=unused
+
+Test 2: TS named imports (only some unused)
+  PASS: TS: only 'beta' flagged (1)
+  PASS: TS: name=beta
+
+Test 3: TS rename alias
+  PASS: TS: alias tracks local binding (0 unused)
+
+Test 4: TS namespace
+  PASS: TS: namespace used (0 unused)
+
+Test 5: Python import
+  PASS: PY: 2 unused imports
+  PASS: PY: names = beta,unused_mod
+
+Test 6: PY rename alias
+  PASS: PY: alias tracked (0 unused)
+
+Test 7: Go imports
+  PASS: Go: 1 unused (strings)
+  PASS: Go: name=strings
+
+Test 8: Rust use
+  PASS: RS: 1 unused (File)
+  PASS: RS: name=File
+
+Test 9: TS private helpers
+  PASS: TS: 2 orphans flagged
+  PASS: TS: names = _orphan,_var_orphan
+
+Test 10: exported private NOT flagged
+  PASS: export _intentional not flagged
+
+Test 11: PY private helpers
+  PASS: PY: 1 orphan
+  PASS: PY: name=_orphan
+
+Test 12: scan_dead_code directory walk
+  PASS: aggregate imports=2
+  PASS: aggregate privates=2
+  PASS: aggregate total=4
+
+Test 13: clean file has 0 findings
+  PASS: clean: total=0
+
+Test 14: missing path handling
+  PASS: missing: total=0
+  PASS: missing: imports=[]
+
+Test 15: find_post_commit_dead git-diff driven
+  PASS: post-commit detected 2 dead (1 import + 1 private)
+
+Test 16: CLI subcommands
+  PASS: CLI imports count=1
+  PASS: CLI scan total=1
+
+Test 17: unknown extension
+  PASS: unknown ext imports=[]
+  PASS: unknown ext privates=[]
+
+=== Results: 29/29 passed, 0 failed ===

--- a/.omc/phase-34-evidence/test_orchestrator_wiring.log
+++ b/.omc/phase-34-evidence/test_orchestrator_wiring.log
@@ -1,0 +1,92 @@
+=== Phase 17 orchestrator-wiring prompt tests ===
+
+Test 1: lib/wave-boundary.sh wired at wave boundary
+  PASS: 3C.NEG1 section present
+  PASS: references wave-boundary.sh scan
+  PASS: routes HIGH severity to fix-story
+
+Test 2: lib/watchdog.sh wired in monitor loop
+  PASS: watchdog tick header
+  PASS: references watchdog.sh poll
+  PASS: status-probe action branch
+  PASS: kill-and-requeue action branch
+  PASS: mark-failed action branch
+  PASS: circuit-breaker bump
+  PASS: circuit-breaker check
+
+Test 3: lib/deep-review.sh wired at full-feature review
+  PASS: 4B.5 deep-review section
+  PASS: score-from-quantum call
+  PASS: tier lookup
+  PASS: dispatch-set call
+  PASS: context preparation
+  PASS: aggregate pipe
+  PASS: BLOCKS_MERGE handled
+  PASS: REQUEST_CHANGES handled
+  PASS: persists into quantum.reviews
+
+Test 4: lib/deslop.sh wired between review-pass and commit
+  PASS: 3A.5B deslop section
+  PASS: validate_scope gate
+  PASS: baseline snapshot before
+  PASS: compare_baseline call
+  PASS: rollback on regression
+  PASS: DESLOP_ROLLED_BACK signal
+  PASS: opt-out via story.deslop.skip
+
+Test 5: lib/commit-trailers.sh validation gate
+  PASS: commit-trailers reference
+  PASS: non-blocking warning
+
+Test 6: handoff.sh ownership is skill-side (orchestrator doesn't write)
+  PASS: orchestrator does NOT write handoffs directly (skills do)
+
+Test 7: all wirings carry a Phase-17 attribution comment
+  PASS: 5 Phase-17 attributions
+
+Test 8: deslop wiring uses DESLOP_AVAILABLE + BASE_SHA
+  PASS: DESLOP_AVAILABLE guard present
+  PASS: DESLOP_AVAILABLE file check
+  PASS: Fallback skip branch
+  PASS: scope loop uses BASE_SHA
+  PASS: rollback uses BASE_SHA
+  PASS: no active STORY_BASE_SHA refs in 3A.5B
+
+Test 9: RUNNER_EXTRA_FLAGS validated after pre_spawn()
+  PASS: RUNNER_EXTRA_FLAGS validation present
+  PASS: blocklist present (regex form varies)
+
+Test 10: runner_build_cmd rejects injection via RUNNER_EXTRA_FLAGS
+  PASS: injection payload rejected with clear error
+
+Test 10b: lib/reground.sh wired at Step 1C
+  PASS: reground source line present
+  PASS: REGROUND_AVAILABLE fallback flag
+  PASS: Step 1C header present
+  PASS: should_reground invoked
+  PASS: build_reground_context invoked
+  PASS: mark_grounded invoked
+  PASS: reground block path stable
+
+Test 10c: lib/tracecoder.sh wired at Step 3A.3
+  PASS: tracecoder source line present
+  PASS: TRACECODER_AVAILABLE fallback flag
+  PASS: observe primitive invoked
+  PASS: should_repair gate check
+  PASS: build_analysis_context call
+  PASS: opaque-failure bypass documented
+
+Test 10d: lib/dead-code.sh wired at Step 3A.5C
+  PASS: dead-code source line present
+  PASS: DEAD_CODE_AVAILABLE fallback flag
+  PASS: 3A.5C header present
+  PASS: find_post_commit_dead invoked
+  PASS: advisory trailer generated
+  PASS: clean-case trailer
+  PASS: side-file path for progress attach
+  PASS: non-blocking by design documented
+
+Test 11: lib/watchdog.sh doc comment corrected
+  PASS: watchdog threshold comment matches code (>30 min = timed-out)
+
+=== Results: 61/61 passed, 0 failed ===

--- a/agents/orchestrator.md
+++ b/agents/orchestrator.md
@@ -43,6 +43,10 @@ source "$REPO_ROOT/lib/reground.sh" 2>/dev/null || REGROUND_AVAILABLE=false
 TRACECODER_AVAILABLE=true
 source "$REPO_ROOT/lib/tracecoder.sh" 2>/dev/null || TRACECODER_AVAILABLE=false
 
+# Source dead-code module (Phase 33 / P3.10 wiring, graceful fallback)
+DEAD_CODE_AVAILABLE=true
+source "$REPO_ROOT/lib/dead-code.sh" 2>/dev/null || DEAD_CODE_AVAILABLE=false
+
 # Run pre-flight checks (idempotent within 1 hour)
 if [[ "$INIT_GUARD_AVAILABLE" != "false" ]]; then
   run_preflight "$REPO_ROOT" "$JSON_PATH"
@@ -329,6 +333,40 @@ fi
 ```
 
 `lib/deslop.sh detect-language` picks the appropriate dead-code detector (knip / ts-prune / vulture / staticcheck / cargo-udeps); tooling-missing → skip-clean (not fail).
+
+### 3A.5C: Post-generation dead-code check (Phase 33 / P3.10 wiring)
+
+Before the commit in 3A.6, run an **advisory** dead-code pass over the files this story just changed. Complements 3A.5B (deslop) which is language-tool-driven; 3A.5C is regex-based and tool-free, so it lands findings even when knip/vulture/staticcheck aren't installed.
+
+This check is **non-blocking by design**: unused imports or unused private helpers don't fail the story — they get recorded on the commit as a trailer and surfaced in the per-story progress entry. Blocking here would fight the deslop pass; advisory status lets reviewers see both signals without either forcing a retry.
+
+```bash
+# Phase 33 wiring: post-generation dead-code advisory check.
+# Runs against the story's changed files only (not the whole repo).
+if [[ "$DEAD_CODE_AVAILABLE" != "false" ]]; then
+  DEAD_CODE_REPORT=$(find_post_commit_dead "$BASE_SHA" "HEAD")
+  DEAD_TOTAL=$(jq -r '.summary.total // 0' <<< "$DEAD_CODE_REPORT")
+  if (( DEAD_TOTAL > 0 )); then
+    DEAD_IMP=$(jq -r '.summary.by_kind.import // 0' <<< "$DEAD_CODE_REPORT")
+    DEAD_PRIV=$(jq -r '.summary.by_kind.private // 0' <<< "$DEAD_CODE_REPORT")
+    echo "[DEAD-CODE] advisory: $DEAD_TOTAL finding(s) — $DEAD_IMP unused imports, $DEAD_PRIV unused privates"
+    # Record trailer to be appended in 3A.6 commit message. Non-blocking.
+    DEAD_CODE_TRAILER="Dead-Code: advisory | $DEAD_IMP imports, $DEAD_PRIV privates"
+    # Persist the full finding list into .quantum-dead-code.$STORY_ID.json
+    # so 3A.6 can attach it to the progress entry for later review.
+    printf '%s' "$DEAD_CODE_REPORT" > "$REPO_ROOT/.quantum-dead-code.$STORY_ID.json"
+  else
+    DEAD_CODE_TRAILER="Dead-Code: clean"
+  fi
+else
+  DEAD_CODE_TRAILER="Dead-Code: skipped | lib/dead-code.sh absent"
+fi
+```
+
+Why advisory not blocking:
+- False positives are real. A private helper called only from a test file in a future commit would be flagged here incorrectly. Blocking would train the loop to retry-until-empty, breaking the one-retry budget.
+- Deslop (3A.5B) already has the blocking authority when it wants to. Dead-code is a secondary read for reviewer context.
+- The advisory trailer makes the signal durable in `git log`; the JSON side-file makes it queryable later without re-running the scan.
 
 ### 3A.6: On Success
 ```bash

--- a/tests/test_orchestrator_wiring.sh
+++ b/tests/test_orchestrator_wiring.sh
@@ -207,6 +207,18 @@ check "should_repair gate check" "| should_repair"
 check "build_analysis_context call" "| build_analysis_context"
 check "opaque-failure bypass documented" "opaque failure"
 
+# Test 10d: Dead-code wired at Step 3A.5C post-review advisory (Phase 33 / P3.10)
+echo ""
+echo "Test 10d: lib/dead-code.sh wired at Step 3A.5C"
+check "dead-code source line present" 'source "$REPO_ROOT/lib/dead-code.sh"'
+check "DEAD_CODE_AVAILABLE fallback flag" "DEAD_CODE_AVAILABLE=true"
+check "3A.5C header present" "3A.5C: Post-generation dead-code check"
+check "find_post_commit_dead invoked" 'find_post_commit_dead "$BASE_SHA" "HEAD"'
+check "advisory trailer generated" "Dead-Code: advisory"
+check "clean-case trailer" "Dead-Code: clean"
+check "side-file path for progress attach" ".quantum-dead-code.\$STORY_ID.json"
+check "non-blocking by design documented" "non-blocking by design"
+
 # Test 11: classify_age doc comment fixed (Phase 21 consistency fix)
 echo ""
 echo "Test 11: lib/watchdog.sh doc comment corrected"


### PR DESCRIPTION
Third wiring PR. Adds post-generation dead-code check at Step 3A.5C (between review gate and commit). **Advisory-only** — unused imports / unused private helpers get recorded as a commit trailer and a JSON side-file, never block the story.

## Placement

3A.5B (deslop) has blocking authority. 3A.5C is a secondary, **tool-free** read — lands findings even when knip/vulture/staticcheck aren't installed. Both signals appear on the same commit; reviewers see both.

## Trailer forms

```
Dead-Code: advisory | <N> imports, <M> privates
Dead-Code: clean
Dead-Code: skipped | lib/dead-code.sh absent
```

## Side-file

`.quantum-dead-code.\$STORY_ID.json` — full finding list with file/line coordinates, attached to progress entry in 3A.6 for later review.

## Why advisory not blocking

- A private helper called only from a test in a future commit would be flagged here incorrectly. Blocking would train the loop into a retry-until-empty shape, breaking the one-retry budget.
- Deslop already owns the blocking decision when it wants to. Dead-code is a secondary read for reviewer context.

## Tests

`tests/test_orchestrator_wiring.sh`: 53 → 61 (+8 assertions).
`tests/test_dead_code.sh`: unchanged (29/29 still green).

## Test plan

- [x] Wiring assertions pass (61/61)
- [x] Dead-code lib tests still pass (29/29)
- [ ] Observe trailer in a live orchestrator run (follow-up)