### PR TITLE
Phase 35 — Wire intent-graph into Step 3A.5D advisory (P3.6)

### DIFF
--- a/.omc/phase-35-evidence/test_intent_graph.log
+++ b/.omc/phase-35-evidence/test_intent_graph.log
@@ -1,0 +1,65 @@
+=== Phase 32 intent-graph tests ===
+
+Test 1: function name decomposition
+  PASS: camelCase: getUserById
+  PASS: snake_case: create_order
+  PASS: mixed: fetch_data_v2
+  PASS: single: validate
+
+Test 2: verb detection
+  PASS: create is verb
+  PASS: delete is verb
+  PASS: hamburger not a verb (PASS=7)
+
+Test 3: extract intents from story description
+  PASS: extracted 6 intents (>=5 expected)
+  PASS: 'delete tokens' captured
+  PASS: 'create sessions' captured
+
+Test 4: source tagging
+  PASS: title source tagged
+  PASS: description source tagged
+  PASS: ac source tagged
+  PASS: task source tagged
+
+Test 5: extract code intents from TS
+  PASS: 3 verb-led functions found
+  PASS: verbs = create,delete,get
+
+Test 6: extract code intents from Python
+  PASS: 3 verb-led (xyz excluded)
+
+Test 7: dir walk across extensions
+  PASS: 3 intents across TS+PY+GO
+
+Test 8: match full overlap
+  PASS: matched count=1
+  PASS: unmatched_story=0
+  PASS: unmatched_code=0
+  PASS: jaccard=1
+
+Test 9: partial overlap - story says delete, code says filter
+  PASS: matched (create session)
+  PASS: unmatched_story verb=delete
+  PASS: unmatched_code verb=filter
+
+Test 10: object token order normalized
+  PASS: token-order-insensitive match
+
+Test 11: empty inputs
+  PASS: empty: matched=0
+  PASS: empty: jaccard=0
+  PASS: empty code: unmatched_story=1
+
+Test 12: end-to-end story→code match
+  PASS: end-to-end matched 2 intent(s)
+
+Test 13: CLI subcommands
+  PASS: CLI story count>=1
+  PASS: CLI code count=1
+  PASS: CLI match jaccard=1
+
+Test 14: non-action function name
+  PASS: no intents (no verb prefix)
+
+=== Results: 34/34 passed, 0 failed ===

