### PR TITLE
Phase 38 — Wire conflict-grade into merge-strategy routing (P3.2)

### DIFF
--- a/.omc/phase-38-evidence/test_conflict_grade.log
+++ b/.omc/phase-38-evidence/test_conflict_grade.log
@@ -1,0 +1,62 @@
+=== Phase 26 conflict-grade tests ===
+
+Test 1: whitespace-only → grade 1
+  PASS: single-ws diff
+  PASS: bracket-indent diff
+
+Test 2: comment-only → grade 2
+  PASS: line comment change
+  PASS: python-style comment change
+  PASS: block comment change
+
+Test 3: single-token rename → grade 2
+  PASS: single identifier rename
+
+Test 4: small body edit → grade 3
+  PASS: 3-line small body edit
+
+Test 5: moderate overlap → grade 4
+  PASS: 7-line overlap
+
+Test 6: structural reorg → grade 5
+  PASS: 2-function reorder
+  PASS: 2-def reorg (python)
+
+Test 7: split_conflict_hunks single
+  PASS: 1 conflict parsed
+  PASS: ours buffer captured
+  PASS: theirs buffer captured
+  PASS: start_line=2
+  PASS: end_line=7
+
+Test 8: split_conflict_hunks multiple
+  PASS: 2 conflicts parsed
+
+Test 9: grade_file end-to-end
+  PASS: 2 hunks graded
+  PASS: max_grade = 5 (structural)
+  PASS: first hunk grade 2 (comment)
+  PASS: second hunk grade 5 (structural)
+
+Test 10: grade_file clean file
+  PASS: clean file max_grade=0
+  PASS: clean file 0 hunks
+
+Test 11: routing_recommendation
+  PASS: grade 0 → none
+  PASS: grade 1 → auto-git
+  PASS: grade 2 → auto-git
+  PASS: grade 3 → diff3
+  PASS: grade 4 → llm-merge
+  PASS: grade 5 → escalate
+
+Test 12a: string literals not truncated at // or /*
+  PASS: identical URL lines → grade 1 (whitespace equiv)
+  PASS: URL preserved, comment-only change → grade 2
+  PASS: URL content changed (single-token) → grade 2
+
+Test 12: CLI subcommands
+  PASS: CLI grade single-word rename
+  PASS: CLI route 4 → llm-merge
+
+=== Results: 33/33 passed, 0 failed ===

