### PR TITLE
fix: test_typecheck_gate 12 failures — allowlist extension for tests

### DIFF
--- a/.omc/phase-42-evidence/test_monitor_merge.log
+++ b/.omc/phase-42-evidence/test_monitor_merge.log
@@ -1,0 +1,28 @@
+=== Test 1: detect_signal finds STORY_PASSED ===
+  PASS: Detects STORY_PASSED
+=== Test 2: detect_signal finds STORY_FAILED ===
+  PASS: Detects STORY_FAILED
+=== Test 3: detect_signal returns empty for no signal ===
+  PASS: No signal returns empty
+=== Test 4: detect_signal returns empty for nonexistent file ===
+  PASS: Nonexistent file returns empty
+=== Test 5: check_agent_status detects completed process with PASSED ===
+  PASS: Completed agent returns STORY_PASSED
+=== Test 6: check_agent_status returns RUNNING for active process ===
+  PASS: Running agent returns RUNNING
+=== Test 7: check_agent_status detects crash (no signal, process done) ===
+  PASS: Crashed agent returns CRASH
+=== Test 8: merge_worktree_branch merges commits into feature branch ===
+  PASS: merge_worktree_branch exits 0
+  PASS: Merged file exists on feature branch
+=== Test 9: merge_worktree_branch detects merge conflict ===
+CONFLICT: conflict.txt
+  PASS: merge_worktree_branch returns 1 on conflict
+  PASS: Working tree clean after conflict abort
+=== Test 10: Input validation ===
+  PASS: detect_signal empty file returns empty
+  PASS: check_agent_status empty PID returns error
+  PASS: merge_worktree_branch empty repo returns error
+  PASS: merge_worktree_branch empty branch returns error
+
+=== Results: 15/15 passed, 0 failed ===

--- a/.omc/phase-42-evidence/test_typecheck_gate.log
+++ b/.omc/phase-42-evidence/test_typecheck_gate.log
@@ -1,0 +1,51 @@
+=== Test 1: No typecheckCommand, no language files -> skip, return 0 ===
+  PASS: No config skip returns 0
+  PASS: Logs skip message
+=== Test 2: Explicit typecheckCommand in JSON -> uses it ===
+  PASS: Explicit command returns 0
+=== Test 3: Auto-detect TypeScript (tsconfig.json) -> tsc --noEmit ===
+  PASS: Auto-detect TS returns 0
+  PASS: Logs auto-detect
+=== Test 4: Command not on allowlist -> rejected, returns 1 ===
+  PASS: Non-allowlisted command returns 1
+  PASS: Logs rejection
+=== Test 5: Baseline not set -> initialize baseline, return 0 ===
+  PASS: Baseline init returns 0
+  PASS: Logs baseline initialized
+  PASS: Baseline value written to JSON
+=== Test 6: Error count <= baseline -> return 0 ===
+  PASS: Errors <= baseline returns 0
+  PASS: Logs PASS
+=== Test 7: Error count > baseline -> revert merge, return 1 ===
+  PASS: Errors > baseline returns 1
+  PASS: Logs FAIL and revert
+  PASS: Revert commit created (HEAD changed)
+=== Test 8: Timeout behavior (command that sleeps > timeout) ===
+  PASS: Timeout returns 0 (graceful)
+  PASS: Logs timeout warning
+=== Test 9: Multiple auto-detect options (tsconfig.json takes priority over go.mod) ===
+  PASS: tsconfig.json priority returns 0
+  PASS: Uses tsc (TypeScript detected)
+=== Test 10: Typecheck with warnings but zero errors passes ===
+  PASS: Warnings-only returns 0
+  PASS: Logs PASS for zero errors
+=== Test 11: Injection — typecheckCommand with semicolon rejected ===
+  PASS: Semicolon injection returns 1
+  PASS: Logs rejection for semicolon
+=== Test 12: Injection — typecheckCommand with pipe rejected ===
+  PASS: Pipe injection returns 1
+  PASS: Logs rejection for pipe
+=== Test 13: Injection — typecheckCommand with redirect > rejected ===
+  PASS: Redirect injection returns 1
+  PASS: Logs rejection for redirect
+=== Test 14: Injection — typecheckCommand with backtick rejected ===
+  PASS: Backtick injection returns 1
+  PASS: Logs rejection for backtick
+=== Test 15: Injection — typecheckCommand with embedded newline rejected ===
+  PASS: Newline injection returns 1
+  PASS: Logs rejection for newline
+=== Test 16: Allowlist — tsc --noEmit accepted ===
+  PASS: Allowed tsc --noEmit returns 0
+  PASS: Logs running for tsc
+
+=== Results: 33/33 passed, 0 failed ===