--- a/.omc/phase-35-evidence/test_orchestrator_wiring.log
+++ b/.omc/phase-35-evidence/test_orchestrator_wiring.log
@@ -1,0 +1,103 @@
+=== Phase 17 orchestrator-wiring prompt tests ===
+
+Test 1: lib/wave-boundary.sh wired at wave boundary
+  PASS: 3C.NEG1 section present
+  PASS: references wave-boundary.sh scan
+  PASS: routes HIGH severity to fix-story
+
+Test 2: lib/watchdog.sh wired in monitor loop
+  PASS: watchdog tick header
+  PASS: references watchdog.sh poll
+  PASS: status-probe action branch
+  PASS: kill-and-requeue action branch
+  PASS: mark-failed action branch
+  PASS: circuit-breaker bump
+  PASS: circuit-breaker check
+
+Test 3: lib/deep-review.sh wired at full-feature review
+  PASS: 4B.5 deep-review section
+  PASS: score-from-quantum call
+  PASS: tier lookup
+  PASS: dispatch-set call
+  PASS: context preparation
+  PASS: aggregate pipe
+  PASS: BLOCKS_MERGE handled
+  PASS: REQUEST_CHANGES handled
+  PASS: persists into quantum.reviews
+
+Test 4: lib/deslop.sh wired between review-pass and commit
+  PASS: 3A.5B deslop section
+  PASS: validate_scope gate
+  PASS: baseline snapshot before
+  PASS: compare_baseline call
+  PASS: rollback on regression
+  PASS: DESLOP_ROLLED_BACK signal
+  PASS: opt-out via story.deslop.skip
+
+Test 5: lib/commit-trailers.sh validation gate
+  PASS: commit-trailers reference
+  PASS: non-blocking warning
+
+Test 6: handoff.sh ownership is skill-side (orchestrator doesn't write)
+  PASS: orchestrator does NOT write handoffs directly (skills do)
+
+Test 7: all wirings carry a Phase-17 attribution comment
+  PASS: 5 Phase-17 attributions
+
+Test 8: deslop wiring uses DESLOP_AVAILABLE + BASE_SHA
+  PASS: DESLOP_AVAILABLE guard present
+  PASS: DESLOP_AVAILABLE file check
+  PASS: Fallback skip branch
+  PASS: scope loop uses BASE_SHA
+  PASS: rollback uses BASE_SHA
+  PASS: no active STORY_BASE_SHA refs in 3A.5B
+
+Test 9: RUNNER_EXTRA_FLAGS validated after pre_spawn()
+  PASS: RUNNER_EXTRA_FLAGS validation present
+  PASS: blocklist present (regex form varies)
+
+Test 10: runner_build_cmd rejects injection via RUNNER_EXTRA_FLAGS
+  PASS: injection payload rejected with clear error
+
+Test 10b: lib/reground.sh wired at Step 1C
+  PASS: reground source line present
+  PASS: REGROUND_AVAILABLE fallback flag
+  PASS: Step 1C header present
+  PASS: should_reground invoked
+  PASS: build_reground_context invoked
+  PASS: mark_grounded invoked
+  PASS: reground block path stable
+
+Test 10c: lib/tracecoder.sh wired at Step 3A.3
+  PASS: tracecoder source line present
+  PASS: TRACECODER_AVAILABLE fallback flag
+  PASS: observe primitive invoked
+  PASS: should_repair gate check
+  PASS: build_analysis_context call
+  PASS: opaque-failure bypass documented
+
+Test 10d: lib/dead-code.sh wired at Step 3A.5C
+  PASS: dead-code source line present
+  PASS: DEAD_CODE_AVAILABLE fallback flag
+  PASS: 3A.5C header present
+  PASS: find_post_commit_dead invoked
+  PASS: advisory trailer generated
+  PASS: clean-case trailer
+  PASS: side-file path for progress attach
+  PASS: non-blocking by design documented
+
+Test 10e: lib/intent-graph.sh wired at Step 3A.5D
+  PASS: intent-graph source line present
+  PASS: INTENT_GRAPH_AVAILABLE fallback flag
+  PASS: 3A.5D header present
+  PASS: extract_story_intents invoked
+  PASS: extract_code_intents invoked
+  PASS: match_intents invoked
+  PASS: intent trailer form
+  PASS: bidirectional drift documented
+  PASS: side-file path
+
+Test 11: lib/watchdog.sh doc comment corrected
+  PASS: watchdog threshold comment matches code (>30 min = timed-out)
+
+=== Results: 70/70 passed, 0 failed ===

--- a/agents/orchestrator.md
+++ b/agents/orchestrator.md
@@ -47,6 +47,10 @@ source "$REPO_ROOT/lib/tracecoder.sh" 2>/dev/null || TRACECODER_AVAILABLE=false
 DEAD_CODE_AVAILABLE=true
 source "$REPO_ROOT/lib/dead-code.sh" 2>/dev/null || DEAD_CODE_AVAILABLE=false
 
+# Source intent-graph module (Phase 32 / P3.6 wiring, graceful fallback)
+INTENT_GRAPH_AVAILABLE=true
+source "$REPO_ROOT/lib/intent-graph.sh" 2>/dev/null || INTENT_GRAPH_AVAILABLE=false
+
 # Run pre-flight checks (idempotent within 1 hour)
 if [[ "$INIT_GUARD_AVAILABLE" != "false" ]]; then
   run_preflight "$REPO_ROOT" "$JSON_PATH"
@@ -367,6 +371,49 @@ Why advisory not blocking:
 - False positives are real. A private helper called only from a test file in a future commit would be flagged here incorrectly. Blocking would train the loop to retry-until-empty, breaking the one-retry budget.
 - Deslop (3A.5B) already has the blocking authority when it wants to. Dead-code is a secondary read for reviewer context.
 - The advisory trailer makes the signal durable in `git log`; the JSON side-file makes it queryable later without re-running the scan.
+
+### 3A.5D: Intent-graph drift check (Phase 32 / P3.6 wiring)
+
+After the dead-code pass, run an **advisory** verb-object intent check between the story's declared intents (title / description / AC / task descriptions) and the code's realized intents (function-name decomposition on changed files). Surfaces action drift: story says "delete expired tokens", code ships `filter_expired_tokens` — same object, different verb = implementation diverged from intent.
+
+Like 3A.5C, this check is **non-blocking**: drift doesn't fail the story. It's a review signal recorded on the commit trailer and in a JSON side-file.
+
+```bash
+# Phase 32 wiring: intent-graph advisory drift check.
+if [[ "$INTENT_GRAPH_AVAILABLE" != "false" ]]; then
+  # Extract story intents once from quantum.json for this story ID.
+  STORY_JSON=$(jq -c --arg sid "$STORY_ID" '.stories[] | select(.id == $sid)' "$JSON_PATH")
+  STORY_INTENTS=$(printf '%s' "$STORY_JSON" | extract_story_intents)
+
+  # Extract code intents from ONLY the files this story changed.
+  # Write names to a temp list, loop each, aggregate.
+  CODE_INTENTS='[]'
+  for f in $(git diff --name-only "$BASE_SHA" "HEAD"); do
+    [[ -f "$f" ]] || continue
+    f_intents=$(extract_code_intents "$f")
+    CODE_INTENTS=$(jq -c --argjson a "$CODE_INTENTS" --argjson b "$f_intents" -n '$a + $b')
+  done
+
+  INTENT_REPORT=$(match_intents "$STORY_INTENTS" "$CODE_INTENTS")
+  J_SCORE=$(jq -r '.jaccard' <<< "$INTENT_REPORT")
+  N_UNMATCHED_STORY=$(jq -r '.unmatched_story | length' <<< "$INTENT_REPORT")
+  N_UNMATCHED_CODE=$(jq -r '.unmatched_code | length' <<< "$INTENT_REPORT")
+
+  # Two signals, both advisory:
+  # - unmatched_story = story asked for an action the code did not realize
+  # - unmatched_code  = code shipped actions the story never requested
+  INTENT_TRAILER="Intent-Graph: jaccard=$J_SCORE | unmatched_story=$N_UNMATCHED_STORY | unmatched_code=$N_UNMATCHED_CODE"
+  printf '%s' "$INTENT_REPORT" > "$REPO_ROOT/.quantum-intent-graph.$STORY_ID.json"
+else
+  INTENT_TRAILER="Intent-Graph: skipped | lib/intent-graph.sh absent"
+fi
+```
+
+Why the (verb, object) graph beats keyword-set overlap:
+- Keyword set says "both mention 'tokens'" → flags nothing wrong.
+- Graph says "story: `delete|tokens`, code: `filter|tokens`" → surfaces the verb mismatch. Same object doesn't make the actions equivalent.
+
+The check is **bidirectional**: unmatched_story catches missing features; unmatched_code catches over-building (scope creep). Each story gets both numbers on the trailer so reviewers can see which direction drifted.
 
 ### 3A.6: On Success
 ```bash

--- a/tests/test_orchestrator_wiring.sh
+++ b/tests/test_orchestrator_wiring.sh
@@ -219,6 +219,19 @@ check "clean-case trailer" "Dead-Code: clean"
 check "side-file path for progress attach" ".quantum-dead-code.\$STORY_ID.json"
 check "non-blocking by design documented" "non-blocking by design"
 
+# Test 10e: Intent-graph wired at Step 3A.5D advisory (Phase 32 / P3.6)
+echo ""
+echo "Test 10e: lib/intent-graph.sh wired at Step 3A.5D"
+check "intent-graph source line present" 'source "$REPO_ROOT/lib/intent-graph.sh"'
+check "INTENT_GRAPH_AVAILABLE fallback flag" "INTENT_GRAPH_AVAILABLE=true"
+check "3A.5D header present" "3A.5D: Intent-graph drift check"
+check "extract_story_intents invoked" "| extract_story_intents"
+check "extract_code_intents invoked" 'extract_code_intents "$f"'
+check "match_intents invoked" 'match_intents "$STORY_INTENTS"'
+check "intent trailer form" "Intent-Graph: jaccard="
+check "bidirectional drift documented" "bidirectional"
+check "side-file path" ".quantum-intent-graph.\$STORY_ID.json"
+
 # Test 11: classify_age doc comment fixed (Phase 21 consistency fix)
 echo ""
 echo "Test 11: lib/watchdog.sh doc comment corrected"


### PR DESCRIPTION
Fourth wiring PR. Adds verb-object drift check at Step 3A.5D. Like 3A.5C (dead-code), **advisory-only** — records commit trailer + JSON side-file, does not block the story.

## Signal shape

Unlike keyword-set Jaccard (Phase 7), the `(verb, object)` graph surfaces **action drift**: story says \"delete expired tokens\", code ships `filter_expired_tokens` — same object, different verb = implementation diverged from intent.

**Bidirectional:**
- `unmatched_story` → story asked for an action code didn't realize (missing feature)
- `unmatched_code` → code shipped actions story never requested (scope creep)

## Trailer form

```
Intent-Graph: jaccard=<0..1> | unmatched_story=<N> | unmatched_code=<M>
Intent-Graph: skipped | lib/intent-graph.sh absent
```

## Side-file

`.quantum-intent-graph.\$STORY_ID.json` — full `{matched, unmatched_story, unmatched_code, jaccard}` report.

## Scope

Runs **only** on files this story changed (`git diff --name-only BASE..HEAD`), not the whole repo. Keeps the check focused on the authored delta.

## Tests

`tests/test_orchestrator_wiring.sh`: 61 → 70 (+9 assertions).

## Test plan

- [x] Wiring assertions pass (70/70)
- [x] intent-graph lib tests still pass (34/34)
- [ ] Observe trailer in a live orchestrator run (follow-up)