--- a/.omc/phase-38-evidence/test_merge_strategy.log
+++ b/.omc/phase-38-evidence/test_merge_strategy.log
@@ -1,0 +1,151 @@
+=== T-036: Test classify_conflict for all rule categories ===
+--- Test 1: dependency_manifest pattern match ---
+  PASS: package.json -> dependency_manifest:ours:install
+--- Test 2: dependency_manifest pattern (package-lock.json) ---
+  PASS: package-lock.json -> dependency_manifest:ours:install
+--- Test 3: dependency_manifest pattern (Cargo.toml) ---
+  PASS: Cargo.toml -> dependency_manifest:ours:install
+--- Test 4: dependency_manifest pattern (pyproject.toml) ---
+  PASS: pyproject.toml -> dependency_manifest:ours:install
+--- Test 5: dependency_manifest pattern (go.mod) ---
+  PASS: go.mod -> dependency_manifest:ours:install
+--- Test 6: barrel_export pattern match ---
+  PASS: src/parsers/index.ts -> barrel_export:regenerate:
+--- Test 7: barrel_export pattern (__init__.py) ---
+  PASS: src/models/__init__.py -> barrel_export:regenerate:
+--- Test 8: barrel_export pattern (mod.rs) ---
+  PASS: src/handlers/mod.rs -> barrel_export:regenerate:
+--- Test 9: barrel_export pattern (index.js) ---
+  PASS: lib/utils/index.js -> barrel_export:regenerate:
+--- Test 10: new_story_file (file not on HEAD) ---
+  PASS: new file not on HEAD -> new_story_file:theirs:
+--- Test 11: shared_infrastructure (file in filesChanged) ---
+  PASS: file in filesChanged (on HEAD) -> shared_infrastructure:ours:
+--- Test 12: contract_stub (file in materializedContracts) ---
+  PASS: file in materializedContracts -> contract_stub:theirs:
+--- Test 13: no match -> escalate ---
+  PASS: no match -> unknown:escalate:
+--- Test 14: rule ordering - first match wins ---
+  PASS: first match wins: package.json -> dependency_manifest (not new_story_file)
+--- Test 15: rule ordering with reordered rules ---
+  PASS: first rule wins when both match
+--- Test 16: empty rules -> defaultAction ---
+  PASS: empty rules -> unknown:escalate:
+--- Test 17: custom defaultAction ---
+  PASS: custom defaultAction -> unknown:ours:
+--- Test 18: basename matching for package.json ---
+  PASS: basename package.json matches
+--- Test 19: pattern + condition - pattern checked first ---
+  PASS: pattern matches before condition checked
+--- Test 20: multiple files in filesChanged ---
+  PASS: README.md in multi-file filesChanged -> shared_infrastructure:ours:
+--- Test 21: multiple files in materializedContracts ---
+  PASS: README.md in materializedContracts -> contract_stub:theirs:
+--- Test 22: classify_conflict error on empty file_path ---
+  PASS: empty file_path returns error
+--- Test 23: classify_conflict error on empty context_file ---
+  PASS: empty context_file returns error
+--- Test 24: classify_conflict error on nonexistent context_file ---
+  PASS: nonexistent context_file returns error
+
+=== T-036 Results: 24/24 passed, 0 failed ===
+
+=== T-037: Test classify_and_merge with git scenarios ===
+--- Test 25: Clean merge - no conflicts ---
+  PASS: clean merge returns 0
+  PASS: merge commit created (commit count: 3)
+  PASS: clean merge logs timing
+--- Test 26: All-resolved merge with ours strategy ---
+  PASS: all-resolved merge returns 0
+  PASS: merge log mentions MERGE-STRATEGY
+  PASS: package.json kept ours version
+  PASS: config.json kept ours version
+--- Test 27: Escalation on unknown file conflict ---
+  PASS: escalation returns 1
+  PASS: CONFLICT line in output
+  PASS: CONFLICT mentions file.txt
+  PASS: merge aborted - main content preserved
+--- Test 28: Fallback - no mergeStrategy -> all escalate ---
+  PASS: no mergeStrategy -> escalation returns 1
+  PASS: fallback escalates with CONFLICT
+--- Test 29: Error handling for missing arguments ---
+  PASS: missing branch returns 1
+  PASS: missing repo_root returns 1
+  PASS: missing json_path returns 1
+--- Test 30: Mixed - some resolved, one escalates ---
+  PASS: mixed conflicts with escalation returns 1
+  PASS: file.txt in CONFLICT output
+  PASS: merge aborted, main content preserved
+--- Test 31: get_merge_context reads correctly ---
+  PASS: get_merge_context returns 0
+  PASS: context has defaultAction
+  PASS: context has filesChanged
+  PASS: context has materializedContracts
+  PASS: context has rules
+--- Test 32: get_merge_context error on missing file ---
+  PASS: get_merge_context on missing file returns 1
+--- Test 33: get_merge_context error on empty path ---
+  PASS: get_merge_context on empty path returns 1
+--- Test 34: get_merge_context with no mergeStrategy ---
+  PASS: get_merge_context returns 0 even without mergeStrategy
+  PASS: defaultAction is escalate
+  PASS: rules is empty array
+=== T-001: quantum.json backup/restore and stash exclusion ===
+--- Test 35: quantum.json dirty content preserved when branch modifies it ---
+  PASS: quantum.json has orchestrator content after merge
+  PASS: quantum.json does NOT have feature branch content
+--- Test 36: backup file cleaned up after merge ---
+  PASS: quantum.json.merge-bak cleaned up
+--- Test 37: quantum.json restored after merge abort ---
+  PASS: escalation returns 1
+  PASS: quantum.json restored after abort
+  PASS: quantum.json does NOT have feature branch content after abort
+  PASS: backup cleaned up after abort
+
+=== T-001 Results so far: 60/60 passed, 0 failed ===
+
+=== T-002: Semantic merge delegation in resolve_conflict ===
+--- Test 38: MERGE_SEMANTIC_AVAILABLE variable exists ---
+  PASS: MERGE_SEMANTIC_AVAILABLE is defined
+--- Test 39: Semantic merge delegates for ours conflict ---
+  PASS: MERGE_SEMANTIC_AVAILABLE true with mock
+Auto-merging package.json
+CONFLICT (content): Merge conflict in package.json
+Automatic merge failed; fix conflicts and then commit the result.
+  PASS: package.json is in conflict state
+  PASS: resolve_conflict with semantic merge succeeds
+  PASS: semantic merge result used instead of ours
+--- Test 40: Fallback to ours when semantic merge fails ---
+Auto-merging package.json
+CONFLICT (content): Merge conflict in package.json
+Automatic merge failed; fix conflicts and then commit the result.
+  PASS: resolve_conflict falls through to ours on semantic failure
+  PASS: ours version used after semantic fallback
+  PASS: semantic result NOT present
+--- Test 41: Theirs action delegates to semantic merge ---
+Auto-merging package.json
+CONFLICT (content): Merge conflict in package.json
+Automatic merge failed; fix conflicts and then commit the result.
+  PASS: theirs with semantic merge succeeds
+  PASS: semantic merge result used for theirs case
+--- Test 42: No semantic merge when unavailable ---
+  PASS: MERGE_SEMANTIC_AVAILABLE false without module
+Auto-merging package.json
+CONFLICT (content): Merge conflict in package.json
+Automatic merge failed; fix conflicts and then commit the result.
+  PASS: ours without semantic merge succeeds
+  PASS: ours version used when semantic unavailable
+--- Test 43: can_semantic_merge returns 1 - skip semantic ---
+Auto-merging package.json
+CONFLICT (content): Merge conflict in package.json
+Automatic merge failed; fix conflicts and then commit the result.
+  PASS: ours when can_semantic_merge returns 1
+  PASS: ours version used when can_semantic_merge fails
+  PASS: semantic_merge not called
+
+=== T-002 Results so far: 76/76 passed, 0 failed ===
+
+
+==========================================
+=== Final Results: 76/76 passed, 0 failed ===
+==========================================

