### PR TITLE
fix: advisory trailers appended to 3A.6 commit (batch-review finding)

### DIFF
--- a/.omc/phase-43-evidence/test_orchestrator_wiring.log
+++ b/.omc/phase-43-evidence/test_orchestrator_wiring.log
@@ -1,0 +1,149 @@
+=== Phase 17 orchestrator-wiring prompt tests ===
+
+Test 1: lib/wave-boundary.sh wired at wave boundary
+  PASS: 3C.NEG1 section present
+  PASS: references wave-boundary.sh scan
+  PASS: routes HIGH severity to fix-story
+
+Test 2: lib/watchdog.sh wired in monitor loop
+  PASS: watchdog tick header
+  PASS: references watchdog.sh poll
+  PASS: status-probe action branch
+  PASS: kill-and-requeue action branch
+  PASS: mark-failed action branch
+  PASS: circuit-breaker bump
+  PASS: circuit-breaker check
+
+Test 3: lib/deep-review.sh wired at full-feature review
+  PASS: 4B.5 deep-review section
+  PASS: score-from-quantum call
+  PASS: tier lookup
+  PASS: dispatch-set call
+  PASS: context preparation
+  PASS: aggregate pipe
+  PASS: BLOCKS_MERGE handled
+  PASS: REQUEST_CHANGES handled
+  PASS: persists into quantum.reviews
+
+Test 4: lib/deslop.sh wired between review-pass and commit
+  PASS: 3A.5B deslop section
+  PASS: validate_scope gate
+  PASS: baseline snapshot before
+  PASS: compare_baseline call
+  PASS: rollback on regression
+  PASS: DESLOP_ROLLED_BACK signal
+  PASS: opt-out via story.deslop.skip
+
+Test 5: lib/commit-trailers.sh validation gate
+  PASS: commit-trailers reference
+  PASS: non-blocking warning
+
+Test 6: handoff.sh ownership is skill-side (orchestrator doesn't write)
+  PASS: orchestrator does NOT write handoffs directly (skills do)
+
+Test 7: all wirings carry a Phase-17 attribution comment
+  PASS: 5 Phase-17 attributions
+
+Test 8: deslop wiring uses DESLOP_AVAILABLE + BASE_SHA
+  PASS: DESLOP_AVAILABLE guard present
+  PASS: DESLOP_AVAILABLE file check
+  PASS: Fallback skip branch
+  PASS: scope loop uses BASE_SHA
+  PASS: rollback uses BASE_SHA
+  PASS: no active STORY_BASE_SHA refs in 3A.5B
+
+Test 9: RUNNER_EXTRA_FLAGS validated after pre_spawn()
+  PASS: RUNNER_EXTRA_FLAGS validation present
+  PASS: blocklist present (regex form varies)
+
+Test 10: runner_build_cmd rejects injection via RUNNER_EXTRA_FLAGS
+  PASS: injection payload rejected with clear error
+
+Test 10b: lib/reground.sh wired at Step 1C
+  PASS: reground source line present
+  PASS: REGROUND_AVAILABLE fallback flag
+  PASS: Step 1C header present
+  PASS: should_reground invoked
+  PASS: build_reground_context invoked
+  PASS: mark_grounded invoked
+  PASS: reground block path stable
+
+Test 10c: lib/tracecoder.sh wired at Step 3A.3
+  PASS: tracecoder source line present
+  PASS: TRACECODER_AVAILABLE fallback flag
+  PASS: observe primitive invoked
+  PASS: should_repair gate check
+  PASS: build_analysis_context call
+  PASS: opaque-failure bypass documented
+
+Test 10d: lib/dead-code.sh wired at Step 3A.5C
+  PASS: dead-code source line present
+  PASS: DEAD_CODE_AVAILABLE fallback flag
+  PASS: 3A.5C header present
+  PASS: find_post_commit_dead invoked
+  PASS: advisory trailer generated
+  PASS: clean-case trailer
+  PASS: side-file path for progress attach
+  PASS: non-blocking by design documented
+
+Test 10e: lib/intent-graph.sh wired at Step 3A.5D
+  PASS: intent-graph source line present
+  PASS: INTENT_GRAPH_AVAILABLE fallback flag
+  PASS: 3A.5D header present
+  PASS: extract_story_intents invoked
+  PASS: extract_code_intents invoked
+  PASS: match_intents invoked
+  PASS: intent trailer form
+  PASS: bidirectional drift documented
+  PASS: side-file path
+
+Test 10f: lib/skeleton.sh wired at 3A.1 + 3A.5E
+  PASS: skeleton source line present
+  PASS: SKELETON_AVAILABLE fallback flag
+  PASS: 3A.1 pre-skeleton preview step
+  PASS: pre-skeleton side-file
+  PASS: skeleton_text invoked in pre
+  PASS: 3A.5E header present
+  PASS: skeleton_diff invoked
+  PASS: trailer form has added/removed/changed
+  PASS: post-task side-file
+
+Test 10g: lib/trajectory.sh wired in Step 3B.3
+  PASS: trajectory source line present
+  PASS: TRAJECTORY_AVAILABLE fallback flag
+  PASS: Trajectory tick header
+  PASS: parse_trajectory invoked
+  PASS: should_early_kill gate
+  PASS: classify_trajectory for log category
+  PASS: agent log uses spawn.sh convention
+  PASS: reap_agent integration (Phase 20)
+  PASS: failureLog phase=trajectory-$cls
+
+Test 10h: lib/conflict-grade.sh wired in merge-strategy.sh
+  PASS: conflict-grade source line
+  PASS: CONFLICT_GRADE_AVAILABLE fallback
+  PASS: grade_file invoked per conflict
+  PASS: routing_recommendation logged
+  PASS: grade 5 short-circuit to escalate
+
+Test 10i: lib/hyclone.sh wired at Step 3C.NEG0
+  PASS: hyclone source line present
+  PASS: HYCLONE_AVAILABLE fallback flag
+  PASS: 3C.NEG0 header present
+  PASS: find_clones invoked
+  PASS: uses WAVE_BASE_SHA diff
+  PASS: persists for deep-review
+  PASS: advisory not blocking documented
+
+Test 10j: 3A.6 commit consumes advisory trailer vars
+  PASS: COMMIT_MSG bootstrap
+  PASS: DESLOP_TRAILER appended
+  PASS: DEAD_CODE_TRAILER appended
+  PASS: INTENT_TRAILER appended
+  PASS: SKELETON_TRAILER appended
+  PASS: git commit uses COMMIT_MSG
+
+Test 11: lib/watchdog.sh doc comment corrected
+  PASS: watchdog threshold comment matches code (>30 min = timed-out)
+
+=== Results: 106/106 passed, 0 failed ===

--- a/agents/orchestrator.md
+++ b/agents/orchestrator.md
@@ -501,9 +501,18 @@ Why a parsed-surface view matters here: a reviewer looking at a 300-line diff us
 
 ### 3A.6: On Success
 ```bash
+# Assemble commit message with advisory trailers from 3A.5B/C/D/E.
+# Trailers persist the per-story check results in git log so they
+# survive context loss and are queryable via `git log --grep`.
+COMMIT_MSG="feat: <Story ID> - <Story Title>"
+[[ -n "${DESLOP_TRAILER:-}" ]]    && COMMIT_MSG+=$'\n\n'"$DESLOP_TRAILER"
+[[ -n "${DEAD_CODE_TRAILER:-}" ]] && COMMIT_MSG+=$'\n'"$DEAD_CODE_TRAILER"
+[[ -n "${INTENT_TRAILER:-}" ]]    && COMMIT_MSG+=$'\n'"$INTENT_TRAILER"
+[[ -n "${SKELETON_TRAILER:-}" ]]  && COMMIT_MSG+=$'\n'"$SKELETON_TRAILER"
+
 # Scope git add to specific files to prevent index.lock contention on main branch
 git add quantum.json <changed_files>
-git commit -m "feat: <Story ID> - <Story Title>"
+git commit -m "$COMMIT_MSG"
 # Validate commit trailer protocol (Phase 17 wiring, P2.7). Non-blocking
 # warning if the implementer's commit message is missing required trailers:
 git log -1 --format=%B HEAD | bash "$REPO_ROOT/lib/commit-trailers.sh" validate \

--- a/tests/test_orchestrator_wiring.sh
+++ b/tests/test_orchestrator_wiring.sh
@@ -289,6 +289,16 @@ check "uses WAVE_BASE_SHA diff"  'git diff --name-only "$WAVE_BASE_SHA" HEAD'
 check "persists for deep-review"  ".quantum-hyclone-wave.json"
 check "advisory not blocking documented" "advisory"
 
+# Test 10j: 3A.6 commit appends advisory trailers from 3A.5B/C/D/E
+echo ""
+echo "Test 10j: 3A.6 commit consumes advisory trailer vars"
+check "COMMIT_MSG bootstrap" 'COMMIT_MSG="feat: <Story ID> - <Story Title>"'
+check "DESLOP_TRAILER appended" '${DESLOP_TRAILER:-}'
+check "DEAD_CODE_TRAILER appended" '${DEAD_CODE_TRAILER:-}'
+check "INTENT_TRAILER appended" '${INTENT_TRAILER:-}'
+check "SKELETON_TRAILER appended" '${SKELETON_TRAILER:-}'
+check "git commit uses COMMIT_MSG" 'git commit -m "$COMMIT_MSG"'
+
 # Test 11: classify_age doc comment fixed (Phase 21 consistency fix)
 echo ""
 echo "Test 11: lib/watchdog.sh doc comment corrected"


### PR DESCRIPTION
Surfaced during batch review of today's PRs.

## Dead-code finding

Four trailer variables were SET but never CONSUMED:

| Var | Set at | Consumed at |
|-----|--------|-------------|
| `DESLOP_TRAILER` | 3A.5B (Phase 17) | **nowhere** |
| `DEAD_CODE_TRAILER` | 3A.5C (Phase 34) | **nowhere** |
| `INTENT_TRAILER` | 3A.5D (Phase 35) | **nowhere** |
| `SKELETON_TRAILER` | 3A.5E (Phase 36) | **nowhere** |

The commit in 3A.6 used a hardcoded message, so the advisory trailers never landed in `git log` — the entire persist-via-trailer mechanism was dead code. `commit-trailers.sh validate` at line 509 would emit \"missing required trailers\" warnings for every commit.

## Fix

Assemble `COMMIT_MSG` before `git commit`; append each non-empty trailer with a leading newline (blank line before the first, then consecutive). Each guard is `[[ -n \"\${VAR:-}\" ]]` so missing trailers silently no-op.

## Tests

`tests/test_orchestrator_wiring.sh`: 100 → 106 (+6 assertions).

## Impact

Without this, all 4 advisory checks (deslop, dead-code, intent-graph, skeleton-drift) would have their findings thrown away at commit time, and the `git log` trailer-search workflow would never surface anything.

## Test plan

- [x] Wiring assertions pass (106/106)
- [x] No regressions in adjacent suites