### PR TITLE
Phase 37 — Wire trajectory into monitor-loop kill path (P3.5)

### DIFF
--- a/.omc/phase-37-evidence/test_orchestrator_wiring.log
+++ b/.omc/phase-37-evidence/test_orchestrator_wiring.log
@@ -1,0 +1,125 @@
+=== Phase 17 orchestrator-wiring prompt tests ===
+
+Test 1: lib/wave-boundary.sh wired at wave boundary
+  PASS: 3C.NEG1 section present
+  PASS: references wave-boundary.sh scan
+  PASS: routes HIGH severity to fix-story
+
+Test 2: lib/watchdog.sh wired in monitor loop
+  PASS: watchdog tick header
+  PASS: references watchdog.sh poll
+  PASS: status-probe action branch
+  PASS: kill-and-requeue action branch
+  PASS: mark-failed action branch
+  PASS: circuit-breaker bump
+  PASS: circuit-breaker check
+
+Test 3: lib/deep-review.sh wired at full-feature review
+  PASS: 4B.5 deep-review section
+  PASS: score-from-quantum call
+  PASS: tier lookup
+  PASS: dispatch-set call
+  PASS: context preparation
+  PASS: aggregate pipe
+  PASS: BLOCKS_MERGE handled
+  PASS: REQUEST_CHANGES handled
+  PASS: persists into quantum.reviews
+
+Test 4: lib/deslop.sh wired between review-pass and commit
+  PASS: 3A.5B deslop section
+  PASS: validate_scope gate
+  PASS: baseline snapshot before
+  PASS: compare_baseline call
+  PASS: rollback on regression
+  PASS: DESLOP_ROLLED_BACK signal
+  PASS: opt-out via story.deslop.skip
+
+Test 5: lib/commit-trailers.sh validation gate
+  PASS: commit-trailers reference
+  PASS: non-blocking warning
+
+Test 6: handoff.sh ownership is skill-side (orchestrator doesn't write)
+  PASS: orchestrator does NOT write handoffs directly (skills do)
+
+Test 7: all wirings carry a Phase-17 attribution comment
+  PASS: 5 Phase-17 attributions
+
+Test 8: deslop wiring uses DESLOP_AVAILABLE + BASE_SHA
+  PASS: DESLOP_AVAILABLE guard present
+  PASS: DESLOP_AVAILABLE file check
+  PASS: Fallback skip branch
+  PASS: scope loop uses BASE_SHA
+  PASS: rollback uses BASE_SHA
+  PASS: no active STORY_BASE_SHA refs in 3A.5B
+
+Test 9: RUNNER_EXTRA_FLAGS validated after pre_spawn()
+  PASS: RUNNER_EXTRA_FLAGS validation present
+  PASS: blocklist present (regex form varies)
+
+Test 10: runner_build_cmd rejects injection via RUNNER_EXTRA_FLAGS
+  PASS: injection payload rejected with clear error
+
+Test 10b: lib/reground.sh wired at Step 1C
+  PASS: reground source line present
+  PASS: REGROUND_AVAILABLE fallback flag
+  PASS: Step 1C header present
+  PASS: should_reground invoked
+  PASS: build_reground_context invoked
+  PASS: mark_grounded invoked
+  PASS: reground block path stable
+
+Test 10c: lib/tracecoder.sh wired at Step 3A.3
+  PASS: tracecoder source line present
+  PASS: TRACECODER_AVAILABLE fallback flag
+  PASS: observe primitive invoked
+  PASS: should_repair gate check
+  PASS: build_analysis_context call
+  PASS: opaque-failure bypass documented
+
+Test 10d: lib/dead-code.sh wired at Step 3A.5C
+  PASS: dead-code source line present
+  PASS: DEAD_CODE_AVAILABLE fallback flag
+  PASS: 3A.5C header present
+  PASS: find_post_commit_dead invoked
+  PASS: advisory trailer generated
+  PASS: clean-case trailer
+  PASS: side-file path for progress attach
+  PASS: non-blocking by design documented
+
+Test 10e: lib/intent-graph.sh wired at Step 3A.5D
+  PASS: intent-graph source line present
+  PASS: INTENT_GRAPH_AVAILABLE fallback flag
+  PASS: 3A.5D header present
+  PASS: extract_story_intents invoked
+  PASS: extract_code_intents invoked
+  PASS: match_intents invoked
+  PASS: intent trailer form
+  PASS: bidirectional drift documented
+  PASS: side-file path
+
+Test 10f: lib/skeleton.sh wired at 3A.1 + 3A.5E
+  PASS: skeleton source line present
+  PASS: SKELETON_AVAILABLE fallback flag
+  PASS: 3A.1 pre-skeleton preview step
+  PASS: pre-skeleton side-file
+  PASS: skeleton_text invoked in pre
+  PASS: 3A.5E header present
+  PASS: skeleton_diff invoked
+  PASS: trailer form has added/removed/changed
+  PASS: post-task side-file
+
+Test 10g: lib/trajectory.sh wired in Step 3B.3
+  PASS: trajectory source line present
+  PASS: TRAJECTORY_AVAILABLE fallback flag
+  PASS: Trajectory tick header
+  PASS: parse_trajectory invoked
+  PASS: should_early_kill gate
+  PASS: classify_trajectory for log category
+  PASS: agent log path convention documented
+  PASS: reap_agent integration (Phase 20)
+  PASS: failureLog phase=trajectory-$cls
+
+Test 11: lib/watchdog.sh doc comment corrected
+  PASS: watchdog threshold comment matches code (>30 min = timed-out)
+
+=== Results: 88/88 passed, 0 failed ===

--- a/.omc/phase-37-evidence/test_trajectory.log
+++ b/.omc/phase-37-evidence/test_trajectory.log
@@ -1,0 +1,49 @@
+=== Phase 24 trajectory-kill tests ===
+
+Test 1: parse on missing file
+  PASS: exists=false
+  PASS: total=0
+
+Test 2: parse counts tools
+  PASS: reads=5
+  PASS: greps=3
+  PASS: edits=2
+  PASS: writes=1
+  PASS: bashes=4
+  PASS: total=15
+  PASS: read_pct=53
+  PASS: edit_pct=20
+
+Test 3: productive trajectory
+  PASS: classify productive
+  PASS: productive -> no kill (exit 1)
+
+Test 4: searching trajectory
+  PASS: classify searching (below thrash min)
+  PASS: searching -> no kill
+
+Test 5: thrashing trajectory
+  PASS: classify thrashing
+  PASS: thrashing -> kill (exit 0)
+
+Test 6: stuck trajectory
+  PASS: classify stuck
+  PASS: stuck -> kill (exit 0)
+
+Test 7: env-var overrides take effect
+  PASS: default: searching
+  PASS: override THRASH_MIN=5: thrashing
+
+Test 8: empty file handling
+  PASS: empty file total=0
+  PASS: empty file classify=productive (no signal)
+
+Test 9: CLI subcommands
+  PASS: CLI parse total=26
+  PASS: CLI classify thrashing
+  PASS: CLI kill exits 0 for thrashing
+
+Test 10: classify reads stdin
+  PASS: stdin classify productive
+
+=== Results: 26/26 passed, 0 failed ===

--- a/agents/orchestrator.md
+++ b/agents/orchestrator.md
@@ -55,6 +55,10 @@ source "$REPO_ROOT/lib/intent-graph.sh" 2>/dev/null || INTENT_GRAPH_AVAILABLE=fa
 SKELETON_AVAILABLE=true
 source "$REPO_ROOT/lib/skeleton.sh" 2>/dev/null || SKELETON_AVAILABLE=false
 
+# Source trajectory module (Phase 24 / P3.5 wiring, graceful fallback)
+TRAJECTORY_AVAILABLE=true
+source "$REPO_ROOT/lib/trajectory.sh" 2>/dev/null || TRAJECTORY_AVAILABLE=false
+
 # Run pre-flight checks (idempotent within 1 hour)
 if [[ "$INIT_GUARD_AVAILABLE" != "false" ]]; then
   run_preflight "$REPO_ROOT" "$JSON_PATH"
@@ -755,6 +759,48 @@ for row in $(printf '%s' "$POLL" | jq -rc '.[]'); do
   esac
 done
 ```
+
+**Trajectory tick (Phase 24 / P3.5 wiring):** a complementary signal to the watchdog. Watchdog fires on wall-clock staleness; trajectory fires on work-shape staleness — agent making tool calls but no edits/writes (thrashing) or many calls with zero productive outputs (stuck). Both checks run per cycle; either can trigger a kill.
+
+```bash
+# Per-story agent-output path convention: $REPO_ROOT/.ql-wt/$sid/agent.log
+# Spawners must tee stdout to this path for trajectory to see work shape.
+# No-op if the file doesn't exist (e.g. sequential run, or older spawn).
+if [[ "$TRAJECTORY_AVAILABLE" != "false" ]]; then
+  for sid in $(jq -r '.stories[] | select(.status == "in_progress") | .id' "$JSON_PATH"); do
+    LOG="$REPO_ROOT/.ql-wt/$sid/agent.log"
+    [[ -f "$LOG" ]] || continue
+    TRAJ=$(parse_trajectory "$LOG")
+    if printf '%s' "$TRAJ" | should_early_kill; then
+      CLS=$(printf '%s' "$TRAJ" | classify_trajectory)
+      echo "[TRAJECTORY] $sid classified as $CLS — early kill" >&2
+      # Kill via reap_agent (Phase 20 orphan reaper) or fall back to
+      # kill_agent_process, same contract as watchdog.
+      if declare -f reap_agent > /dev/null 2>&1; then
+        reap_agent "$sid" 2>/dev/null
+      else
+        kill_agent_process "$sid" 2>/dev/null
+      fi
+      jq --arg sid "$sid" --arg cls "$CLS" --arg ts "$(date -u +%FT%TZ)" '
+        (.stories[] | select(.id == $sid) | .status) = "failed"
+        | (.stories[] | select(.id == $sid) | .retries.failureLog) += [{
+            "phase": ("trajectory-" + $cls),
+            "timestamp": $ts,
+            "error": ("trajectory classified as " + $cls + " - early kill")
+          }]
+      ' "$JSON_PATH" > "$JSON_PATH.tmp" && mv "$JSON_PATH.tmp" "$JSON_PATH"
+    fi
+  done
+fi
+```
+
+Trajectory thresholds are env-overrideable:
+- `TRAJECTORY_THRASH_MIN_CALLS=20` — min total calls before a thrash verdict
+- `TRAJECTORY_STUCK_MIN_CALLS=30` — min calls + zero edits → stuck
+- `TRAJECTORY_THRASH_READ_RATIO=70` — read/grep % over which thrashing is flagged
+- `TRAJECTORY_THRASH_EDIT_RATIO=5` — edit % under which thrashing is flagged
+
+Setting `TRAJECTORY_THRASH_MIN_CALLS=999` effectively disables the check without removing the wiring.
 
 On each repeated same-error failure for a story, bump the circuit-breaker counter:
 

--- a/tests/test_orchestrator_wiring.sh
+++ b/tests/test_orchestrator_wiring.sh
@@ -245,6 +245,19 @@ check "skeleton_diff invoked" 'skeleton_diff "$PRE_TMP" "$POST_TMP"'
 check "trailer form has added/removed/changed" "Skeleton: added="
 check "post-task side-file" ".quantum-skeleton-diff.\$STORY_ID.json"
 
+# Test 10g: Trajectory wired into monitor loop (Phase 24 / P3.5)
+echo ""
+echo "Test 10g: lib/trajectory.sh wired in Step 3B.3"
+check "trajectory source line present" 'source "$REPO_ROOT/lib/trajectory.sh"'
+check "TRAJECTORY_AVAILABLE fallback flag" "TRAJECTORY_AVAILABLE=true"
+check "Trajectory tick header" "Trajectory tick"
+check "parse_trajectory invoked" 'parse_trajectory "$LOG"'
+check "should_early_kill gate" "| should_early_kill"
+check "classify_trajectory for log category" "| classify_trajectory"
+check "agent log path convention documented" ".ql-wt/\$sid/agent.log"
+check "reap_agent integration (Phase 20)" "reap_agent"
+check "failureLog phase=trajectory-\$cls" '"trajectory-" + $cls'
+
 # Test 11: classify_age doc comment fixed (Phase 21 consistency fix)
 echo ""
 echo "Test 11: lib/watchdog.sh doc comment corrected"


### PR DESCRIPTION
Sixth wiring PR. Adds a **trajectory tick** alongside the existing watchdog tick in Step 3B.3. Two complementary signals:

| Signal | Dimension | Triggers |
|--------|-----------|----------|
| **Watchdog** | wall-clock staleness | agent running N+ min |
| **Trajectory** | work-shape staleness | thrashing (reads no edits) or stuck (zero productive outputs) |

Either can trigger a kill. Reuses `reap_agent` (Phase 20) with fallback to `kill_agent_process`.

## Failure-log shape

```
phase: "trajectory-thrashing"  OR  "trajectory-stuck"
timestamp: ISO 8601
error: "trajectory classified as <cls> - early kill"
```

Retry path can inspect `phase` to decide whether to re-spawn with a different prompt shape (e.g., \"narrow scope further\").

## Log-path convention

`\$REPO_ROOT/.ql-wt/\$sid/agent.log` — spawners tee agent stdout to this path. If the file doesn't exist (sequential run, older spawn harness), the check is a no-op — fail-open.

## Thresholds (env-overrideable)

| Var | Default |
|-----|--------:|
| `TRAJECTORY_THRASH_MIN_CALLS` | 20 |
| `TRAJECTORY_STUCK_MIN_CALLS` | 30 |
| `TRAJECTORY_THRASH_READ_RATIO` | 70 |
| `TRAJECTORY_THRASH_EDIT_RATIO` | 5 |

Setting `THRASH_MIN_CALLS=999` effectively disables the check without removing the wiring.

## Tests

`tests/test_orchestrator_wiring.sh`: 79 → 88 (+9 assertions).

## Test plan

- [x] Wiring assertions pass (88/88)
- [x] trajectory lib tests still pass (26/26)
- [ ] Spawner harness updated to tee agent stdout (follow-up PR)