### PR TITLE
chore(release): v0.5.1 — --audit flag (first dogfood feature)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Universal CLI orchestrator with multi-runner support. Autonomous spec-driven development pipeline with dependency DAG, parallel worktree execution, two-stage review gates, DAG intelligence validation, and modular merge hardening",
-    "version": "0.5.0"
+    "version": "0.5.1"
   },
   "plugins": [
     {
       "name": "quantum-loop",
       "source": "./",
       "description": "6 skills (brainstorm, spec, plan, execute, verify, review) and 5 agents for autonomous spec-driven development with multi-runner support, DAG intelligence, and modular merge hardening",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "keywords": ["autonomous", "prd", "tdd", "verification", "review", "planning", "agent-loop", "multi-runner", "codex", "copilot", "gemini", "universal-orchestrator"],
       "category": "productivity"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "quantum-loop",
   "description": "Universal CLI orchestrator with multi-runner support. Autonomous spec-driven development with dependency DAG, parallel worktree execution, two-stage review gates, and modular merge hardening.",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "author": {
     "name": "andyzengmath"
   }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "quantum-loop",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Spec-driven autonomous development loop with DAG-based execution, parallel worktree agents, two-stage review gates, and Iron Law verification. Turns a feature description into verified, reviewed, autonomously-implemented code.",
   "author": {
     "name": "andyzengmath"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ Format: [Semantic Versioning](https://semver.org/). Bump per PR:
 - **Minor** (0.x.0): new features, backward-compatible
 - **Major** (x.0.0): breaking changes
 
+## [0.5.1] - 2026-04-24
+
+### Added
+
+- **`quantum-loop.sh --audit`** (#56) — read-only repo-hygiene check that prints the six IDEA_REPORT §6 measurement metrics with drill-down on failures. Exit 0 all-OK, exit 1 any off-target, exit 2 misuse. Env-tunable thresholds via `QL_AUDIT_BRANCH_MAX` / `QL_AUDIT_ORPHAN_MAX` / `QL_AUDIT_CONFLICT_MAX` / `QL_AUDIT_CPC_MAX`.
+- **`docs/plans/2026-04-24-audit-flag-design.md`** + **`tasks/prd-audit-flag.md`** (#57) — pipeline artifacts from dogfooding `/ql-brainstorm` + `/ql-spec` on the audit feature. Preserves the IDEA_REPORT §6 → design → PRD → shipped-feature traceback.
+
+### Dogfood milestone
+
+First real pipeline self-use. The `/ql-brainstorm` → `/ql-spec` → `/ql-plan` → `/ql-execute` cycle drove a complete 4-story feature end-to-end. Findings captured in #56 PR body for follow-up skill refinements (question-count rigidity in ql-spec, placeholder-drift across stories, file-conflict serialization heuristics).
+
 ## [0.5.0] - 2026-04-24
 
 ### Added — P3 academic-wedge libraries (10 libs)


### PR DESCRIPTION
Release bump for the audit-flag feature (#56) and its supporting docs (#57), shipped via the first full quantum-loop pipeline self-use.

## Bumps

| File | Before | After |
|------|:-:|:-:|
| `.claude-plugin/plugin.json` | 0.5.0 | 0.5.1 |
| `.claude-plugin/marketplace.json` | 0.5.0 | 0.5.1 |
| `.cursor-plugin/plugin.json` | 0.5.0 | 0.5.1 |

## Tag after merge

`git tag v0.5.1 && git push origin v0.5.1`