### PR TITLE
fix: audit — TEST_GLOB impl + phase-dir numeric sort + review fixes

### DIFF
--- a/quantum-loop.sh
+++ b/quantum-loop.sh
@@ -70,8 +70,10 @@ _audit_format_row() {
 # _audit_drill_join NAMES_VAR_REF  (bash-4 nameref pattern)
 # Given an array of offending names, emit at most the first 3 joined with
 # ", " plus "(+N more)" when there's a tail. Empty input → empty string.
+# Requires bash 4.3+ (uses `local -n` nameref). All audit code paths are
+# bash-4-only; older bashes (e.g., macOS default 3.2) are unsupported.
 _audit_drill_join() {
-  local -n _arr="$1"  # nameref
+  local -n _arr="$1"  # nameref (bash 4.3+)
   local n="${#_arr[@]}"
   if (( n == 0 )); then printf ""; return 0; fi
   local head_count=3
@@ -201,11 +203,28 @@ _audit_cpc_files() {
   fi
 }
 
+# _audit_validate_env
+# Validate env-var inputs to the audit before any output is emitted.
+# Per PRD FR-11: QL_AUDIT_TEST_GLOB must match ^[A-Za-z0-9._/*-]+$. On
+# mismatch print error + exit 2. Called from the pre-arg-loop audit
+# shortcut so invalid input never produces a half-rendered audit frame.
+_audit_validate_env() {
+  local test_glob="${QL_AUDIT_TEST_GLOB:-*}"
+  if [[ ! "$test_glob" =~ ^[A-Za-z0-9._/*-]+$ ]]; then
+    printf "Error: invalid QL_AUDIT_TEST_GLOB (must match [A-Za-z0-9._/*-]+)\n" >&2
+    exit 2
+  fi
+}
+
 # _audit_test_suites
 # Inspects the most-recent .omc/phase-*-evidence/ dir for evidence logs
 # matching `=== Results: <P>/<T> passed, <F> failed ===`. Sums P/T/F.
 # OK iff F == 0. When no evidence dir exists, emits unknown/FAIL per FR-10.
+#
+# Filtered by QL_AUDIT_TEST_GLOB (default "*", validated by
+# _audit_validate_env before this helper runs).
 _audit_test_suites() {
+  local test_glob="${QL_AUDIT_TEST_GLOB:-*}"
   local -a dirs=()
   local d
   while IFS= read -r d; do
@@ -216,13 +235,16 @@ _audit_test_suites() {
     printf 'test-suites|unknown|green|FAIL|no evidence logs found — run tests first\n'
     return 0
   fi
-  # Pick latest (lexicographic sort, highest phase number wins)
+  # Pick latest by NUMERIC phase number. Plain `sort` is lexicographic so
+  # phase-9 sorts after phase-43 (wrong). `sort -V` handles version-style
+  # numeric-aware sorting and is available on GNU + BSD + Git Bash.
   local latest
-  latest=$(printf '%s\n' "${dirs[@]}" | sort | tail -1)
+  latest=$(printf '%s\n' "${dirs[@]}" | sort -V | tail -1)
   local sum_p=0 sum_t=0 sum_f=0
   local -a failing=()
   local log line p t f
-  for log in "$latest"/*.log; do
+  # shellcheck disable=SC2231  # intentional glob expansion of validated TEST_GLOB
+  for log in "$latest"/${test_glob}.log; do
     [[ -f "$log" ]] || continue
     line=$({ grep -E '^=== (Final )?Results: [0-9]+/[0-9]+ passed' "$log" 2>/dev/null ; } || true)
     [[ -z "$line" ]] && continue
@@ -288,6 +310,7 @@ if [[ " $* " == *" --audit "* ]]; then
     printf "Error: --audit is exclusive and takes no other arguments\n" >&2
     exit 2
   fi
+  _audit_validate_env
   do_audit
   exit $?
 fi

--- a/tests/test_audit.sh
+++ b/tests/test_audit.sh
@@ -399,16 +399,87 @@ out=$(cd "$TMP" && bash "$REPO_ROOT/quantum-loop.sh" --audit 2>&1 || true)
 rc=$(cd "$TMP" && bash "$REPO_ROOT/quantum-loop.sh" --audit >/dev/null 2>&1 ; echo $?)
 TOTAL=$((TOTAL + 1))
 fail_count=$(printf '%s' "$out" | grep -cE 'FAIL$')
-if [[ "$rc" -eq 1 ]] && (( fail_count >= 4 )) \
+if [[ "$rc" -eq 1 ]] && (( fail_count == 5 )) \
    && printf '%s' "$out" | grep -q 'branches-local.*FAIL' \
    && printf '%s' "$out" | grep -q 'cpc-files.*FAIL' \
    && printf '%s' "$out" | grep -q 'orphan-worktrees.*FAIL' \
+   && printf '%s' "$out" | grep -q 'readme-conflicts.*FAIL' \
    && printf '%s' "$out" | grep -q 'test-suites.*FAIL'; then
-  echo "  PASS: full-flow all-fail (rc=$rc, fail_count=$fail_count)"; PASS=$((PASS + 1))
+  echo "  PASS: full-flow all-fail (rc=$rc, fail_count=5, all 5 metrics FAIL)"; PASS=$((PASS + 1))
 else
   echo "  FAIL: full-flow all-fail (rc=$rc, fail_count=$fail_count)"; FAIL=$((FAIL + 1))
   printf '%s\n' "$out" | sed 's/^/    /' | head -10
 fi
+rm -rf "$TMP"
+
+# --- Review-followup tests (PR #56 improvement + bug fix) ------------------
+
+# Test 25: QL_AUDIT_TEST_GLOB validation rejects shell metacharacters
+echo ""
+echo "Test 25: QL_AUDIT_TEST_GLOB validation"
+TMP=$(setup_audit_repo)
+mkdir -p "$TMP/.omc/phase-99-evidence"
+printf '=== Results: 1/1 passed, 0 failed ===\n' > "$TMP/.omc/phase-99-evidence/test_x.log"
+out=$(cd "$TMP" && QL_AUDIT_TEST_GLOB='; rm -rf /' bash "$REPO_ROOT/quantum-loop.sh" --audit 2>&1 || true)
+rc=$(cd "$TMP" && QL_AUDIT_TEST_GLOB='; rm -rf /' bash "$REPO_ROOT/quantum-loop.sh" --audit >/dev/null 2>&1 ; echo $?)
+TOTAL=$((TOTAL + 1))
+# Validation must fire BEFORE header is printed (clean-exit, no half-audit)
+if [[ "$rc" -eq 2 ]] \
+   && printf '%s' "$out" | grep -q 'invalid QL_AUDIT_TEST_GLOB' \
+   && ! printf '%s' "$out" | grep -q '=== Quantum-loop audit ==='; then
+  echo "  PASS: invalid TEST_GLOB rejected clean (no half-audit frame)"; PASS=$((PASS + 1))
+else
+  echo "  FAIL: TEST_GLOB validation (rc=$rc)"; FAIL=$((FAIL + 1))
+  printf '%s\n' "$out" | head -5 | sed 's/^/    /'
+fi
+rm -rf "$TMP"
+
+# Test 26: QL_AUDIT_TEST_GLOB filter narrows which logs are considered
+echo ""
+echo "Test 26: QL_AUDIT_TEST_GLOB filter"
+TMP=$(setup_audit_repo)
+mkdir -p "$TMP/.omc/phase-99-evidence"
+# Two logs: one with failures, one all-green. Default "*" considers both.
+printf '=== Results: 1/1 passed, 0 failed ===\n' > "$TMP/.omc/phase-99-evidence/test_good.log"
+printf '=== Results: 3/5 passed, 2 failed ===\n' > "$TMP/.omc/phase-99-evidence/test_bad.log"
+# Filter to test_good only → OK, exit 0 (on test-suites alone)
+out_filter=$(cd "$TMP" && QL_AUDIT_TEST_GLOB='test_good' _audit_test_suites)
+# Default filter → includes test_bad → FAIL
+out_default=$(cd "$TMP" && _audit_test_suites)
+TOTAL=$((TOTAL + 1))
+case "$out_filter" in
+  test-suites\|1/1\ passed\|green\|OK\|*) pass_filter=1 ;;
+  *) pass_filter=0 ;;
+esac
+case "$out_default" in
+  test-suites\|4/6\ passed\|green\|FAIL\|*) pass_default=1 ;;
+  *) pass_default=0 ;;
+esac
+if [[ "$pass_filter" -eq 1 && "$pass_default" -eq 1 ]]; then
+  echo "  PASS: TEST_GLOB filter isolates logs correctly"; PASS=$((PASS + 1))
+else
+  echo "  FAIL: filter=[$out_filter] default=[$out_default]"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$TMP"
+
+# Test 27: Numeric sort picks phase-43 over phase-9 (regression guard)
+echo ""
+echo "Test 27: phase-dir sort is numeric, not lexicographic"
+TMP=$(setup_audit_repo)
+# Seed phase-9 with FAILING results and phase-43 with PASSING results.
+# Lexicographic sort picks phase-9 (bug); numeric sort picks phase-43 (fixed).
+# Correct behavior: audit reads phase-43 → OK.
+mkdir -p "$TMP/.omc/phase-9-evidence" "$TMP/.omc/phase-43-evidence"
+printf '=== Results: 0/1 passed, 1 failed ===\n' > "$TMP/.omc/phase-9-evidence/test_z.log"
+printf '=== Results: 5/5 passed, 0 failed ===\n' > "$TMP/.omc/phase-43-evidence/test_z.log"
+out=$(cd "$TMP" && _audit_test_suites)
+case "$out" in
+  test-suites\|5/5\ passed\|green\|OK\|*)
+    echo "  PASS: numeric sort picks phase-43 (not phase-9)"; PASS=$((PASS + 1));;
+  *)
+    echo "  FAIL: phase-sort regression — got [$out]"; FAIL=$((FAIL + 1));;
+esac
+TOTAL=$((TOTAL + 1))
 rm -rf "$TMP"
 
 echo ""


### PR DESCRIPTION
Post-#56 self-review fixes. 4 items:

| Severity | Finding |
|----------|---------|
| improvement | `QL_AUDIT_TEST_GLOB` advertised in PRD but never read/validated |
| correctness (found mid-fix) | Phase-dir sort was lexicographic — `phase-9` > `phase-43`, audit picks wrong "latest" |
| nitpick | `local -n` nameref needs bash 4.3+ (undocumented) |
| nitpick | Test 24 used loose `>= 4` fail-count assertion |

## Key additions

- `_audit_validate_env()` runs BEFORE audit starts printing → clean error/exit, no half-rendered frame
- `_audit_test_suites` now actually uses `$test_glob` to filter log basenames
- `sort -V` replaces plain `sort` for phase-dir numeric ordering

## Tests: 27 → 30 (+3)

- Test 25: TEST_GLOB validation rejects `; rm -rf /`-style input with clean exit 2
- Test 26: TEST_GLOB filter narrows logs (seeded fixture: 2 logs, filter picks 1)
- Test 27: numeric-sort regression guard (phase-9 RED + phase-43 GREEN, audit picks 43)

## Real-world impact

Before: `./quantum-loop.sh --audit` was reading stale `phase-9-evidence/` (lex sort), so `test-suites` reported wrong / outdated counts.

After: reads `phase-43-evidence/` correctly — `test-suites: 106/106 passed`.