--- a/lib/monitor.sh
+++ b/lib/monitor.sh
@@ -299,8 +299,20 @@ post_merge_typecheck() {
     return 0
   fi
 
-  # Allowlist of known-safe typecheck command prefixes
+  # Allowlist of known-safe typecheck command prefixes. Tests may extend
+  # via TYPECHECK_EXTRA_ALLOWED_PREFIXES (colon-separated) — env-var
+  # tunable, same pattern as TYPECHECK_TIMEOUT. Env var is not readable
+  # by the quantum.json it guards, so this cannot be weaponized by a
+  # malicious repo.
   local -a ALLOWED_TYPECHECK_PREFIXES=("tsc" "pyright" "mypy" "go vet" "go build" "npx tsc" "pnpm tsc" "yarn tsc" "pnpm exec tsc" "npx pyright")
+  if [[ -n "${TYPECHECK_EXTRA_ALLOWED_PREFIXES:-}" ]]; then
+    local IFS=':'
+    local extra
+    for extra in $TYPECHECK_EXTRA_ALLOWED_PREFIXES; do
+      [[ -n "$extra" ]] && ALLOWED_TYPECHECK_PREFIXES+=("$extra")
+    done
+    unset IFS
+  fi
 
   local allowed=false
   for prefix in "${ALLOWED_TYPECHECK_PREFIXES[@]}"; do

--- a/tests/test_typecheck_gate.sh
+++ b/tests/test_typecheck_gate.sh
@@ -35,6 +35,11 @@ if [[ ! -f "$LIB_DIR/monitor.sh" ]]; then
 fi
 source "$LIB_DIR/monitor.sh"
 
+# Tests use `bash $TEST_REPO/fake_typecheck.sh` as an explicit typecheck
+# command; extend the allowlist so the security gate lets it through.
+# See lib/monitor.sh:303 for the production allowlist.
+export TYPECHECK_EXTRA_ALLOWED_PREFIXES="bash"
+
 assert_eq() {
   local test_name="$1" expected="$2" actual="$3"
   TOTAL=$((TOTAL + 1))


### PR DESCRIPTION
Pre-existing failure (12 of 33 tests) — confirmed before this session and re-surfaced during the final-review sweep.

## Root cause

- `lib/monitor.sh:303` added a security allowlist of known-safe typecheck command prefixes (`tsc`, `pyright`, `mypy`, `go vet`, etc.).
- `tests/test_typecheck_gate.sh` predates that allowlist and supplies `typecheckCommand` as `bash \$TEST_REPO/fake_typecheck.sh` — fails the prefix check and gets rejected before execution.

The allowlist gate is a real security feature (prevents arbitrary command execution via malicious `quantum.json`). Don't weaken it.

## Fix

Add `TYPECHECK_EXTRA_ALLOWED_PREFIXES` env var (colon-separated) that extends the allowlist at runtime.

**Why this is safe**: env vars are not readable from the `quantum.json` being gated — a malicious repo can't weaponize this. Only settable by the shell that invokes the orchestrator.

Same tunable pattern as `TYPECHECK_TIMEOUT` (already used in tests/).

Test sets: `export TYPECHECK_EXTRA_ALLOWED_PREFIXES=\"bash\"`

## Result

| Suite | Before | After |
|-------|:-:|:-:|
| `test_typecheck_gate` | 21/33 | **33/33** |
| `test_monitor_merge` | 15/15 | 15/15 |
| `test_monitor_merge_delegation` | 32/32 | 32/32 |
| `test_orchestrator_wiring` | 100/100 | 100/100 |