--- a/.omc/phase-38-evidence/test_orchestrator_wiring.log
+++ b/.omc/phase-38-evidence/test_orchestrator_wiring.log
@@ -1,0 +1,132 @@
+=== Phase 17 orchestrator-wiring prompt tests ===
+
+Test 1: lib/wave-boundary.sh wired at wave boundary
+  PASS: 3C.NEG1 section present
+  PASS: references wave-boundary.sh scan
+  PASS: routes HIGH severity to fix-story
+
+Test 2: lib/watchdog.sh wired in monitor loop
+  PASS: watchdog tick header
+  PASS: references watchdog.sh poll
+  PASS: status-probe action branch
+  PASS: kill-and-requeue action branch
+  PASS: mark-failed action branch
+  PASS: circuit-breaker bump
+  PASS: circuit-breaker check
+
+Test 3: lib/deep-review.sh wired at full-feature review
+  PASS: 4B.5 deep-review section
+  PASS: score-from-quantum call
+  PASS: tier lookup
+  PASS: dispatch-set call
+  PASS: context preparation
+  PASS: aggregate pipe
+  PASS: BLOCKS_MERGE handled
+  PASS: REQUEST_CHANGES handled
+  PASS: persists into quantum.reviews
+
+Test 4: lib/deslop.sh wired between review-pass and commit
+  PASS: 3A.5B deslop section
+  PASS: validate_scope gate
+  PASS: baseline snapshot before
+  PASS: compare_baseline call
+  PASS: rollback on regression
+  PASS: DESLOP_ROLLED_BACK signal
+  PASS: opt-out via story.deslop.skip
+
+Test 5: lib/commit-trailers.sh validation gate
+  PASS: commit-trailers reference
+  PASS: non-blocking warning
+
+Test 6: handoff.sh ownership is skill-side (orchestrator doesn't write)
+  PASS: orchestrator does NOT write handoffs directly (skills do)
+
+Test 7: all wirings carry a Phase-17 attribution comment
+  PASS: 5 Phase-17 attributions
+
+Test 8: deslop wiring uses DESLOP_AVAILABLE + BASE_SHA
+  PASS: DESLOP_AVAILABLE guard present
+  PASS: DESLOP_AVAILABLE file check
+  PASS: Fallback skip branch
+  PASS: scope loop uses BASE_SHA
+  PASS: rollback uses BASE_SHA
+  PASS: no active STORY_BASE_SHA refs in 3A.5B
+
+Test 9: RUNNER_EXTRA_FLAGS validated after pre_spawn()
+  PASS: RUNNER_EXTRA_FLAGS validation present
+  PASS: blocklist present (regex form varies)
+
+Test 10: runner_build_cmd rejects injection via RUNNER_EXTRA_FLAGS
+  PASS: injection payload rejected with clear error
+
+Test 10b: lib/reground.sh wired at Step 1C
+  PASS: reground source line present
+  PASS: REGROUND_AVAILABLE fallback flag
+  PASS: Step 1C header present
+  PASS: should_reground invoked
+  PASS: build_reground_context invoked
+  PASS: mark_grounded invoked
+  PASS: reground block path stable
+
+Test 10c: lib/tracecoder.sh wired at Step 3A.3
+  PASS: tracecoder source line present
+  PASS: TRACECODER_AVAILABLE fallback flag
+  PASS: observe primitive invoked
+  PASS: should_repair gate check
+  PASS: build_analysis_context call
+  PASS: opaque-failure bypass documented
+
+Test 10d: lib/dead-code.sh wired at Step 3A.5C
+  PASS: dead-code source line present
+  PASS: DEAD_CODE_AVAILABLE fallback flag
+  PASS: 3A.5C header present
+  PASS: find_post_commit_dead invoked
+  PASS: advisory trailer generated
+  PASS: clean-case trailer
+  PASS: side-file path for progress attach
+  PASS: non-blocking by design documented
+
+Test 10e: lib/intent-graph.sh wired at Step 3A.5D
+  PASS: intent-graph source line present
+  PASS: INTENT_GRAPH_AVAILABLE fallback flag
+  PASS: 3A.5D header present
+  PASS: extract_story_intents invoked
+  PASS: extract_code_intents invoked
+  PASS: match_intents invoked
+  PASS: intent trailer form
+  PASS: bidirectional drift documented
+  PASS: side-file path
+
+Test 10f: lib/skeleton.sh wired at 3A.1 + 3A.5E
+  PASS: skeleton source line present
+  PASS: SKELETON_AVAILABLE fallback flag
+  PASS: 3A.1 pre-skeleton preview step
+  PASS: pre-skeleton side-file
+  PASS: skeleton_text invoked in pre
+  PASS: 3A.5E header present
+  PASS: skeleton_diff invoked
+  PASS: trailer form has added/removed/changed
+  PASS: post-task side-file
+
+Test 10g: lib/trajectory.sh wired in Step 3B.3
+  PASS: trajectory source line present
+  PASS: TRAJECTORY_AVAILABLE fallback flag
+  PASS: Trajectory tick header
+  PASS: parse_trajectory invoked
+  PASS: should_early_kill gate
+  PASS: classify_trajectory for log category
+  PASS: agent log path convention documented
+  PASS: reap_agent integration (Phase 20)
+  PASS: failureLog phase=trajectory-$cls
+
+Test 10h: lib/conflict-grade.sh wired in merge-strategy.sh
+  PASS: conflict-grade source line
+  PASS: CONFLICT_GRADE_AVAILABLE fallback
+  PASS: grade_file invoked per conflict
+  PASS: routing_recommendation logged
+  PASS: grade 5 short-circuit to escalate
+
+Test 11: lib/watchdog.sh doc comment corrected
+  PASS: watchdog threshold comment matches code (>30 min = timed-out)
+
+=== Results: 93/93 passed, 0 failed ===

--- a/lib/merge-strategy.sh
+++ b/lib/merge-strategy.sh
@@ -25,6 +25,14 @@ source "$MERGE_STRATEGY_LIB_DIR/dep-manifest.sh" 2>/dev/null || DEP_MANIFEST_AVA
 MERGE_SEMANTIC_AVAILABLE=true
 source "$MERGE_STRATEGY_LIB_DIR/merge-semantic.sh" 2>/dev/null || MERGE_SEMANTIC_AVAILABLE=false
 
+# Phase 38 / P3.2 wiring: conflict-grade for per-hunk severity routing.
+# Grade 1 whitespace / 2 rename/comment -> auto-git
+# Grade 3 small-body-edit                -> diff3 (three-way)
+# Grade 4 moderate-overlap                -> llm-merge (semantic)
+# Grade 5 structural reorg                -> escalate (operator)
+CONFLICT_GRADE_AVAILABLE=true
+source "$MERGE_STRATEGY_LIB_DIR/conflict-grade.sh" 2>/dev/null || CONFLICT_GRADE_AVAILABLE=false
+
 # get_merge_context(json_path)
 # Reads quantum.json and extracts merge-related context into a temp file.
 # Extracts: materializedContracts, progress[].filesChanged, mergeStrategy.rules, defaultAction.
@@ -505,6 +513,24 @@ classify_and_merge() {
   while IFS= read -r file; do
     [[ -z "$file" ]] && continue
     total_conflicts=$((total_conflicts + 1))
+
+    # Phase 38 / P3.2 wiring: per-hunk severity grading BEFORE category
+    # classification. Grade 5 (structural reorganization) is unsafe to
+    # auto-resolve regardless of file kind — short-circuit to escalation.
+    # Lower grades proceed through the normal category flow.
+    if [[ "$CONFLICT_GRADE_AVAILABLE" != "false" ]]; then
+      local cg_report cg_max
+      cg_report=$(cd "$repo_root" && grade_file "$file" 2>/dev/null || printf '{"max_grade":0,"hunks":[]}')
+      cg_max=$(printf '%s' "$cg_report" | jq -r '.max_grade // 0')
+      printf "[CONFLICT-GRADE] %s max_grade=%s (%s)\n" \
+        "$file" "$cg_max" "$(routing_recommendation "$cg_max" 2>/dev/null || printf 'unknown')" >&2
+      if (( cg_max >= 5 )); then
+        printf "[CONFLICT-GRADE] %s grade 5 (structural) — escalating without category attempt\n" "$file" >&2
+        escalated=true
+        escalated_files="${escalated_files}${file}\n"
+        continue
+      fi
+    fi
 
     # Classify the conflict
     local classification

--- a/tests/test_orchestrator_wiring.sh
+++ b/tests/test_orchestrator_wiring.sh
@@ -258,6 +258,26 @@ check "agent log path convention documented" ".ql-wt/\$sid/agent.log"
 check "reap_agent integration (Phase 20)" "reap_agent"
 check "failureLog phase=trajectory-\$cls" '"trajectory-" + $cls'
 
+# Test 10h: Conflict-grade wired into merge-strategy (Phase 38 / P3.2)
+echo ""
+echo "Test 10h: lib/conflict-grade.sh wired in merge-strategy.sh"
+MERGE_STRATEGY="$REPO_ROOT/lib/merge-strategy.sh"
+check_ms() {
+  local name="$1" needle="$2"
+  TOTAL=$((TOTAL + 1))
+  if grep -qF -- "$needle" "$MERGE_STRATEGY"; then
+    echo "  PASS: $name"; PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $name — needle [$needle] not in merge-strategy.sh"
+    FAIL=$((FAIL + 1))
+  fi
+}
+check_ms "conflict-grade source line" 'source "$MERGE_STRATEGY_LIB_DIR/conflict-grade.sh"'
+check_ms "CONFLICT_GRADE_AVAILABLE fallback" "CONFLICT_GRADE_AVAILABLE=true"
+check_ms "grade_file invoked per conflict" "grade_file \"\$file\""
+check_ms "routing_recommendation logged" "routing_recommendation \"\$cg_max\""
+check_ms "grade 5 short-circuit to escalate" "grade 5 (structural)"
+
 # Test 11: classify_age doc comment fixed (Phase 21 consistency fix)
 echo ""
 echo "Test 11: lib/watchdog.sh doc comment corrected"


### PR DESCRIPTION
Seventh wiring PR. `lib/conflict-grade.sh` from #36 now consulted per conflicted file **inside** `classify_and_merge`, **before** the category-based `classify_conflict` step.

## Two effects

**1. Grade 5 short-circuit.** Structural reorganization (≥2 function boundaries on either side) escalates without attempting category resolution. Category-based merge (barrel / dep-manifest / generated-file / etc.) is unsafe for structural conflicts regardless of file kind — auto-resolving would be a correctness hazard.

**2. Grades 1-4 proceed normally**, but the grade and its routing recommendation are **logged alongside** for reviewer visibility. Informational; the category flow retains the final action choice.

## Orthogonal dimensions

| Signal | Routes by | Example |
|--------|-----------|---------|
| `classify_conflict` | **file kind** | barrel-export / dep-manifest / generated-file |
| `conflict-grade` | **conflict shape** | whitespace / rename / small-edit / moderate / structural |

Both signals now appear in merge decisions. Grade 5 being pre-emptive keeps structural surprises from slipping through as auto-resolved.

## Log form

```
[CONFLICT-GRADE] <file> max_grade=<N> (<routing>)
[CONFLICT-GRADE] <file> grade 5 (structural) — escalating...
```

where `<routing>` ∈ `{none | auto-git | diff3 | llm-merge | escalate}`.

## Graceful fallback

`CONFLICT_GRADE_AVAILABLE=false` if `lib/conflict-grade.sh` missing → `classify_and_merge` reverts to pre-Phase-38 behavior.

## Tests

`tests/test_orchestrator_wiring.sh`: 88 → 93 (+5 assertions). merge-strategy (76/76) and conflict-grade (33/33) unchanged.

## Test plan

- [x] Wiring assertions pass (93/93)
- [x] merge-strategy tests still pass (76/76)
- [x] conflict-grade tests still pass (33/33)
- [ ] Observe `[CONFLICT-GRADE]` log in a live merge (follow-up)