### PR TITLE
chore(release): v0.6.2 — G10 PRD-sha migration shim + .cursor-plugin catch-up

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Universal CLI orchestrator with multi-runner support. Autonomous spec-driven development pipeline with dependency DAG, parallel worktree execution, two-stage review gates, DAG intelligence validation, and modular merge hardening",
-    "version": "0.6.1"
+    "version": "0.6.2"
   },
   "plugins": [
     {
       "name": "quantum-loop",
       "source": "./",
       "description": "6 skills (brainstorm, spec, plan, execute, verify, review) and 5 agents for autonomous spec-driven development with multi-runner support, DAG intelligence, and modular merge hardening",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "keywords": ["autonomous", "prd", "tdd", "verification", "review", "planning", "agent-loop", "multi-runner", "codex", "copilot", "gemini", "universal-orchestrator"],
       "category": "productivity"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "quantum-loop",
   "description": "Universal CLI orchestrator with multi-runner support. Autonomous spec-driven development with dependency DAG, parallel worktree execution, two-stage review gates, and modular merge hardening.",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "author": {
     "name": "andyzengmath"
   }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "quantum-loop",
-  "version": "0.5.1",
+  "version": "0.6.2",
   "description": "Spec-driven autonomous development loop with DAG-based execution, parallel worktree agents, two-stage review gates, and Iron Law verification. Turns a feature description into verified, reviewed, autonomously-implemented code.",
   "author": {
     "name": "andyzengmath"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ Format: [Semantic Versioning](https://semver.org/). Bump per PR:
 - **Minor** (0.x.0): new features, backward-compatible
 - **Major** (x.0.0): breaking changes
 
+## [0.6.2] - 2026-04-26
+
+### Fixed
+
+Two follow-up items from the v0.6.x cycle's `/soliton:pr-review` post-merge findings (IDEA_REPORT_v3 §G10 + score-100 .cursor-plugin gap):
+
+- **G10 — `lib/json-atomic.sh` PRD-sha migration shim** (`compute_prd_sha_legacy` + `verify_prd_sha`). Before v0.6.1, `compute_prd_sha` did not normalize CRLF; Windows users with `autocrlf=true` who ran `/ql-plan` under v0.6.0 stored CRLF-era hashes. After upgrading to v0.6.1, the same PRD now hashes differently — every story's `prdSha` would be marked `stale` and force a full `/ql-plan` re-run. v0.6.2 adds a transparent migration: `verify_prd_sha` tries the new (LF-normalized) hash first; on mismatch, falls back to the legacy (v0.6.0) hash; if THAT matches, the orchestrator's Step 1.1 updates the stored value in-place with a single one-line "MIGRATE" log message and no re-plan. Real drift still marks the story stale as before. 3 new tests added (match / migrate / drift paths) + 1 orchestrator-wiring test.
+- **`.cursor-plugin/plugin.json` version catch-up bump 0.5.1 → 0.6.2** — the v0.6.0 + v0.6.1 cycle bumped `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` but the Cursor manifest was missed. PR #58 established the convention of moving all three plugin manifests in lockstep on every release; `/soliton:pr-review` flagged this at score 100 on PR #61 but the fix landed here. Cursor marketplace consumers will now see v0.6.2 in sync with the Claude side.
+
+### Backward compatibility
+
+The migration path is transparent: existing v0.6.0/v0.6.1 `quantum.json` files load and run without operator action. The first orchestrator pass after upgrade silently rewrites legacy `prdSha` values to the new format. Stories without a `prdSha` field continue to behave exactly as before (back-compat warning logged once).
+
 ## [0.6.1] - 2026-04-26
 
 ### Fixed

--- a/agents/orchestrator.md
+++ b/agents/orchestrator.md
@@ -60,12 +60,31 @@ for story_id in $(jq -r '.stories[].id' "$JSON_PATH"); do
     echo "[PRD-HASH] $story_id has no prdSha — proceeding (back-compat)" >&2
     continue
   fi
-  if [[ "$STORED_SHA" != "$CURRENT_PRD_SHA" ]]; then
-    echo "[PRD-HASH] $story_id WARNING: stored prdSha=${STORED_SHA:0:12} != current=${CURRENT_PRD_SHA:0:12}; marking stale (re-plan needed)" >&2
-    jq --arg id "$story_id" '
-      (.stories[] | select(.id==$id) | .status) = "stale"
-    ' "$JSON_PATH" > "$JSON_PATH.tmp" && mv "$JSON_PATH.tmp" "$JSON_PATH"
-  fi
+  # G10 / v0.6.2 — verify_prd_sha returns:
+  #   "match"                  — story is up-to-date
+  #   "migrate <new-sha>"      — stored is the v0.6.0 legacy form (pre-CRLF-fix);
+  #                              update field instead of marking stale (transparent
+  #                              upgrade for Windows users with autocrlf=true).
+  #   exit 1 + stderr "drift…" — real PRD drift; mark story stale as before.
+  VERIFY_RESULT=$(verify_prd_sha "$STORED_SHA" "$PRD_PATH" 2>/dev/null) || VERIFY_RESULT="drift"
+  case "$VERIFY_RESULT" in
+    match)
+      : # silent — story is up-to-date
+      ;;
+    migrate*)
+      NEW_SHA="${VERIFY_RESULT#migrate }"
+      echo "[PRD-HASH] $story_id MIGRATE: legacy v0.6.0 prdSha format detected; updating in-place to v0.6.1+ LF-normalized hash (no re-plan needed)" >&2
+      jq --arg id "$story_id" --arg sha "$NEW_SHA" '
+        (.stories[] | select(.id==$id) | .prdSha) = $sha
+      ' "$JSON_PATH" > "$JSON_PATH.tmp" && mv "$JSON_PATH.tmp" "$JSON_PATH"
+      ;;
+    *)
+      echo "[PRD-HASH] $story_id WARNING: stored prdSha=${STORED_SHA:0:12} != current=${CURRENT_PRD_SHA:0:12}; marking stale (re-plan needed)" >&2
+      jq --arg id "$story_id" '
+        (.stories[] | select(.id==$id) | .status) = "stale"
+      ' "$JSON_PATH" > "$JSON_PATH.tmp" && mv "$JSON_PATH.tmp" "$JSON_PATH"
+      ;;
+  esac
 done
 ```
 

--- a/lib/json-atomic.sh
+++ b/lib/json-atomic.sh
@@ -32,6 +32,53 @@ print(hashlib.sha256(content).hexdigest())
 " "$prd_path"
 }
 
+# compute_prd_sha_legacy(prd_path)
+# G10 / P5.A5 v0.6.0 compatibility — pre-v0.6.1 hash that did NOT normalize
+# CRLF before stripping trailing whitespace. Used by verify_prd_sha to detect
+# upgrade-path mismatches and trigger one-shot migration without forcing a
+# full /ql-plan re-run on Windows users with autocrlf=true checkouts.
+compute_prd_sha_legacy() {
+  local prd_path="${1:?compute_prd_sha_legacy: PRD path required}"
+  if [[ ! -f "$prd_path" ]]; then
+    printf "ERROR: compute_prd_sha_legacy: file not found: %s\n" "$prd_path" >&2
+    return 1
+  fi
+  python3 -c "
+import sys, hashlib
+with open(sys.argv[1], 'rb') as f:
+    content = f.read().rstrip(b' \t\n\r')
+print(hashlib.sha256(content).hexdigest())
+" "$prd_path"
+}
+
+# verify_prd_sha(stored_sha, prd_path)
+# G10 / P5.A5 v0.6.2 — compares stored_sha against the PRD's current sha,
+# falling back to the legacy (v0.6.0) hash on miss to detect upgrade paths.
+# Returns one of:
+#   exit 0 + stdout "match"            — stored == current (already on v0.6.1+ format)
+#   exit 0 + stdout "migrate <new-sha>" — stored == legacy v0.6.0 sha; caller should
+#                                         update the field with the new value rather
+#                                         than mark the story stale.
+#   exit 1 + stderr "drift: ..."        — neither matches; real PRD drift.
+verify_prd_sha() {
+  local stored="${1:?verify_prd_sha: stored sha required}"
+  local prd_path="${2:?verify_prd_sha: PRD path required}"
+  local current legacy
+  current=$(compute_prd_sha "$prd_path") || return 1
+  if [[ "$stored" == "$current" ]]; then
+    printf "match\n"
+    return 0
+  fi
+  legacy=$(compute_prd_sha_legacy "$prd_path") || return 1
+  if [[ "$stored" == "$legacy" ]]; then
+    printf "migrate %s\n" "$current"
+    return 0
+  fi
+  printf "drift: stored=%s current=%s legacy=%s\n" \
+    "${stored:0:12}" "${current:0:12}" "${legacy:0:12}" >&2
+  return 1
+}
+
 # write_quantum_json(json_path, content)
 # Writes content to json_path atomically via a .tmp intermediate file.
 # Validates that content is non-empty and valid JSON before writing.

--- a/tests/test_prd_hash_pinning.sh
+++ b/tests/test_prd_hash_pinning.sh
@@ -165,6 +165,49 @@ else
   echo "  FAIL: quantum.json.example missing prdSha"; FAIL=$((FAIL + 1))
 fi
 
+# Test 7: verify_prd_sha — match path (v0.6.2 G10 helper)
+echo ""
+echo "Test 7: verify_prd_sha — match path"
+PRD_M="$TMP/prd-match.md"
+printf "v0.6.1+ PRD\nLF only\n" > "$PRD_M"
+SHA_M=$(compute_prd_sha "$PRD_M")
+RES_M=$(verify_prd_sha "$SHA_M" "$PRD_M")
+assert_eq "verify_prd_sha returns 'match' when stored == current" "match" "$RES_M"
+
+# Test 8: verify_prd_sha — migrate path (v0.6.0 legacy → v0.6.1+ format)
+echo ""
+echo "Test 8: verify_prd_sha — migrate path (v0.6.0 CRLF legacy hash)"
+PRD_L="$TMP/prd-legacy.md"
+printf "Windows v0.6.0 PRD\r\nwith CRLF\r\nstored under legacy hash\r\n" > "$PRD_L"
+LEGACY_SHA=$(compute_prd_sha_legacy "$PRD_L")
+NEW_SHA=$(compute_prd_sha "$PRD_L")
+assert_neq "legacy and new hashes differ for CRLF input" "$LEGACY_SHA" "$NEW_SHA"
+RES_L=$(verify_prd_sha "$LEGACY_SHA" "$PRD_L")
+assert_eq "verify_prd_sha returns 'migrate <new>' for legacy stored sha" "migrate $NEW_SHA" "$RES_L"
+
+# Test 9: verify_prd_sha — drift path (neither matches)
+echo ""
+echo "Test 9: verify_prd_sha — drift path"
+PRD_D="$TMP/prd-drift.md"
+printf "real content unrelated to fake sha\n" > "$PRD_D"
+TOTAL=$((TOTAL + 1))
+if ! verify_prd_sha "deadbeef0000000000000000000000000000000000000000000000000000dead" "$PRD_D" 2>/dev/null; then
+  echo "  PASS: unrelated sha returns non-zero (drift)"; PASS=$((PASS + 1))
+else
+  echo "  FAIL: drift path"; FAIL=$((FAIL + 1))
+fi
+
+# Test 10: orchestrator.md references verify_prd_sha + migrate path
+echo ""
+echo "Test 10: orchestrator.md Step 1.1 wires verify_prd_sha + migrate case"
+TOTAL=$((TOTAL + 1))
+if grep -qF "verify_prd_sha" "$REPO_ROOT/agents/orchestrator.md" \
+   && grep -qF "migrate" "$REPO_ROOT/agents/orchestrator.md"; then
+  echo "  PASS: orchestrator references verify_prd_sha + migrate"; PASS=$((PASS + 1))
+else
+  echo "  FAIL: orchestrator missing verify_prd_sha or migrate handling"; FAIL=$((FAIL + 1))
+fi
+
 # Cleanup
 rm -rf "$TMP"
 


### PR DESCRIPTION
## Summary

- **G10 (PRD-sha migration shim)** — transparent upgrade path for Windows users running v0.6.0 → v0.6.1+. `verify_prd_sha` falls back to the legacy hash on miss and migrates the stored value in-place rather than marking the story stale.
- **`.cursor-plugin/plugin.json` catch-up bump** 0.5.1 → 0.6.2. Aligns the three plugin manifests per the PR #58 lockstep convention. Was the only score-100 finding from `/soliton:pr-review` on PR #61.

## Why now

`idea-stage/IDEA_REPORT_v3.md` §G10 explicitly recommended G10 as a v0.6.2 patch standalone before any v0.7 work. The fix is small (≤1 story), upgrade-path-affecting, and worth shipping ahead of the bigger v0.7.0 cycle.

## Changes

| File | Change |
|---|---|
| `lib/json-atomic.sh` | + `compute_prd_sha_legacy()` (pre-v0.6.1 hash), + `verify_prd_sha()` (returns match / migrate / drift) |
| `agents/orchestrator.md` Step 1.1 | Case-switch on verify_prd_sha result; migrate case updates prdSha in-place rather than marking stale |
| `tests/test_prd_hash_pinning.sh` | +5 assertions covering match / migrate (real CRLF input) / drift / orchestrator-wiring |
| `.claude-plugin/plugin.json` | 0.6.1 → 0.6.2 |
| `.claude-plugin/marketplace.json` | 0.6.1 → 0.6.2 (both metadata.version + plugins[0].version) |
| `.cursor-plugin/plugin.json` | **0.5.1 → 0.6.2** (catch-up; was missed in v0.6.0 + v0.6.1 cycles) |
| `CHANGELOG.md` | v0.6.2 entry |

## Test plan

- [x] `bash tests/test_prd_hash_pinning.sh` → 17/17 pass (was 12)
- [x] `bash tests/test_orchestrator_wiring.sh` → 113/113 pass (no regression)
- [x] `bash tests/test_json_atomic.sh` → 19/19 pass (no regression)
- [x] Migration round-trip verified with real CRLF fixture (Test 8)
- [x] All 4 plugin manifest versions read 0.6.2

## Backward compatibility

Transparent — existing v0.6.0/v0.6.1 `quantum.json` files load + run without operator action. First orchestrator pass after upgrade silently rewrites legacy `prdSha` values to the new format with a single one-line `[PRD-HASH] <story> MIGRATE: ...` log message. Stories without `prdSha` continue to behave exactly as before. Real PRD drift still marks the story stale.

## Out of scope (queued for v0.7.0 per IDEA_REPORT_v3.md)

- G8 — critic fallback divergence (parse_critic_arg vs parse_role_arg vs PS1)
- G9 — orchestrator Step 2.5 expectedTests filter (typecheck/lint mixed in)
- G11 — write_routing_snapshot canonicalization via write_quantum_json
- G2, G3 (existing v0.6.0 dogfood backlog)
- P5.B2-B5 (bidirectional reviewer, /ultrareview, spec-review-before-impl, AgentGA tournament)