### PR TITLE
docs: act on 3 dogfood pipeline findings from #56

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,6 +201,42 @@ You WILL be tempted to take shortcuts. Every one of these will cause failures in
 | Skip reading codebasePatterns | You'll repeat mistakes previous iterations already solved |
 | Add patterns that aren't genuinely reusable | Noise in codebasePatterns misleads future iterations |
 
+## Platform Notes (Git Bash / MSYS / bash 4 gotchas)
+
+Surfaced during pipeline dogfood runs on Git Bash. Apply when authoring
+tests or shell helpers.
+
+**Heredoc line endings on Git Bash:** files written via bash heredoc on
+Git Bash/MSYS land with CRLF endings. `awk $0` captures the trailing
+`\r`; `read -r sig` strips `\n` but not `\r`. When matching or comparing,
+either strip `\r` defensively (`s="${s%$'\r'}"` or `tr -d '\r'`) or
+write fixtures with `printf` instead of heredocs.
+
+**Subshell exit-code capture:** inside `$(cmd 2>&1)` and under
+`set -uo pipefail`, a command that exits non-zero does NOT abort the
+assignment, but the subsequent `rc=$?` captures `$?` of whatever ran
+most recently — if you interpose another command, you lose the original
+exit code. Reliable pattern for tests:
+
+```bash
+out=$(cd "$TMP" && bash script.sh --flag 2>&1 || true)
+rc=$(cd "$TMP" && bash script.sh --flag >/dev/null 2>&1 ; echo $?)
+```
+
+Two invocations — one captures stdout with `|| true`, one captures exit
+code via explicit `; echo $?`. Inelegant but robust across Git Bash /
+MSYS and under strict shell flags.
+
+**bash 4.3+ features:** `local -n` namerefs require bash 4.3+. The
+quantum-loop repo assumes bash 4+ throughout (macOS default 3.2 is
+unsupported). If adding a helper that uses `local -n`, document it in
+the function comment so future readers aren't surprised.
+
+**Lexicographic vs numeric sort on `phase-*` dirs:** plain `sort` puts
+`phase-9` AFTER `phase-43` (because `'9' > '4'`). Use `sort -V` for
+version-style numeric sort anywhere you're finding the "latest" of a
+set of numbered siblings.
+
 ## Signal Reference
 
 | Signal | Meaning |

--- a/agents/conflict-auditor.md
+++ b/agents/conflict-auditor.md
@@ -42,6 +42,16 @@ Discard all entries with only 1 story.
 
 For each conflicting file, determine its severity using the following rules, evaluated in priority order (first match wins):
 
+#### Rule 0: None Severity -- Already Serialized via DAG
+
+**Evaluated BEFORE all other rules.** If every pair of stories in the conflict set has a direct or transitive `dependsOn` relationship (i.e., the stories form a chain in the DAG such that no two can be co-scheduled), classify as `"none"` — the conflict is benign because the stories cannot run concurrently. The downstream story always sees the upstream story's committed state when it runs.
+
+**Algorithm:** Build a transitive-closure reachability map from the `dependsOn` edges. For each unordered pair `(A, B)` in the conflict set, check whether A reaches B or B reaches A in the closure. If every pair has at least one direction of reachability, the set is totally ordered — classify `"none"`.
+
+**Why:** Without this rule, features that serialize shared-file edits via an explicit `dependsOn` chain (a common and correct pattern for small features that all edit one driver file) get flagged `"high"` for a non-problem. The user then wonders whether they're doing something wrong. They aren't — the DAG already guarantees no concurrent edits.
+
+**Note on reporting:** Even when classified `"none"`, the conflict SHOULD still appear in the `fileConflicts` output with `severity: "none"` so tooling can distinguish "no conflict possible (serialized)" from "no conflict examined yet." A `"none"` entry is informational; it does not trigger any synthetic edges or escalation.
+
 #### Rule 1: High Severity -- Barrel/Index Files
 
 Extract the basename of the file path (the filename without directory components). If the basename matches any entry in the `barrelFilePatterns` array, classify as `"high"`.
@@ -109,7 +119,7 @@ Each entry contains:
 
 - **files**: Array with a single file path string (the conflicting file)
 - **stories**: Array of all story IDs that touch this file, sorted alphabetically
-- **severity**: One of `"high"`, `"medium"`, or `"low"` as determined by Step 3
+- **severity**: One of `"none"`, `"high"`, `"medium"`, or `"low"` as determined by Step 3. `"none"` means the stories are totally ordered via `dependsOn` and cannot run concurrently — informational only, no remediation needed.
 
 Sort the `fileConflicts` array by severity (high first, then medium, then low), and alphabetically by file path within the same severity level.
 

