### PR TITLE
feat: quantum-loop.sh --audit flag (dogfood feature, 4 stories)

### DIFF
--- a/quantum-loop.sh
+++ b/quantum-loop.sh
@@ -157,15 +157,107 @@ _audit_readme_conflicts() {
   fi
 }
 
+# _audit_orphan_worktrees
+# Counts .claude/worktrees/agent-* directories. Target QL_AUDIT_ORPHAN_MAX
+# (default 0). Drill = first 3 basenames.
+_audit_orphan_worktrees() {
+  local max="${QL_AUDIT_ORPHAN_MAX:-0}"
+  local -a names=()
+  local d
+  while IFS= read -r d; do
+    [[ -z "$d" ]] && continue
+    [[ -d "$d" ]] || continue
+    names+=("$(basename "$d")")
+  done < <({ ls -d .claude/worktrees/agent-* 2>/dev/null ; } || true)
+  local n="${#names[@]}"
+  if (( n <= max )); then
+    printf 'orphan-worktrees|%d|%d|OK|\n' "$n" "$max"
+  else
+    local drill
+    drill=$(_audit_drill_join names)
+    printf 'orphan-worktrees|%d|%d|FAIL|%s\n' "$n" "$max" "$drill"
+  fi
+}
+
+# _audit_cpc_files
+# Counts CPC-variant files (legacy *-CPC-*.json / *-CPC-*.md / etc).
+# Target QL_AUDIT_CPC_MAX (default 0). Drill = first 3 paths.
+_audit_cpc_files() {
+  local max="${QL_AUDIT_CPC_MAX:-0}"
+  local -a names=()
+  local f
+  while IFS= read -r f; do
+    [[ -z "$f" ]] && continue
+    names+=("$f")
+  done < <({ find . -maxdepth 3 -name '*-CPC-*' -not -path './.git/*' 2>/dev/null ; } || true)
+  local n="${#names[@]}"
+  if (( n <= max )); then
+    printf 'cpc-files|%d|%d|OK|\n' "$n" "$max"
+  else
+    local drill
+    drill=$(_audit_drill_join names)
+    printf 'cpc-files|%d|%d|FAIL|%s\n' "$n" "$max" "$drill"
+  fi
+}
+
+# _audit_test_suites
+# Inspects the most-recent .omc/phase-*-evidence/ dir for evidence logs
+# matching `=== Results: <P>/<T> passed, <F> failed ===`. Sums P/T/F.
+# OK iff F == 0. When no evidence dir exists, emits unknown/FAIL per FR-10.
+_audit_test_suites() {
+  local -a dirs=()
+  local d
+  while IFS= read -r d; do
+    [[ -z "$d" || ! -d "$d" ]] && continue
+    dirs+=("$d")
+  done < <({ ls -d .omc/phase-*-evidence 2>/dev/null ; } || true)
+  if (( ${#dirs[@]} == 0 )); then
+    printf 'test-suites|unknown|green|FAIL|no evidence logs found — run tests first\n'
+    return 0
+  fi
+  # Pick latest (lexicographic sort, highest phase number wins)
+  local latest
+  latest=$(printf '%s\n' "${dirs[@]}" | sort | tail -1)
+  local sum_p=0 sum_t=0 sum_f=0
+  local -a failing=()
+  local log line p t f
+  for log in "$latest"/*.log; do
+    [[ -f "$log" ]] || continue
+    line=$({ grep -E '^=== (Final )?Results: [0-9]+/[0-9]+ passed' "$log" 2>/dev/null ; } || true)
+    [[ -z "$line" ]] && continue
+    if [[ "$line" =~ ([0-9]+)/([0-9]+)\ passed(,\ ([0-9]+)\ failed)? ]]; then
+      p="${BASH_REMATCH[1]}"
+      t="${BASH_REMATCH[2]}"
+      f="${BASH_REMATCH[4]:-0}"
+      sum_p=$((sum_p + p))
+      sum_t=$((sum_t + t))
+      sum_f=$((sum_f + f))
+      if (( f > 0 )); then
+        failing+=("$(basename "$log" .log)")
+      fi
+    fi
+  done
+  if (( sum_f == 0 )); then
+    printf 'test-suites|%d/%d passed|green|OK|\n' "$sum_p" "$sum_t"
+  else
+    local drill
+    drill=$(_audit_drill_join failing)
+    printf 'test-suites|%d/%d passed|green|FAIL|%s\n' "$sum_p" "$sum_t" "$drill"
+  fi
+}
+
 # do_audit
-# Driver for --audit. Calls all metric helpers in canonical order, renders
+# Driver for --audit. Calls all 6 metric helpers in canonical order, renders
 # each row via _audit_format_row, returns 0 if all OK else 1.
 do_audit() {
   printf "=== Quantum-loop audit ===\n"
   local -a ROWS=()
   ROWS+=("$(_audit_branches_local)")
   ROWS+=("$(_audit_branches_remote)")
+  ROWS+=("$(_audit_orphan_worktrees)")
   ROWS+=("$(_audit_readme_conflicts)")
+  ROWS+=("$(_audit_cpc_files)")
+  ROWS+=("$(_audit_test_suites)")
   local any_fail=0 ok_count=0 total=0
   local row
   for row in "${ROWS[@]}"; do

--- a/quantum-loop.sh
+++ b/quantum-loop.sh
@@ -66,14 +66,106 @@ _audit_format_row() {
   fi
 }
 
+# _audit_drill_join NAMES_VAR_REF  (bash-4 nameref pattern)
+# Given an array of offending names, emit at most the first 3 joined with
+# ", " plus "(+N more)" when there's a tail. Empty input → empty string.
+_audit_drill_join() {
+  local -n _arr="$1"  # nameref
+  local n="${#_arr[@]}"
+  if (( n == 0 )); then printf ""; return 0; fi
+  local head_count=3
+  (( n < head_count )) && head_count=$n
+  local i=0 out=""
+  while (( i < head_count )); do
+    if (( i > 0 )); then out+=", "; fi
+    out+="${_arr[$i]}"
+    i=$((i + 1))
+  done
+  if (( n > head_count )); then
+    out+=" (+$((n - head_count)) more)"
+  fi
+  printf '%s' "$out"
+}
+
+# _audit_branches_local
+# Counts local branches excluding master/HEAD; emits OK row if count <=
+# QL_AUDIT_BRANCH_MAX (default 10) else FAIL with first-3 drill.
+_audit_branches_local() {
+  local max="${QL_AUDIT_BRANCH_MAX:-10}"
+  local -a names=()
+  local b
+  while IFS= read -r b; do
+    b="${b#\* }"
+    b="${b# }"
+    [[ -z "$b" || "$b" == "master" || "$b" == "HEAD" ]] && continue
+    names+=("$b")
+  done < <({ git branch 2>/dev/null ; } || true)
+  local n="${#names[@]}"
+  if (( n <= max )); then
+    printf 'branches-local|%d|≤%d|OK|\n' "$n" "$max"
+  else
+    local drill
+    drill=$(_audit_drill_join names)
+    printf 'branches-local|%d|≤%d|FAIL|%s\n' "$n" "$max" "$drill"
+  fi
+}
+
+# _audit_branches_remote
+# Same as _audit_branches_local but against `git branch -r`, excluding
+# HEAD pointers and origin/master.
+_audit_branches_remote() {
+  local max="${QL_AUDIT_BRANCH_MAX:-10}"
+  local -a names=()
+  local b
+  while IFS= read -r b; do
+    b="${b# }"
+    [[ -z "$b" ]] && continue
+    [[ "$b" == *"HEAD"* ]] && continue
+    [[ "$b" == "origin/master" ]] && continue
+    names+=("$b")
+  done < <({ git branch -r 2>/dev/null ; } || true)
+  local n="${#names[@]}"
+  if (( n <= max )); then
+    printf 'branches-remote|%d|≤%d|OK|\n' "$n" "$max"
+  else
+    local drill
+    drill=$(_audit_drill_join names)
+    printf 'branches-remote|%d|≤%d|FAIL|%s\n' "$n" "$max" "$drill"
+  fi
+}
+
+# _audit_readme_conflicts
+# Counts merge-conflict markers in README.md. Guards against missing file.
+# Target QL_AUDIT_CONFLICT_MAX (default 0). Drill = first 3 line numbers.
+_audit_readme_conflicts() {
+  local max="${QL_AUDIT_CONFLICT_MAX:-0}"
+  local n=0
+  local -a lines=()
+  if [[ -f README.md ]]; then
+    local ln
+    while IFS=: read -r ln _; do
+      [[ -n "$ln" ]] && lines+=("$ln")
+    done < <({ grep -nE '^(<<<<<<<|=======|>>>>>>>)' README.md 2>/dev/null ; } || true)
+    n="${#lines[@]}"
+  fi
+  if (( n <= max )); then
+    printf 'readme-conflicts|%d|%d|OK|\n' "$n" "$max"
+  else
+    local drill
+    drill=$(_audit_drill_join lines)
+    printf 'readme-conflicts|%d|%d|FAIL|%s\n' "$n" "$max" "$drill"
+  fi
+}
+
 # do_audit
-# Driver for --audit. US-001 ships a stub that emits header + one placeholder
-# row + Summary. US-002 and US-003 extend it with real metric helpers.
+# Driver for --audit. Calls all metric helpers in canonical order, renders
+# each row via _audit_format_row, returns 0 if all OK else 1.
 do_audit() {
   printf "=== Quantum-loop audit ===\n"
   local -a ROWS=()
-  # US-001 placeholder row (removed in US-002 T-004 once real helpers land):
-  ROWS+=("placeholder|0|0|OK|")
+  ROWS+=("$(_audit_branches_local)")
+  ROWS+=("$(_audit_branches_remote)")
+  ROWS+=("$(_audit_readme_conflicts)")
   local any_fail=0 ok_count=0 total=0
   local row
   for row in "${ROWS[@]}"; do

--- a/quantum-loop.sh
+++ b/quantum-loop.sh
@@ -20,6 +20,7 @@ set -euo pipefail
 #   ./quantum-loop.sh [OPTIONS]
 #
 # Options:
+#   --audit              Print §6 measurement metrics and exit (read-only).
 #   --max-iterations N   Maximum iterations before stopping (default: 20)
 #   --max-retries N      Max retry attempts per story (default: 3)
 #   --tool TOOL          AI tool to use (default: "claude"). Any runner in runners/*.json.
@@ -323,7 +324,7 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --help)
-      head -24 "$0" | tail -19
+      head -29 "$0" | tail -24
       exit 0
       ;;
     *)

--- a/quantum-loop.sh
+++ b/quantum-loop.sh
@@ -42,6 +42,71 @@ MAX_PARALLEL=4
 STALE_TIMEOUT=20
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# =============================================================================
+# --audit flag support (Phase 44 / US-001 -- US-004). Read-only repo-hygiene
+# check per idea-stage/IDEA_REPORT.md §6 measurement plan.
+# Helpers live near the top so the pre-arg-loop audit shortcut can call them.
+# =============================================================================
+
+# _audit_format_row PIPE_ROW
+# Takes one pipe-delimited string "name|value|target|status|drill" and emits
+# formatted output on stdout. Single line for OK, two lines for FAIL (main
+# line + indented drill-down with └─ prefix). Column widths locked so CI
+# scripts can grep reliably.
+_audit_format_row() {
+  local row="${1:-}"
+  local name value target status drill
+  IFS='|' read -r name value target status drill <<< "$row"
+  # Main line: "<name>: <value> (target <target>) <status>"
+  # Column widths: name: padded to 18, value+target padded to 30, status right.
+  printf "%-18s %s (target %s) %6s\n" "${name}:" "$value" "$target" "$status"
+  # Drill only when FAIL and non-empty drill
+  if [[ "$status" == "FAIL" && -n "$drill" ]]; then
+    printf "                   └─ %s\n" "$drill"
+  fi
+}
+
+# do_audit
+# Driver for --audit. US-001 ships a stub that emits header + one placeholder
+# row + Summary. US-002 and US-003 extend it with real metric helpers.
+do_audit() {
+  printf "=== Quantum-loop audit ===\n"
+  local -a ROWS=()
+  # US-001 placeholder row (removed in US-002 T-004 once real helpers land):
+  ROWS+=("placeholder|0|0|OK|")
+  local any_fail=0 ok_count=0 total=0
+  local row
+  for row in "${ROWS[@]}"; do
+    _audit_format_row "$row"
+    total=$((total + 1))
+    if [[ "$row" == *"|FAIL|"* ]]; then
+      any_fail=1
+    else
+      ok_count=$((ok_count + 1))
+    fi
+  done
+  printf "\nSummary: %d/%d metrics on target.\n" "$ok_count" "$total"
+  return "$any_fail"
+}
+
+# Test-mode guard (Phase 44 / US-001): when QL_AUDIT_TEST_MODE=1 is set,
+# sourcing this file returns here so unit tests can reach the audit
+# helpers defined above without triggering the main arg-loop or any
+# state-mutating code below.
+[[ "${QL_AUDIT_TEST_MODE:-0}" == "1" ]] && return 0 2>/dev/null
+
+# Pre-arg-loop audit shortcut: --audit is exclusive and takes no other args.
+# Must run BEFORE the normal arg-parsing loop so any stray sibling flag
+# (--audit --parallel) is rejected with exit 2.
+if [[ " $* " == *" --audit "* ]]; then
+  if [[ "$#" -ne 1 ]]; then
+    printf "Error: --audit is exclusive and takes no other arguments\n" >&2
+    exit 2
+  fi
+  do_audit
+  exit $?
+fi
+
 # Parse arguments
 while [[ $# -gt 0 ]]; do
   case $1 in

--- a/tests/test_audit.sh
+++ b/tests/test_audit.sh
@@ -86,10 +86,12 @@ case "$out" in
 esac
 TOTAL=$((TOTAL + 1))
 
-# Test 5: --audit clean repo exit 0
+# Test 5: --audit clean repo exit 0 (seed green evidence so test-suites is OK)
 echo ""
 echo "Test 5: --audit clean repo exit 0"
 TMP=$(setup_audit_repo)
+mkdir -p "$TMP/.omc/phase-99-evidence"
+printf '=== Results: 1/1 passed, 0 failed ===\n' > "$TMP/.omc/phase-99-evidence/test_x.log"
 out=$(cd "$TMP" && bash "$REPO_ROOT/quantum-loop.sh" --audit 2>&1 || true)
 rc=$(cd "$TMP" && bash "$REPO_ROOT/quantum-loop.sh" --audit >/dev/null 2>&1 ; echo $?)
 TOTAL=$((TOTAL + 1))
@@ -201,12 +203,131 @@ echo ""
 echo "Test 12: env-override BRANCH_MAX"
 TMP=$(setup_audit_repo)
 (cd "$TMP" && for i in $(seq 1 12); do git branch "extra-$i" 2>/dev/null; done)
+# Seed green evidence so test-suites does not independently fail
+mkdir -p "$TMP/.omc/phase-99-evidence"
+printf '=== Results: 1/1 passed, 0 failed ===\n' > "$TMP/.omc/phase-99-evidence/test_x.log"
 # Default threshold (10) → 12 branches should FAIL → exit 1
 rc_default=$(cd "$TMP" && bash "$REPO_ROOT/quantum-loop.sh" --audit >/dev/null 2>&1 ; echo $?)
 # With QL_AUDIT_BRANCH_MAX=20 → 12 <= 20 → exit 0
 rc_override=$(cd "$TMP" && QL_AUDIT_BRANCH_MAX=20 bash "$REPO_ROOT/quantum-loop.sh" --audit >/dev/null 2>&1 ; echo $?)
 assert "default BRANCH_MAX=10 → exit 1" "1" "$rc_default"
 assert "override BRANCH_MAX=20 → exit 0" "0" "$rc_override"
+rm -rf "$TMP"
+
+# --- US-003 tests -----------------------------------------------------------
+
+# Test 13: _audit_orphan_worktrees OK when no agent-* dirs
+echo ""
+echo "Test 13: _audit_orphan_worktrees OK"
+TMP=$(setup_audit_repo)
+out=$(cd "$TMP" && _audit_orphan_worktrees)
+case "$out" in
+  orphan-worktrees\|0\|0\|OK\|*)
+    echo "  PASS: orphan_worktrees OK on clean repo"; PASS=$((PASS + 1));;
+  *)
+    echo "  FAIL: orphan_worktrees OK — got [$out]"; FAIL=$((FAIL + 1));;
+esac
+TOTAL=$((TOTAL + 1))
+rm -rf "$TMP"
+
+# Test 14: _audit_orphan_worktrees FAIL when agent-* dir present
+echo ""
+echo "Test 14: _audit_orphan_worktrees FAIL"
+TMP=$(setup_audit_repo)
+mkdir -p "$TMP/.claude/worktrees/agent-foo"
+out=$(cd "$TMP" && _audit_orphan_worktrees)
+case "$out" in
+  orphan-worktrees\|1\|0\|FAIL\|*agent-foo*)
+    echo "  PASS: orphan_worktrees FAIL with drill"; PASS=$((PASS + 1));;
+  *)
+    echo "  FAIL: orphan_worktrees FAIL — got [$out]"; FAIL=$((FAIL + 1));;
+esac
+TOTAL=$((TOTAL + 1))
+rm -rf "$TMP"
+
+# Test 15: _audit_cpc_files FAIL when CPC file present
+echo ""
+echo "Test 15: _audit_cpc_files FAIL"
+TMP=$(setup_audit_repo)
+touch "$TMP/plugin-CPC-xyz.json"
+out=$(cd "$TMP" && _audit_cpc_files)
+case "$out" in
+  cpc-files\|1\|0\|FAIL\|*plugin-CPC-xyz.json*)
+    echo "  PASS: cpc_files FAIL with drill"; PASS=$((PASS + 1));;
+  *)
+    echo "  FAIL: cpc_files FAIL — got [$out]"; FAIL=$((FAIL + 1));;
+esac
+TOTAL=$((TOTAL + 1))
+rm -rf "$TMP"
+
+# Test 16: _audit_test_suites OK when green evidence log present
+echo ""
+echo "Test 16: _audit_test_suites OK"
+TMP=$(setup_audit_repo)
+mkdir -p "$TMP/.omc/phase-99-evidence"
+# Canonical evidence format: '=== Results: ...' on its own line (no prefix)
+printf '=== Results: 5/5 passed, 0 failed ===\n' > "$TMP/.omc/phase-99-evidence/test_x.log"
+out=$(cd "$TMP" && _audit_test_suites)
+case "$out" in
+  test-suites\|5/5\ passed\|green\|OK\|*)
+    echo "  PASS: test_suites OK"; PASS=$((PASS + 1));;
+  *)
+    echo "  FAIL: test_suites OK — got [$out]"; FAIL=$((FAIL + 1));;
+esac
+TOTAL=$((TOTAL + 1))
+rm -rf "$TMP"
+
+# Test 17: _audit_test_suites FAIL when log shows failures
+echo ""
+echo "Test 17: _audit_test_suites FAIL"
+TMP=$(setup_audit_repo)
+mkdir -p "$TMP/.omc/phase-99-evidence"
+printf '=== Results: 3/5 passed, 2 failed ===\n' > "$TMP/.omc/phase-99-evidence/test_x.log"
+out=$(cd "$TMP" && _audit_test_suites)
+case "$out" in
+  test-suites\|3/5\ passed\|green\|FAIL\|*test_x*)
+    echo "  PASS: test_suites FAIL with drill"; PASS=$((PASS + 1));;
+  *)
+    echo "  FAIL: test_suites FAIL — got [$out]"; FAIL=$((FAIL + 1));;
+esac
+TOTAL=$((TOTAL + 1))
+rm -rf "$TMP"
+
+# Test 18: _audit_test_suites unknown when no evidence dir (FR-10)
+echo ""
+echo "Test 18: _audit_test_suites unknown (no evidence dir)"
+TMP=$(setup_audit_repo)
+out=$(cd "$TMP" && _audit_test_suites)
+case "$out" in
+  test-suites\|unknown\|green\|FAIL\|no\ evidence*)
+    echo "  PASS: test_suites unknown (no evidence)"; PASS=$((PASS + 1));;
+  *)
+    echo "  FAIL: test_suites unknown — got [$out]"; FAIL=$((FAIL + 1));;
+esac
+TOTAL=$((TOTAL + 1))
+rm -rf "$TMP"
+
+# Test 19: failure-path integration (cpc + orphans + green test-suites → exit 1)
+echo ""
+echo "Test 19: failure-path integration"
+TMP=$(setup_audit_repo)
+touch "$TMP/plugin-CPC-xyz.json"
+mkdir -p "$TMP/.claude/worktrees/agent-stale"
+mkdir -p "$TMP/.omc/phase-99-evidence"
+echo 'test_x: === Results: 1/1 passed, 0 failed ===' > "$TMP/.omc/phase-99-evidence/test_x.log"
+out=$(cd "$TMP" && bash "$REPO_ROOT/quantum-loop.sh" --audit 2>&1 || true)
+rc=$(cd "$TMP" && bash "$REPO_ROOT/quantum-loop.sh" --audit >/dev/null 2>&1 ; echo $?)
+TOTAL=$((TOTAL + 1))
+if [[ "$rc" -eq 1 ]] \
+   && printf '%s' "$out" | grep -q 'cpc-files.*FAIL' \
+   && printf '%s' "$out" | grep -q 'orphan-worktrees.*FAIL' \
+   && printf '%s' "$out" | grep -q 'test-suites.*OK' \
+   && printf '%s' "$out" | grep -q '└─'; then
+  echo "  PASS: failure-path exit 1 with drill-down"; PASS=$((PASS + 1))
+else
+  echo "  FAIL: failure-path integration (rc=$rc)"; FAIL=$((FAIL + 1))
+  echo "    out=$out" | head -5
+fi
 rm -rf "$TMP"
 
 echo ""

--- a/tests/test_audit.sh
+++ b/tests/test_audit.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Phase 44 / US-001..US-004 — --audit flag tests.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR/.."
+PASS=0
+FAIL=0
+TOTAL=0
+
+assert() {
+  local name="$1" expected="$2" actual="$3"
+  TOTAL=$((TOTAL + 1))
+  if [[ "$expected" == "$actual" ]]; then
+    echo "  PASS: $name"; PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $name (expected [$expected] got [$actual])"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+setup_audit_repo() {
+  local d; d=$(mktemp -d)
+  (
+    cd "$d"
+    git init -q
+    git config user.email "t@t.t"
+    git config user.name  "t"
+    echo "initial" > README.md
+    git add README.md && git commit -qm init
+  )
+  printf '%s' "$d"
+}
+
+# Source quantum-loop.sh in test mode — skips main arg-loop, just defines helpers.
+# shellcheck disable=SC1091
+QL_AUDIT_TEST_MODE=1 source "$REPO_ROOT/quantum-loop.sh"
+
+echo "=== Phase 44 audit-flag tests ==="
+
+# --- US-001 tests -----------------------------------------------------------
+
+# Test 1: format_row OK shape
+echo ""
+echo "Test 1: _audit_format_row OK shape"
+out=$(_audit_format_row 'branches-local|5|≤10|OK|')
+case "$out" in
+  *"branches-local:"*"5"*"(target ≤10)"*"OK"*)
+    echo "  PASS: format_row OK shape"; PASS=$((PASS + 1));;
+  *)
+    echo "  FAIL: format_row OK shape — got [$out]"; FAIL=$((FAIL + 1));;
+esac
+TOTAL=$((TOTAL + 1))
+
+# Test 2: format_row FAIL shape with drill
+echo ""
+echo "Test 2: _audit_format_row FAIL shape"
+out=$(_audit_format_row 'cpc-files|2|0|FAIL|plugin-CPC.json, README-CPC.md')
+case "$out" in
+  *"cpc-files:"*"FAIL"*"└─"*"plugin-CPC.json"*)
+    echo "  PASS: format_row FAIL shape with drill"; PASS=$((PASS + 1));;
+  *)
+    echo "  FAIL: format_row FAIL shape — got [$out]"; FAIL=$((FAIL + 1));;
+esac
+TOTAL=$((TOTAL + 1))
+
+# Test 3: format_row FAIL with empty drill — no drill line
+echo ""
+echo "Test 3: _audit_format_row FAIL empty drill omits drill line"
+out=$(_audit_format_row 'x|1|0|FAIL|')
+line_count=$(printf '%s' "$out" | awk 'END{print NR}')
+assert "empty-drill FAIL = 1 line" "1" "$line_count"
+
+# Test 4: do_audit stub returns 0 and prints header
+echo ""
+echo "Test 4: do_audit stub happy path"
+out=$(do_audit 2>&1)
+rc=$?
+assert "do_audit exits 0" "0" "$rc"
+case "$out" in
+  *"=== Quantum-loop audit ==="*"placeholder:"*"Summary:"*)
+    echo "  PASS: header + placeholder + summary present"; PASS=$((PASS + 1));;
+  *)
+    echo "  FAIL: stub output — got [$out]"; FAIL=$((FAIL + 1));;
+esac
+TOTAL=$((TOTAL + 1))
+
+# Test 5: --audit clean repo exit 0
+echo ""
+echo "Test 5: --audit clean repo exit 0"
+TMP=$(setup_audit_repo)
+out=$(cd "$TMP" && bash "$REPO_ROOT/quantum-loop.sh" --audit 2>&1 || true)
+rc=$(cd "$TMP" && bash "$REPO_ROOT/quantum-loop.sh" --audit >/dev/null 2>&1 ; echo $?)
+TOTAL=$((TOTAL + 1))
+if [[ "$rc" -eq 0 ]] && printf '%s' "$out" | grep -q '=== Quantum-loop audit ==='; then
+  echo "  PASS: --audit clean repo exit 0"; PASS=$((PASS + 1))
+else
+  echo "  FAIL: --audit clean repo exit (rc=$rc, out=$out)"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$TMP"
+
+# Test 6: --audit exclusive-flag guard
+echo ""
+echo "Test 6: --audit exclusive"
+out=$(bash "$REPO_ROOT/quantum-loop.sh" --audit --parallel 2>&1 || true)
+rc=$(bash "$REPO_ROOT/quantum-loop.sh" --audit --parallel >/dev/null 2>&1 ; echo $?)
+TOTAL=$((TOTAL + 1))
+if [[ "$rc" -eq 2 ]] && printf '%s' "$out" | grep -q -- '--audit is exclusive'; then
+  echo "  PASS: --audit exclusive exits 2 with clear error"; PASS=$((PASS + 1))
+else
+  echo "  FAIL: --audit exclusive guard (rc=$rc)"; FAIL=$((FAIL + 1))
+fi
+
+echo ""
+echo "=== Results: $PASS/$TOTAL passed, $FAIL failed ==="
+exit $((FAIL > 0 ? 1 : 0))

--- a/tests/test_audit.sh
+++ b/tests/test_audit.sh
@@ -330,6 +330,87 @@ else
 fi
 rm -rf "$TMP"
 
+# --- US-004 tests -----------------------------------------------------------
+
+# Test 20: --help output contains --audit line
+echo ""
+echo "Test 20: --help documents --audit"
+help_out=$(bash "$REPO_ROOT/quantum-loop.sh" --help 2>&1)
+TOTAL=$((TOTAL + 1))
+if printf '%s' "$help_out" | grep -- '--audit' | grep -q 'measurement metrics'; then
+  echo "  PASS: --help contains --audit line"; PASS=$((PASS + 1))
+else
+  echo "  FAIL: --help missing --audit"; FAIL=$((FAIL + 1))
+fi
+
+# Test 21: format_row byte-exact regression (OK)
+echo ""
+echo "Test 21: format_row byte-exact OK regression"
+expected='branches-local:    5 (target ≤10)     OK'
+actual=$(_audit_format_row 'branches-local|5|≤10|OK|')
+assert "format_row OK byte-exact" "$expected" "$actual"
+
+# Test 22: format_row byte-exact regression (FAIL with drill)
+echo ""
+echo "Test 22: format_row byte-exact FAIL regression"
+expected_main='cpc-files:         2 (target 0)   FAIL'
+expected_drill='                   └─ plugin-CPC.json, README-CPC.md'
+actual=$(_audit_format_row 'cpc-files|2|0|FAIL|plugin-CPC.json, README-CPC.md')
+line1=$(printf '%s\n' "$actual" | sed -n '1p')
+line2=$(printf '%s\n' "$actual" | sed -n '2p')
+assert "format_row FAIL line 1"   "$expected_main"  "$line1"
+assert "format_row FAIL drill line" "$expected_drill" "$line2"
+
+# Test 23: full-flow happy-path integration (all 6 OK, exit 0)
+echo ""
+echo "Test 23: full-flow happy path 6/6"
+TMP=$(setup_audit_repo)
+mkdir -p "$TMP/.omc/phase-99-evidence"
+printf '=== Results: 1/1 passed, 0 failed ===\n' > "$TMP/.omc/phase-99-evidence/test_x.log"
+out=$(cd "$TMP" && bash "$REPO_ROOT/quantum-loop.sh" --audit 2>&1 || true)
+rc=$(cd "$TMP" && bash "$REPO_ROOT/quantum-loop.sh" --audit >/dev/null 2>&1 ; echo $?)
+TOTAL=$((TOTAL + 1))
+ok_count=$(printf '%s' "$out" | grep -cE '^[a-z].*OK$')
+if [[ "$rc" -eq 0 ]] && [[ "$ok_count" -eq 6 ]] && printf '%s' "$out" | grep -q 'Summary: 6/6 metrics on target.'; then
+  echo "  PASS: full-flow happy 6/6"; PASS=$((PASS + 1))
+else
+  echo "  FAIL: full-flow happy (rc=$rc, ok_count=$ok_count)"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$TMP"
+
+# Test 24: full-flow all-fail integration
+echo ""
+echo "Test 24: full-flow all-fail"
+TMP=$(setup_audit_repo)
+# Seed all 5 non-remote failure conditions
+(cd "$TMP" && for i in $(seq 1 15); do git branch "extra-$i" 2>/dev/null; done)
+touch "$TMP/plugin-CPC-xyz.json"
+mkdir -p "$TMP/.claude/worktrees/agent-stale"
+cat > "$TMP/README.md" <<'EOF'
+<<<<<<< HEAD
+ours
+=======
+theirs
+>>>>>>> branch
+EOF
+mkdir -p "$TMP/.omc/phase-99-evidence"
+printf '=== Results: 3/5 passed, 2 failed ===\n' > "$TMP/.omc/phase-99-evidence/test_x.log"
+out=$(cd "$TMP" && bash "$REPO_ROOT/quantum-loop.sh" --audit 2>&1 || true)
+rc=$(cd "$TMP" && bash "$REPO_ROOT/quantum-loop.sh" --audit >/dev/null 2>&1 ; echo $?)
+TOTAL=$((TOTAL + 1))
+fail_count=$(printf '%s' "$out" | grep -cE 'FAIL$')
+if [[ "$rc" -eq 1 ]] && (( fail_count >= 4 )) \
+   && printf '%s' "$out" | grep -q 'branches-local.*FAIL' \
+   && printf '%s' "$out" | grep -q 'cpc-files.*FAIL' \
+   && printf '%s' "$out" | grep -q 'orphan-worktrees.*FAIL' \
+   && printf '%s' "$out" | grep -q 'test-suites.*FAIL'; then
+  echo "  PASS: full-flow all-fail (rc=$rc, fail_count=$fail_count)"; PASS=$((PASS + 1))
+else
+  echo "  FAIL: full-flow all-fail (rc=$rc, fail_count=$fail_count)"; FAIL=$((FAIL + 1))
+  printf '%s\n' "$out" | sed 's/^/    /' | head -10
+fi
+rm -rf "$TMP"
+
 echo ""
 echo "=== Results: $PASS/$TOTAL passed, $FAIL failed ==="
 exit $((FAIL > 0 ? 1 : 0))

--- a/tests/test_audit.sh
+++ b/tests/test_audit.sh
@@ -79,10 +79,10 @@ out=$(do_audit 2>&1)
 rc=$?
 assert "do_audit exits 0" "0" "$rc"
 case "$out" in
-  *"=== Quantum-loop audit ==="*"placeholder:"*"Summary:"*)
-    echo "  PASS: header + placeholder + summary present"; PASS=$((PASS + 1));;
+  *"=== Quantum-loop audit ==="*"Summary:"*)
+    echo "  PASS: header + summary present"; PASS=$((PASS + 1));;
   *)
-    echo "  FAIL: stub output — got [$out]"; FAIL=$((FAIL + 1));;
+    echo "  FAIL: do_audit output — got [$out]"; FAIL=$((FAIL + 1));;
 esac
 TOTAL=$((TOTAL + 1))
 
@@ -111,6 +111,103 @@ if [[ "$rc" -eq 2 ]] && printf '%s' "$out" | grep -q -- '--audit is exclusive'; 
 else
   echo "  FAIL: --audit exclusive guard (rc=$rc)"; FAIL=$((FAIL + 1))
 fi
+
+# --- US-002 tests -----------------------------------------------------------
+
+# Test 7: _audit_branches_local OK on clean repo
+echo ""
+echo "Test 7: _audit_branches_local OK on clean tmp repo"
+TMP=$(setup_audit_repo)
+out=$(cd "$TMP" && _audit_branches_local)
+case "$out" in
+  branches-local\|0\|≤10\|OK\|*)
+    echo "  PASS: branches_local OK on clean repo"; PASS=$((PASS + 1));;
+  *)
+    echo "  FAIL: branches_local OK — got [$out]"; FAIL=$((FAIL + 1));;
+esac
+TOTAL=$((TOTAL + 1))
+rm -rf "$TMP"
+
+# Test 8: _audit_branches_local FAIL when 12 branches exist
+echo ""
+echo "Test 8: _audit_branches_local FAIL over threshold"
+TMP=$(setup_audit_repo)
+(cd "$TMP" && for i in $(seq 1 12); do git branch "extra-$i" 2>/dev/null; done)
+out=$(cd "$TMP" && _audit_branches_local)
+case "$out" in
+  branches-local\|12\|≤10\|FAIL\|*extra-*)
+    echo "  PASS: branches_local FAIL with drill"; PASS=$((PASS + 1));;
+  *)
+    echo "  FAIL: branches_local FAIL — got [$out]"; FAIL=$((FAIL + 1));;
+esac
+TOTAL=$((TOTAL + 1))
+rm -rf "$TMP"
+
+# Test 9: _audit_branches_remote OK on clean repo
+echo ""
+echo "Test 9: _audit_branches_remote OK"
+TMP=$(setup_audit_repo)
+out=$(cd "$TMP" && _audit_branches_remote)
+case "$out" in
+  branches-remote\|0\|≤10\|OK\|*)
+    echo "  PASS: branches_remote OK"; PASS=$((PASS + 1));;
+  *)
+    echo "  FAIL: branches_remote OK — got [$out]"; FAIL=$((FAIL + 1));;
+esac
+TOTAL=$((TOTAL + 1))
+rm -rf "$TMP"
+
+# Test 10: _audit_readme_conflicts OK on clean README
+echo ""
+echo "Test 10: _audit_readme_conflicts OK"
+TMP=$(setup_audit_repo)
+out=$(cd "$TMP" && _audit_readme_conflicts)
+case "$out" in
+  readme-conflicts\|0\|0\|OK\|*)
+    echo "  PASS: readme_conflicts OK"; PASS=$((PASS + 1));;
+  *)
+    echo "  FAIL: readme_conflicts OK — got [$out]"; FAIL=$((FAIL + 1));;
+esac
+TOTAL=$((TOTAL + 1))
+rm -rf "$TMP"
+
+# Test 11: _audit_readme_conflicts FAIL when markers present
+echo ""
+echo "Test 11: _audit_readme_conflicts FAIL with markers"
+TMP=$(setup_audit_repo)
+(
+  cd "$TMP"
+  cat > README.md <<'EOF'
+line before
+<<<<<<< HEAD
+ours
+=======
+theirs
+>>>>>>> branch
+EOF
+)
+out=$(cd "$TMP" && _audit_readme_conflicts)
+case "$out" in
+  readme-conflicts\|3\|0\|FAIL\|*)
+    echo "  PASS: readme_conflicts FAIL with drill"; PASS=$((PASS + 1));;
+  *)
+    echo "  FAIL: readme_conflicts FAIL — got [$out]"; FAIL=$((FAIL + 1));;
+esac
+TOTAL=$((TOTAL + 1))
+rm -rf "$TMP"
+
+# Test 12: env-override BRANCH_MAX raises threshold
+echo ""
+echo "Test 12: env-override BRANCH_MAX"
+TMP=$(setup_audit_repo)
+(cd "$TMP" && for i in $(seq 1 12); do git branch "extra-$i" 2>/dev/null; done)
+# Default threshold (10) → 12 branches should FAIL → exit 1
+rc_default=$(cd "$TMP" && bash "$REPO_ROOT/quantum-loop.sh" --audit >/dev/null 2>&1 ; echo $?)
+# With QL_AUDIT_BRANCH_MAX=20 → 12 <= 20 → exit 0
+rc_override=$(cd "$TMP" && QL_AUDIT_BRANCH_MAX=20 bash "$REPO_ROOT/quantum-loop.sh" --audit >/dev/null 2>&1 ; echo $?)
+assert "default BRANCH_MAX=10 → exit 1" "1" "$rc_default"
+assert "override BRANCH_MAX=20 → exit 0" "0" "$rc_override"
+rm -rf "$TMP"
 
 echo ""
 echo "=== Results: $PASS/$TOTAL passed, $FAIL failed ==="


### PR DESCRIPTION
**First dogfood feature** — drove through the full quantum-loop pipeline: `/ql-brainstorm` → `/ql-spec` → `/ql-plan` → `/ql-execute`.

## What

Read-only `--audit` flag on `quantum-loop.sh` prints the six §6 measurement metrics from `idea-stage/IDEA_REPORT.md` with drill-down on failures and a machine-actionable exit code.

```
$ ./quantum-loop.sh --audit
=== Quantum-loop audit ===
branches-local:    2 (target ≤10)     OK
branches-remote:   3 (target ≤10)     OK
orphan-worktrees:  0 (target 0)     OK
readme-conflicts:  0 (target 0)     OK
cpc-files:         0 (target 0)     OK
test-suites:       301/301 passed (target green)     OK

Summary: 6/6 metrics on target.
```

Exit 0 when all metrics OK, exit 1 on any FAIL, exit 2 on misuse (`--audit --parallel`).

## Stories

| # | Title | Content |
|---|-------|---------|
| US-001 | Audit driver infrastructure | Test-mode guard, `_audit_format_row`, `do_audit` stub, `--audit` pre-arg-loop shortcut with exclusive guard |
| US-002 | Git-based metrics | `_audit_branches_local`, `_audit_branches_remote`, `_audit_readme_conflicts` + `_audit_drill_join` helper |
| US-003 | Filesystem + evidence metrics | `_audit_orphan_worktrees`, `_audit_cpc_files`, `_audit_test_suites` (w/ no-evidence FR-10 fallback) |
| US-004 | --help integration + format regression | `--audit` in Options comment, byte-exact format regression tests, full-flow happy/all-fail integration |

## Tunables (all env-overrideable)

`QL_AUDIT_BRANCH_MAX=10`, `QL_AUDIT_ORPHAN_MAX=0`, `QL_AUDIT_CONFLICT_MAX=0`, `QL_AUDIT_CPC_MAX=0`, `QL_AUDIT_TEST_MODE=1` (test-source guard).

## Tests

`tests/test_audit.sh`: **27 assertions**, runtime <3s. Includes per-helper unit tests, env-override integration, byte-exact format regression, full-flow happy and all-fail paths.

Regression check: `test_orchestrator_wiring` (106/106), `test_spawn` (37/37), `test_dag_query` (35/35), `test_typecheck_gate` (33/33) — all green. No new shellcheck warnings.

## Dogfood findings (pipeline rough edges)

1. **Skills drive structure, not execution** — `/ql-brainstorm`, `/ql-spec`, `/ql-plan`, `/ql-execute` all hand me markdown workflows I interpret as the orchestrator. Skill value is gate-enforcement, not automation.
2. **Question minimums are rigid** — `/ql-spec` required 5+ questions even when the design doc answered most. Padded with release-ops and non-goal confirmations that don't strictly belong in a PRD.
3. **File-level conflicts force serialization** — all 4 stories edit 2 shared files (`quantum-loop.sh`, `tests/test_audit.sh`). DAG-validator preserved the intentional linear chain but flagged it as a bottleneck. Pipeline has no concept of "fast-forward mergeable serial stories" distinct from "true parallel-safe stories."
4. **Cross-story test drift** — US-001 Test 4 matched `"placeholder:"` which US-002 removed. Had to patch Test 4 mid-story. Orchestrator spec's "progress must preserve all prior tests" assumption doesn't hold when stories replace scaffolding.
5. **Windows CRLF in subshells** — ran into `(...)` subshell command-substitution exit-code issues on Git Bash; switched to explicit `$(cmd >/dev/null 2>&1 ; echo $?)` pattern for robust exit-code capture.

## Test plan

- [x] 27/27 audit tests pass
- [x] 5 adjacent test suites green (no regressions)
- [x] shellcheck clean (only pre-existing SC1091 info)
- [x] `./quantum-loop.sh --audit` on master: all 6 OK, exit 0
- [x] `./quantum-loop.sh --audit --parallel` exit 2 with clear error
- [ ] v0.5.1 release PR to follow (per brainstorm answer 6B)