--- a/skills/ql-spec/SKILL.md
+++ b/skills/ql-spec/SKILL.md
@@ -56,7 +56,7 @@ Treat `brainstorm.decided` as binding (already agreed — do not re-litigate), `
 
 ## Step 2: Ask Clarifying Questions
 
-Ask 5-8 clarifying questions. Format each with LETTERED OPTIONS so the user can respond with shorthand like "1A, 2C, 3B, 4D, 5A".
+Ask **2-8 clarifying questions** — count adaptive to remaining ambiguity (see Question Rules below). Format each with LETTERED OPTIONS so the user can respond with shorthand like "1A, 2C, 3B, 4D, 5A".
 
 Focus questions on areas where the design doc (if any) is ambiguous or incomplete:
 
@@ -86,12 +86,16 @@ Focus questions on areas where the design doc (if any) is ambiguous or incomplet
 ```
 
 ### Question Rules
-- Minimum 5 questions, maximum 8
+- **Question count is adaptive to remaining ambiguity, not a hard minimum.**
+  - If there is **no design doc** and the feature is non-trivial: ask **5-8** questions.
+  - If a **design doc exists** and answers most of Phase 1's concerns: ask only what the design doc leaves ambiguous — typically **2-4** questions. Padding beyond that produces release-ops / non-goal-confirmation questions that don't belong in a PRD.
+  - Absolute floor: **ask at least 2** questions so the user has a chance to correct course before the PRD is saved. Absolute ceiling: **8**.
 - Every question MUST have lettered options (A, B, C, D)
-- At least one question must probe NON-GOALS (what it should NOT do)
-- At least one question must probe ERROR SCENARIOS
+- At least one question MUST probe NON-GOALS (what it should NOT do)
+- At least one question MUST probe ERROR SCENARIOS
 - Do NOT ask implementation questions (framework choice, library selection)
 - If a design doc exists, do NOT re-ask questions already answered there
+- **Count-quality test:** before each question, ask yourself "is this question answered in the design doc, or would its answer materially change the PRD?" If neither, don't ask it — shallow padding is worse than fewer questions.
 
 ## Step 3: Generate the PRD
 
@@ -190,7 +194,7 @@ Every criterion must answer: "How would a machine verify this?"
 
 | Excuse | Reality |
 |--------|---------|
-| "Fewer than 5 questions is enough" | Shallow questions produce ambiguous specs. Ask at least 5. |
+| "I'll pad questions to hit 5" | Padding past real ambiguity produces release-ops / non-goal-confirmation questions that don't belong in a PRD. If the design doc answers most of Phase 1, ask only what remains genuinely open — 2-4 is fine. The floor is 2, not 5. |
 | "This story is slightly too big but it's fine" | Too-big stories fail during autonomous execution. Split ruthlessly. |
 | "The acceptance criteria are obvious" | Obvious to you is ambiguous to an AI agent. Be explicit. |
 | "Non-goals aren't needed for this feature" | Unbounded scope is the root of scope creep. Always define boundaries. |
@@ -200,7 +204,7 @@ Every criterion must answer: "How would a machine verify this?"
 ## Pre-Save Checklist
 
 Before saving the PRD, verify:
-- [ ] Asked at least 5 clarifying questions with lettered options
+- [ ] Asked 2-8 clarifying questions with lettered options (count adapted to remaining ambiguity — see Question Rules)
 - [ ] Incorporated user's answers into the PRD
 - [ ] Every user story fits in one context window
 - [ ] Every acceptance criterion is machine-verifiable


### PR DESCRIPTION
Surfaced during the first real self-use of `/ql-brainstorm` → `/ql-spec` → `/ql-plan` → `/ql-execute` on the --audit feature.

## Changes

| # | File | Fix |
|---|------|-----|
| 1 | `skills/ql-spec/SKILL.md` | Question count is now **adaptive** (2-8) to remaining ambiguity, not hard minimum 5. Anti-rationalization row rewritten to target over-asking. |
| 2 | `agents/conflict-auditor.md` | New **Rule 0**: stories with a direct-or-transitive `dependsOn` chain classify as `"none"` severity — the DAG already prevents concurrent edits. |
| 3 | `CLAUDE.md` | New **Platform Notes** section: Git Bash CRLF heredoc gotcha, subshell exit-code capture pattern, bash 4.3+ nameref requirement, `sort -V` for phase-dir numeric sort. |

## Why

All three were real rough edges in the dogfood run:

1. `/ql-spec` forced 5+ questions when the design doc answered most; padded with non-goal confirmations.
2. Conflict-auditor flagged audit-flag's 4-story linear chain as `"high"` severity with a manual footnote "already serialized via dependsOn" — a future automated flow would miss that nuance.
3. Each of the CLAUDE.md gotchas bit during test authoring (Test 5 CRLF mismatch, Tests 5/6 subshell exit-code mangling, phase-9-vs-phase-43 sort bug).

No code change — skill/agent prompts and CLAUDE.md guidance.

## Test plan

- [x] Master test suite unchanged — these are documentation/prompt files
- [ ] Next `/ql-spec` run should ask fewer questions when design doc is present (verify in follow-up dogfood)
- [ ] Next `/ql-plan` validator run should classify linear-chain shared-file conflicts as `"none"` (verify in follow-up dogfood)