### PR TITLE
feat: v0.7.2 — patch-tier (N24, G22-second-pass + retrospective)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Universal CLI orchestrator with multi-runner support. Autonomous spec-driven development pipeline with dependency DAG, parallel worktree execution, two-stage review gates, DAG intelligence validation, and modular merge hardening",
-    "version": "0.7.1"
+    "version": "0.7.2"
   },
   "plugins": [
     {
       "name": "quantum-loop",
       "source": "./",
       "description": "6 skills (brainstorm, spec, plan, execute, verify, review) and 5 agents for autonomous spec-driven development with multi-runner support, DAG intelligence, and modular merge hardening",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "keywords": [
         "autonomous",
         "prd",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "quantum-loop",
   "description": "Universal CLI orchestrator with multi-runner support. Autonomous spec-driven development with dependency DAG, parallel worktree execution, two-stage review gates, and modular merge hardening.",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "author": {
     "name": "andyzengmath"
   }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "quantum-loop",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Spec-driven autonomous development loop with DAG-based execution, parallel worktree agents, two-stage review gates, and Iron Law verification. Turns a feature description into verified, reviewed, autonomously-implemented code.",
   "author": {
     "name": "andyzengmath"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,14 +13,14 @@ Format: [Semantic Versioning](https://semver.org/). Bump per PR:
 
 2 user-facing changes closing the IDEA_REPORT_v12 v0.7.2 slate (N24, G22-second-pass) + 1 retrospective. **Eighth multi-cycle populated-CSV run** — ledger 21 → 24 rows. Patch-tier; 3-story compact bundle. v0.7.2 diff self-validated: tier=LOW score=10 files=4 sensitive=0 → skip recorded with `automated:true`. **8 consecutive LOW-tier self-validations** (v0.6.5..v0.7.2).
 
-- **N24 — `wrap_orchestrator_dispatch` QL_RESPAWN_CMD auto-respawn** (US-001) — `lib/orchestrator-liveness.sh::wrap_orchestrator_dispatch` gains `QL_RESPAWN_CMD` env-var branch. When non-empty and STALE detected, executes `bash -c "${QL_RESPAWN_CMD}"` and returns its exit code instead of emitting the manual-takeover handoff. When empty/unset, v0.7.1 behavior unchanged (handoff + return 1). Operator sets `QL_RESPAWN_CMD` to a fully-specified orchestrator invocation to enable unattended auto-respawn. Tests 8 + 9 (4 new assertions): Test 8 — `QL_RESPAWN_CMD="echo respawned"` + stale repo → "respawned" in stdout + rc=0; Test 9 — unset + stale → handoff + rc=1 (regression guard). 18 → 22 liveness tests.
+- **N24 — `wrap_orchestrator_dispatch` QL_RESPAWN_CMD auto-respawn** (US-001) — `lib/orchestrator-liveness.sh::wrap_orchestrator_dispatch` gains `QL_RESPAWN_CMD` env-var branch. When non-empty and STALE detected, executes `bash -c "${QL_RESPAWN_CMD}"` and returns its exit code instead of emitting the manual-takeover handoff. When empty/unset, v0.7.1 behavior unchanged (handoff + return 1). Operator sets `QL_RESPAWN_CMD` to a fully-specified orchestrator invocation to enable unattended auto-respawn. Tests 8 + 9 + 10 (6 new assertions, 2 added in post-soliton inline fix): Test 8 — `QL_RESPAWN_CMD="echo respawned"` + stale repo → "respawned" in stdout + rc=0 + wall-clock ≤10s; Test 9 — unset + stale → handoff + rc=1 (regression guard); Test 10 — `QL_RESPAWN_CMD="exit 42"` + stale → rc=42 (exit-code propagation). 18 → 24 liveness tests.
 - **G22 second calibration pass** (US-002) — `references/severity-rubric-calibration-v0.7.2.md` created: updated empirical tables (8-cycle / 57-finding baseline), bundle-tier comparison axis (patch-tier 7 cycles vs minor-tier 1 cycle — v0.7.0). Key finding: patch-tier HIGH=4.1% vs minor-tier HIGH=12.5% — directionally confirms v0.7.0 first-pass hypothesis that HIGH under-classification was patch-tier-skew driven, not rubric miscalibration. MEDIUM stable across tiers (~25%). `CLAUDE.md` Process references updated from v0.7.0 to v0.7.2 calibration doc.
 
 ### Test-suite delta
 
 **+4 new assertions** in 1 extended test file:
 
-- 1 extended: `test_orchestrator_liveness.sh` 18 → 22 (+4 N24 Tests 8 + 9)
+- 1 extended: `test_orchestrator_liveness.sh` 18 → 24 (+6 N24 Tests 8+9+10 + soliton wall-clock fix)
 
 ### Dogfood milestone (v0.7.2)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ Format: [Semantic Versioning](https://semver.org/). Bump per PR:
 - **Minor** (0.x.0): new features, backward-compatible
 - **Major** (x.0.0): breaking changes
 
+## [0.7.2] - 2026-04-28
+
+### Added
+
+2 user-facing changes closing the IDEA_REPORT_v12 v0.7.2 slate (N24, G22-second-pass) + 1 retrospective. **Eighth multi-cycle populated-CSV run** — ledger 21 → 24 rows. Patch-tier; 3-story compact bundle. v0.7.2 diff self-validated: tier=LOW score=10 files=4 sensitive=0 → skip recorded with `automated:true`. **8 consecutive LOW-tier self-validations** (v0.6.5..v0.7.2).
+
+- **N24 — `wrap_orchestrator_dispatch` QL_RESPAWN_CMD auto-respawn** (US-001) — `lib/orchestrator-liveness.sh::wrap_orchestrator_dispatch` gains `QL_RESPAWN_CMD` env-var branch. When non-empty and STALE detected, executes `bash -c "${QL_RESPAWN_CMD}"` and returns its exit code instead of emitting the manual-takeover handoff. When empty/unset, v0.7.1 behavior unchanged (handoff + return 1). Operator sets `QL_RESPAWN_CMD` to a fully-specified orchestrator invocation to enable unattended auto-respawn. Tests 8 + 9 (4 new assertions): Test 8 — `QL_RESPAWN_CMD="echo respawned"` + stale repo → "respawned" in stdout + rc=0; Test 9 — unset + stale → handoff + rc=1 (regression guard). 18 → 22 liveness tests.
+- **G22 second calibration pass** (US-002) — `references/severity-rubric-calibration-v0.7.2.md` created: updated empirical tables (8-cycle / 57-finding baseline), bundle-tier comparison axis (patch-tier 7 cycles vs minor-tier 1 cycle — v0.7.0). Key finding: patch-tier HIGH=4.1% vs minor-tier HIGH=12.5% — directionally confirms v0.7.0 first-pass hypothesis that HIGH under-classification was patch-tier-skew driven, not rubric miscalibration. MEDIUM stable across tiers (~25%). `CLAUDE.md` Process references updated from v0.7.0 to v0.7.2 calibration doc.
+
+### Test-suite delta
+
+**+4 new assertions** in 1 extended test file:
+
+- 1 extended: `test_orchestrator_liveness.sh` 18 → 22 (+4 N24 Tests 8 + 9)
+
+### Dogfood milestone (v0.7.2)
+
+**2/2 user-facing stories shipped first-attempt PASS** under manual takeover (6th consecutive cycle). 0 retries. **Multi-cycle CSV milestone**: 21 → 24 rows. Aggregate across 8 cycles: 57 findings (0 critical / 3 high / 13 medium / 41 low; LOW share 71.9%). **G30 self-validation** (8th consecutive correct LOW classification): tier=LOW score=10 files=4 sensitive=0 → skip; recorded with `automated:true`. Full retrospective: `idea-stage/PIPELINE_REPORT_v13.md`. v0.8.0+ backlog: `idea-stage/IDEA_REPORT_v13.md`.
+
 ## [0.7.1] - 2026-04-28
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -266,11 +266,12 @@ Test-related, and Process-related.
   validate-before-design workflow for sub-threshold (<85) `/soliton:pr-review`
   findings the operator chooses to address in the next cycle. Worked
   example: v0.6.7 G36 hallucination.
-- [`references/severity-rubric-calibration-v0.7.0.md`](references/severity-rubric-calibration-v0.7.0.md):
-  v0.7.0 first calibration pass of `references/finding-severity.md`
-  against the 6-cycle / 18-row CSV baseline. Empirical aggregate:
-  49 findings, 0/3/13/33 (critical/high/medium/low). Re-snapshot at
-  v0.7.x retrospectives via the companion parse-script.
+- [`references/severity-rubric-calibration-v0.7.2.md`](references/severity-rubric-calibration-v0.7.2.md):
+  v0.7.2 second calibration pass of `references/finding-severity.md`
+  against the 8-cycle / 24-row CSV baseline. Empirical aggregate:
+  57 findings, 0/3/13/41 (critical/high/medium/low). Bundle-tier
+  comparison: patch-tier HIGH 4.1% vs minor-tier HIGH 12.5% (n=1).
+  Re-snapshot at v0.8.0+ via the companion parse-script.
 
 ## Signal Reference
 

--- a/idea-stage/IDEA_REPORT_v13.md
+++ b/idea-stage/IDEA_REPORT_v13.md
@@ -1,0 +1,81 @@
+# IDEA_REPORT_v13 — what's still open after v0.7.2
+
+**Date:** 2026-04-28
+**Source:** `ql/v0.7.2-bundle` dogfood retrospective (US-003)
+**Branch:** `ql/v0.7.2-bundle` (release tag v0.7.2)
+**Predecessor:** `idea-stage/IDEA_REPORT_v12.md`
+
+## Closed in v0.7.2
+
+| ID | Story | Notes |
+|---|---|---|
+| **N24** | US-001 | `lib/orchestrator-liveness.sh::wrap_orchestrator_dispatch` QL_RESPAWN_CMD auto-respawn branch. Tests 8+9 (4 new assertions). 18 → 22 liveness tests. |
+| **G22 second pass** | US-002 | `references/severity-rubric-calibration-v0.7.2.md` with bundle-tier comparison axis. CLAUDE.md ref updated. |
+
+The **N24 + G22-second-pass cluster** (the v0.7.2 priority list from IDEA_REPORT_v12) is now **fully closed**.
+
+## Persistent canon
+
+p001-p011 unchanged. Source-of-truth: `idea-stage/PIPELINE_REPORT_v7.md` § "codebasePatterns harvested".
+
+## Multi-cycle CSV milestone (24 rows, 57 findings, 8 cycles)
+
+| Cycle | design | prd | plan | total |
+|---|---|---|---|---:|
+| v0.6.5 | 0/0/0/1 | 0/0/0/4 | 0/0/0/0 | 5 |
+| v0.6.6 | 0/0/0/0 | 0/2/4/3 | 0/0/0/1 | 10 |
+| v0.6.7 | 0/0/1/2 | 0/0/2/3 | 0/0/0/2 | 10 |
+| v0.6.8 | 0/0/1/2 | 0/0/1/2 | 0/0/0/2 | 8 |
+| v0.6.9 | 0/0/1/2 | 0/0/1/2 | 0/0/0/2 | 8 |
+| v0.7.0 | 0/1/1/1 | 0/0/1/2 | 0/0/0/2 | 8 |
+| v0.7.1 | 0/0/0/2 | 0/0/0/1 | 0/0/0/1 | 4 |
+| v0.7.2 | 0/0/0/2 | 0/0/0/1 | 0/0/0/1 | 4 |
+| **Total** | **0/1/4/12** | **0/2/9/18** | **0/0/0/11** | **57** |
+
+Severity distribution: **0 critical / 3 high / 13 medium / 41 low (0% / 5.3% / 22.8% / 71.9%)**.
+
+Key observations from G22 second calibration pass:
+- HIGH under-classification confirmed as **patch-tier-skew**, not rubric miscalibration (minor-tier HIGH 12.5% vs patch-tier 4.1%).
+- MEDIUM stable across tiers (~25%) — rubric working as intended.
+- plan-review STILL 100% LOW (11/11 rows across 8 cycles).
+
+## Still open after v0.7.2
+
+### G19 / G21 / G24 / P5.B2/B3/B5 / P5.C frontier
+**Status:** unchanged from v0.7.0. Defer indefinitely.
+
+## New gaps from v0.7.2 dogfood
+
+### N25 — QL_RESPAWN_CMD not exercised end-to-end in CI
+**Surfaced:** N24 ships the auto-respawn branch but tests use `echo respawned` stub. No test exercises a real claude invocation. Future minor-tier cycle could add a smoke-test that verifies the respawn command is a valid CLI invocation form.
+**Severity:** LOW (test coverage gap, not a functional bug).
+**Path:** Track for a future minor-tier bundle or reactive patch if auto-respawn is adopted by operators.
+
+### N26 — plan-review MEDIUM still not triggered after 8 cycles
+**Surfaced:** N18 (v0.7.1) added second MEDIUM example to plan-review rubric. v0.7.1 and v0.7.2 both emitted 1 LOW for plan-review. The example has not surfaced a real MEDIUM across 8 cycles.
+**Severity:** LOW (calibration-data observation).
+**Path:** Track. A minor-tier cycle with complex multi-wave DAG is the most likely trigger. No rubric action until triggered.
+
+### N27 — G22 third calibration pass needs more minor-tier data
+**Surfaced:** G22 second pass had n=1 minor-tier data point. Third calibration pass needs 2-3 minor-tier cycles for statistical comparison.
+**Severity:** LOW (calibration-data scarcity).
+**Path:** Track for v0.8.0+ retrospective when minor-tier cycles accumulate.
+
+## Recommendation for v0.7.3 or v0.8.0
+
+**v0.7.3 candidate slate (patch-tier):**
+The patch-tier backlog is drained again. N25/N26/N27 are observations, not actionable items. A v0.7.3 patch would be purely reactive (soliton finding or operator-discovered issue).
+
+**Suggestion:** Skip v0.7.3 unless a reactive item surfaces. The next substantive cycle is **v0.8.0 minor-tier** with new feature scope (TBD by operator).
+
+**v0.8.0 candidate slate (minor tier):**
+1. **New feature** — TBD; would need a feature-driven v0.8.0 PRD authored separately.
+2. **G22 third calibration pass** — needs at least 1 more minor-tier data point first (the v0.8.0 release itself would provide that).
+3. **QL_RESPAWN_CMD operator docs** — if auto-respawn adoption warrants it.
+
+## Recurring observations
+
+- **8 consecutive LOW-tier self-validations** (v0.6.5..v0.7.2). G30 calibration consistent.
+- **6 consecutive manual-takeover cycles** with 0-retry first-attempt PASS. 5-layer recovery infrastructure complete. Auto-respawn requires operator to set QL_RESPAWN_CMD explicitly — manual-takeover may continue until operators adopt it.
+- **Bundle size trend: 7-7-7-7-5-6-5-3.** v0.7.2 is the smallest bundle yet (3 stories). Patch-tier track mature.
+- **Plan-review 100% LOW (11/11)** across 8 cycles. Second MEDIUM example (N18) not yet triggered.

--- a/idea-stage/PIPELINE_REPORT_v13.md
+++ b/idea-stage/PIPELINE_REPORT_v13.md
@@ -1,0 +1,67 @@
+# PIPELINE_REPORT_v13 — v0.7.2 dogfood retrospective
+
+**Date:** 2026-04-28
+**Bundle:** `ql/v0.7.2-bundle` (release tag v0.7.2)
+**Predecessor report:** `idea-stage/PIPELINE_REPORT_v12.md`
+**Master parent:** `a9794f2` (v0.7.1 ship state)
+**Source IDEA report:** `idea-stage/IDEA_REPORT_v12.md`
+
+## Overview
+
+v0.7.2 closes the IDEA_REPORT_v12 v0.7.2 slate (N24 auto-respawn + G22 second calibration pass). Patch-tier; 3-story compact bundle. **Eighth multi-cycle populated-CSV release** (21 → 24 rows).
+
+## The 3 stories
+
+| # | ID | Title | Outcome |
+|:-:|---|---|:-:|
+| 1 | US-001 | N24 — `wrap_orchestrator_dispatch` QL_RESPAWN_CMD auto-respawn (lib + 2 tests) | first-attempt PASS (22/22 = 18 baseline + 4 N24) |
+| 2 | US-002 | G22 second calibration pass — `references/severity-rubric-calibration-v0.7.2.md` + CLAUDE.md ref | first-attempt PASS |
+| 3 | US-003 | Retrospective + IDEA_REPORT_v13 + version bump 0.7.1 → 0.7.2 | this report |
+
+## Wave plan vs. realized
+
+DAG-validator not invoked (3-story bundle, trivial DAG). Wave 0 (2): US-001, US-002 (parallel-safe, no file conflicts). Wave 1 (1): US-003 [deps: US-001, US-002]. Realized sequential by priority under manual takeover (6th consecutive cycle).
+
+## G30 self-validation — 8th consecutive LOW
+
+`bash lib/deep-review.sh score <base> <head> | bash lib/deep-review.sh tier` → **score=10 tier=LOW files=4 sensitive=0 → skip**. Decision recorded in quantum.json `reviews` with `automated:true`.
+
+Note: v0.7.2 diff (4 files) scores 10 — lower than v0.7.1 (10 files, score=25). The blast-radius formula scales with files_changed below the 10-file cap; 4 files x~2.5 = 10.
+
+## Multi-cycle CSV milestone (eighth populated run)
+
+`metrics/pre-impl-review-findings.csv` → 24 rows. Advisory hook findings for v0.7.2: design=2 (0/0/0/2), prd=1 (0/0/0/1), plan=1 (0/0/0/1) — all LOW as expected for a compact patch-tier bundle.
+
+All-stages aggregate (via `bash references/severity-rubric-calibration-parse.sh`): 57 findings across 8 cycles. 0 critical / 3 high / 13 medium / 41 low (0% / 5.3% / 22.8% / 71.9%). LOW share at 71.9%; HIGH at 5.3% — consistent with patch-tier-skew hypothesis confirmed in G22 second pass.
+
+## Test-suite delta vs v0.7.1
+
+| Test file | v0.7.1 | v0.7.2 | delta |
+|---|---:|---:|---:|
+| tests/test_orchestrator_liveness.sh | 18 | 22 | +4 (Tests 8+9 N24) |
+| Other | unchanged | unchanged | 0 |
+| **Total v0.7.2 added:** | | | **+4** |
+
+Full audit: `bash quantum-loop.sh --audit` → 6/7 OK, 1 FAIL (branches-remote environmental artifact, unchanged from v0.7.1).
+
+## Manual-takeover (6th consecutive cycle)
+
+v0.7.2 dogfood ran with v0.7.1 master HEAD. The wrap_orchestrator_dispatch function (N20) and QL_RESPAWN_CMD extension (N24) are now both present, but the SKILL operator still invoked manual takeover — QL_RESPAWN_CMD requires operator to set the env var explicitly. The 5-layer recovery infrastructure is now complete:
+
+| Layer | Version | Mechanism |
+|---|---|---|
+| Prose | v0.6.8 | orchestrator.md self-monitoring guard |
+| Lib helper | v0.6.9 | poll_orchestrator_commits() |
+| SKILL prose | v0.7.0 | ql-execute SKILL.md liveness gate |
+| Callable fn | v0.7.1 | wrap_orchestrator_dispatch() |
+| Auto-respawn | v0.7.2 | QL_RESPAWN_CMD branch |
+
+**0-retry first-attempt PASS preserved across 6 consecutive manual-takeover cycles** (v0.6.7..v0.7.2).
+
+## codebasePatterns
+
+No new patterns harvested in v0.7.2. p001-p011 carried over unchanged.
+
+## Recommendation pointer
+
+See `idea-stage/IDEA_REPORT_v13.md` for v0.8.0+ backlog.

--- a/idea-stage/PIPELINE_REPORT_v13.md
+++ b/idea-stage/PIPELINE_REPORT_v13.md
@@ -14,7 +14,7 @@ v0.7.2 closes the IDEA_REPORT_v12 v0.7.2 slate (N24 auto-respawn + G22 second ca
 
 | # | ID | Title | Outcome |
 |:-:|---|---|:-:|
-| 1 | US-001 | N24 — `wrap_orchestrator_dispatch` QL_RESPAWN_CMD auto-respawn (lib + 2 tests) | first-attempt PASS (22/22 = 18 baseline + 4 N24) |
+| 1 | US-001 | N24 — `wrap_orchestrator_dispatch` QL_RESPAWN_CMD auto-respawn (lib + 2 tests) | first-attempt PASS + soliton inline (24/24 = 18 baseline + 6 N24+soliton) |
 | 2 | US-002 | G22 second calibration pass — `references/severity-rubric-calibration-v0.7.2.md` + CLAUDE.md ref | first-attempt PASS |
 | 3 | US-003 | Retrospective + IDEA_REPORT_v13 + version bump 0.7.1 → 0.7.2 | this report |
 
@@ -38,9 +38,9 @@ All-stages aggregate (via `bash references/severity-rubric-calibration-parse.sh`
 
 | Test file | v0.7.1 | v0.7.2 | delta |
 |---|---:|---:|---:|
-| tests/test_orchestrator_liveness.sh | 18 | 22 | +4 (Tests 8+9 N24) |
+| tests/test_orchestrator_liveness.sh | 18 | 24 | +6 (Tests 8+9+10 N24 + soliton wall-clock+rc-propagation) |
 | Other | unchanged | unchanged | 0 |
-| **Total v0.7.2 added:** | | | **+4** |
+| **Total v0.7.2 added:** | | | **+6** |
 
 Full audit: `bash quantum-loop.sh --audit` → 6/7 OK, 1 FAIL (branches-remote environmental artifact, unchanged from v0.7.1).
 

--- a/lib/orchestrator-liveness.sh
+++ b/lib/orchestrator-liveness.sh
@@ -100,7 +100,11 @@ wrap_orchestrator_dispatch() {
   if [[ -n "${QL_RESPAWN_CMD:-}" ]]; then
     printf "[QL-EXECUTE] orchestrator-stale — respawning via QL_RESPAWN_CMD\n" >&2
     bash -c "${QL_RESPAWN_CMD}"
-    return $?
+    local respawn_rc=$?
+    if [[ "$respawn_rc" -ne 0 ]]; then
+      printf "[QL-EXECUTE] QL_RESPAWN_CMD exited %d — respawn may have failed\n" "$respawn_rc" >&2
+    fi
+    return $respawn_rc
   fi
 
   cat <<'HANDOFF'

--- a/lib/orchestrator-liveness.sh
+++ b/lib/orchestrator-liveness.sh
@@ -70,15 +70,18 @@ poll_orchestrator_commits() {
 # logic into a callable function. The /ql-execute SKILL invokes this
 # function instead of inlining the conditional + handoff message.
 #
-# Honors QL_LIVENESS_ENABLE env var:
-#   unset / "true"  -> wrap with poll_orchestrator_commits (default behavior).
-#   "false"         -> silent skip (preserves v0.6.9 dispatch semantics).
-#   any other value -> treated as "true".
+# N24 / US-001 (v0.7.2) — adds QL_RESPAWN_CMD auto-respawn path. When set
+# to a non-empty string, the command is executed via `bash -c` on STALE
+# instead of emitting the manual-takeover handoff. QL_RESPAWN_CMD is an
+# operator-controlled env var (trusted invocation, not user input).
 #
-# On STALE: emits the canonical handoff message to stdout (pointer to the
-# orchestrator-takeover SOP + numbered recovery steps) and returns 1.
+# Honors env vars:
+#   QL_LIVENESS_ENABLE  unset/"true" -> wrap with poll (default).
+#                       "false"      -> silent skip, return 0.
+#   QL_RESPAWN_CMD      non-empty    -> execute via `bash -c` on STALE, return its rc.
+#                       empty/unset  -> emit canonical handoff message, return 1.
+#
 # On LIVE / OPT-OUT: returns 0 without printing.
-#
 # Defaults: timeout_sec=600 (10 min), interval_sec=60 (1 min).
 wrap_orchestrator_dispatch() {
   local timeout_sec="${1:-600}"
@@ -90,6 +93,14 @@ wrap_orchestrator_dispatch() {
 
   if poll_orchestrator_commits "$timeout_sec" "$interval_sec"; then
     return 0
+  fi
+
+  # N24: auto-respawn path — operator supplies a fully-specified orchestrator
+  # invocation (e.g. `claude --skill ql-execute`) via QL_RESPAWN_CMD.
+  if [[ -n "${QL_RESPAWN_CMD:-}" ]]; then
+    printf "[QL-EXECUTE] orchestrator-stale — respawning via QL_RESPAWN_CMD\n" >&2
+    bash -c "${QL_RESPAWN_CMD}"
+    return $?
   fi
 
   cat <<'HANDOFF'

--- a/references/severity-rubric-calibration-v0.7.2.md
+++ b/references/severity-rubric-calibration-v0.7.2.md
@@ -1,0 +1,129 @@
+# Severity rubric calibration — v0.7.2 second pass (8-cycle / 24-row baseline)
+
+**Date:** 2026-04-28
+**Scope:** v0.6.5..v0.7.2 (8 populated cycles, 24 CSV rows / 57 findings)
+**Source data:** `metrics/pre-impl-review-findings.csv`
+**Companion script:** `references/severity-rubric-calibration-parse.sh`
+**Rubric under review:** `references/finding-severity.md`
+**Predecessor:** `references/severity-rubric-calibration-v0.7.0.md` (6-cycle / 18-row baseline)
+
+This is the **second calibration pass** of the severity rubric. The v0.7.0 first pass (18 rows, 49 findings) identified mild HIGH under-classification (~8pp below expected) and LOW over-classification (~10pp over), with the caveat that the 5-of-6-cycle patch-tier skew might explain the drift rather than genuine rubric miscalibration. This pass adds 2 more cycles (v0.7.1 patch + v0.7.2 patch advisory hooks) and introduces a **bundle-tier comparison axis** using v0.7.0 as the single minor-tier data point.
+
+## Methodology
+
+Same as v0.7.0 first pass. Run `bash references/severity-rubric-calibration-parse.sh` against the full CSV. Tables below are reproduced directly from the script output. The bundle-tier comparison section manually partitions the 24-row dataset by release tier (minor vs patch).
+
+## Empirical distribution (8-cycle baseline)
+
+### design
+
+| Date | total | critical | high | medium | low |
+|------|------:|---------:|-----:|-------:|----:|
+| 2026-04-27 (v0.6.5) | 1 | 0 | 0 | 0 | 1 |
+| 2026-04-27 (v0.6.6) | 0 | 0 | 0 | 0 | 0 |
+| 2026-04-28 (v0.6.7) | 3 | 0 | 0 | 1 | 2 |
+| 2026-04-28 (v0.6.8) | 3 | 0 | 0 | 1 | 2 |
+| 2026-04-28 (v0.6.9) | 3 | 0 | 0 | 1 | 2 |
+| 2026-04-28 (v0.7.0) | 3 | 0 | 1 | 1 | 1 |
+| 2026-04-28 (v0.7.1) | 2 | 0 | 0 | 0 | 2 |
+| 2026-04-28 (v0.7.2) | 2 | 0 | 0 | 0 | 2 |
+
+**Aggregate (design):** total=17, critical=0 (0%), high=1 (5.9%), medium=4 (23.5%), low=12 (70.6%)
+
+### prd
+
+| Date | total | critical | high | medium | low |
+|------|------:|---------:|-----:|-------:|----:|
+| 2026-04-27 (v0.6.5) | 4 | 0 | 0 | 0 | 4 |
+| 2026-04-27 (v0.6.6) | 9 | 0 | 2 | 4 | 3 |
+| 2026-04-28 (v0.6.7) | 5 | 0 | 0 | 2 | 3 |
+| 2026-04-28 (v0.6.8) | 3 | 0 | 0 | 1 | 2 |
+| 2026-04-28 (v0.6.9) | 3 | 0 | 0 | 1 | 2 |
+| 2026-04-28 (v0.7.0) | 3 | 0 | 0 | 1 | 2 |
+| 2026-04-28 (v0.7.1) | 1 | 0 | 0 | 0 | 1 |
+| 2026-04-28 (v0.7.2) | 1 | 0 | 0 | 0 | 1 |
+
+**Aggregate (prd):** total=29, critical=0 (0%), high=2 (6.9%), medium=9 (31.0%), low=18 (62.1%)
+
+### plan
+
+| Date | total | critical | high | medium | low |
+|------|------:|---------:|-----:|-------:|----:|
+| 2026-04-27 (v0.6.5) | 0 | 0 | 0 | 0 | 0 |
+| 2026-04-28 (v0.6.6) | 1 | 0 | 0 | 0 | 1 |
+| 2026-04-28 (v0.6.7) | 2 | 0 | 0 | 0 | 2 |
+| 2026-04-28 (v0.6.8) | 2 | 0 | 0 | 0 | 2 |
+| 2026-04-28 (v0.6.9) | 2 | 0 | 0 | 0 | 2 |
+| 2026-04-28 (v0.7.0) | 2 | 0 | 0 | 0 | 2 |
+| 2026-04-28 (v0.7.1) | 1 | 0 | 0 | 0 | 1 |
+| 2026-04-28 (v0.7.2) | 1 | 0 | 0 | 0 | 1 |
+
+**Aggregate (plan):** total=11, critical=0 (0%), high=0 (0%), medium=0 (0%), low=11 (100%)
+
+### All-stages aggregate
+
+57 findings across 8 cycles x 3 stages.
+
+| Severity | Count | Percentage |
+|----------|------:|-----------:|
+| critical | 0 | 0.0% |
+| high | 3 | 5.3% |
+| medium | 13 | 22.8% |
+| low | 41 | 71.9% |
+
+## Bundle-tier comparison
+
+**Partition:** v0.7.0 = minor-tier (1 cycle). All other cycles = patch-tier (7 cycles: v0.6.5..v0.6.9, v0.7.1, v0.7.2).
+
+**Limitation:** n=1 minor-tier cycle. Results are directional signals, not statistically conclusive. A third calibration pass with 3+ minor-tier cycles would be needed for statistical confidence.
+
+### Patch-tier (7 cycles, 21 rows, 49 findings)
+
+| Stage | total | critical | high | medium | low |
+|-------|------:|---------:|-----:|-------:|----:|
+| design | 14 | 0 | 0 | 4 | 10 |
+| prd | 26 | 0 | 2 | 8 | 16 |
+| plan | 9 | 0 | 0 | 0 | 9 |
+| **All** | **49** | **0 (0%)** | **2 (4.1%)** | **12 (24.5%)** | **35 (71.4%)** |
+
+### Minor-tier (1 cycle — v0.7.0, 3 rows, 8 findings)
+
+| Stage | total | critical | high | medium | low |
+|-------|------:|---------:|-----:|-------:|----:|
+| design | 3 | 0 | 1 | 1 | 1 |
+| prd | 3 | 0 | 0 | 1 | 2 |
+| plan | 2 | 0 | 0 | 0 | 2 |
+| **All** | **8** | **0 (0%)** | **1 (12.5%)** | **2 (25.0%)** | **5 (62.5%)** |
+
+### Bundle-tier commentary
+
+The most notable signal is **HIGH severity**: minor-tier produced 12.5% HIGH vs patch-tier 4.1%. This directionally supports the v0.7.0 first-pass hypothesis that the HIGH under-classification (~8pp below expected) was driven by patch-tier-track skew rather than genuine rubric miscalibration. The single minor-tier cycle shows HIGH within the expected 10-15% range.
+
+MEDIUM is stable across tiers (24.5% patch vs 25.0% minor), consistent with the rubric intent that MEDIUM captures incomplete-but-correctable content regardless of bundle size.
+
+LOW is higher for patch-tier (71.4% vs 62.5%), partially offset by fewer HIGH findings in patch-tier bundles. This is expected: smaller, mature patch bundles are structurally cleaner, generating fewer HIGH findings and absorbing the residual into LOW.
+
+## Updated drift analysis
+
+Extending the v0.7.0 drift table with v0.7.2 empirical percentages and bundle-tier-informed verdicts:
+
+| Severity | v0.7.0 empirical % | v0.7.2 empirical % | Expected % | Drift (v0.7.2) | Updated verdict |
+|----------|-------------------:|-------------------:|-----------:|---------------:|-----------------|
+| critical | 0.0% | 0.0% | 0-5% | within range | OK — unchanged. 0 CRITICAL across 8 cycles consistent with healthy patch-track baseline. |
+| high | 6.1% | 5.3% | 10-15% | **-5 to -10 pp** | **Explained by patch-tier skew.** Patch-tier: 4.1% HIGH; minor-tier: 12.5% (within expected). Rubric language is likely correct; the all-cycles aggregate is pulled down by 7:1 patch-to-minor ratio. No rubric edit required. |
+| medium | 26.5% | 22.8% | 25-35% | mild under | Slight downward drift. Plan-review STILL 100% LOW (11/11 rows). Patch bundles running cleaner in v0.7.1/v0.7.2 (0 MEDIUM each). No rubric action required. |
+| low | 67.3% | 71.9% | 50-60% | **+12 pp** above | Consistent with HIGH under-classification driven by patch-tier skew. LOW share should decrease toward expected range as minor-tier cycles accumulate. |
+
+**Plan-review MEDIUM status:** v0.7.1 N18 shipped a second MEDIUM example in the plan-review rubric row. The v0.7.1 and v0.7.2 plan-review hooks both emitted 1 LOW (not MEDIUM). The example has not yet surfaced a real MEDIUM finding — likely because both cycles had compact, clean DAG structures. A minor-tier cycle with a complex multi-wave DAG is the more likely trigger.
+
+## Future work
+
+1. **Third calibration pass at v0.8.0+ with 2+ minor-tier cycles.** The bundle-tier comparison is currently n=1 minor. Accumulating 2-3 minor-tier data points would allow statistical comparison rather than directional signal. ~~First minor-tier comparison data point — closed with this pass.~~
+
+2. **Plan-review MEDIUM trigger observation.** The N18 second example has not yet surfaced a real MEDIUM in plan-review (11 consecutive LOW across 8 cycles). Track whether a minor-tier cycle with complex DAG structure triggers one. No rubric action yet.
+
+3. **HIGH/LOW boundary re-evaluation at v0.9.0.** If the patch/minor ratio normalizes, re-examine whether the all-stages HIGH/LOW distribution converges toward expected quartiles. Current hypothesis (patch-tier skew) should be tested with more data before any rubric edits.
+
+4. **Critical-tier reservation unchanged.** 0 CRITICAL across 8 cycles expected for a healthy track. No action.
+
+5. **Re-snapshot procedure.** Replace empirical tables with fresh `bash references/severity-rubric-calibration-parse.sh` output at each retrospective. The bundle-tier comparison section requires manual partition (the parse script aggregates all stages only).

--- a/tests/test_orchestrator_liveness.sh
+++ b/tests/test_orchestrator_liveness.sh
@@ -209,6 +209,40 @@ else
 fi
 rm -rf "$TMP7"
 
+# Test 8: N24 / US-001 (v0.7.2) — QL_RESPAWN_CMD set + STALE -> respawn cmd executed, rc=0
+echo ""
+echo "Test 8: wrap_orchestrator_dispatch QL_RESPAWN_CMD set + stale -> respawn executed rc=0 (wall-clock <10s)"
+TMP8=$(mktemp -d)
+( cd "$TMP8" && git init -q && git config user.email "t@t.t" && git config user.name "t" \
+  && echo "init" > README.md && git add README.md && git commit -qm "init" ) >/dev/null 2>&1
+rc8=0
+out8=$(cd "$TMP8" && QL_RESPAWN_CMD="echo respawned" bash -c "source '$LIB' && wrap_orchestrator_dispatch 2 1" 2>&1) || rc8=$?
+assert "Test 8: QL_RESPAWN_CMD respawn rc=0" "0" "$rc8"
+TOTAL=$((TOTAL + 1))
+if printf '%s' "$out8" | grep -q 'respawned'; then
+  echo "  PASS: respawn command output 'respawned' present in stdout"; PASS=$((PASS + 1))
+else
+  echo "  FAIL: 'respawned' not found in stdout — out: $out8"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$TMP8"
+
+# Test 9: N24 / US-001 (v0.7.2) — QL_RESPAWN_CMD unset + STALE -> handoff + rc=1 (v0.7.1 regression guard)
+echo ""
+echo "Test 9: wrap_orchestrator_dispatch QL_RESPAWN_CMD unset + stale -> handoff rc=1 (regression guard)"
+TMP9=$(mktemp -d)
+( cd "$TMP9" && git init -q && git config user.email "t@t.t" && git config user.name "t" \
+  && echo "init" > README.md && git add README.md && git commit -qm "init" ) >/dev/null 2>&1
+rc9=0
+out9=$(cd "$TMP9" && bash -c "source '$LIB' && wrap_orchestrator_dispatch 2 1" 2>&1) || rc9=$?
+assert "Test 9: unset QL_RESPAWN_CMD fallback rc=1" "1" "$rc9"
+TOTAL=$((TOTAL + 1))
+if printf '%s' "$out9" | grep -qE 'orchestrator-stale signal'; then
+  echo "  PASS: handoff message present (v0.7.1 behavior unchanged)"; PASS=$((PASS + 1))
+else
+  echo "  FAIL: handoff message missing — out: $out9"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$TMP9"
+
 echo ""
 echo "=== Results: $PASS/$TOTAL passed, $FAIL failed ==="
 [[ $FAIL -eq 0 ]] || exit 1

--- a/tests/test_orchestrator_liveness.sh
+++ b/tests/test_orchestrator_liveness.sh
@@ -215,9 +215,18 @@ echo "Test 8: wrap_orchestrator_dispatch QL_RESPAWN_CMD set + stale -> respawn e
 TMP8=$(mktemp -d)
 ( cd "$TMP8" && git init -q && git config user.email "t@t.t" && git config user.name "t" \
   && echo "init" > README.md && git add README.md && git commit -qm "init" ) >/dev/null 2>&1
+t0=$(date +%s)
 rc8=0
 out8=$(cd "$TMP8" && QL_RESPAWN_CMD="echo respawned" bash -c "source '$LIB' && wrap_orchestrator_dispatch 2 1" 2>&1) || rc8=$?
+t1=$(date +%s)
+elapsed=$((t1 - t0))
 assert "Test 8: QL_RESPAWN_CMD respawn rc=0" "0" "$rc8"
+TOTAL=$((TOTAL + 1))
+if (( elapsed <= 10 )); then
+  echo "  PASS: stale+respawn completed within 10s (got ${elapsed}s)"; PASS=$((PASS + 1))
+else
+  echo "  FAIL: stale+respawn took ${elapsed}s (>10s)"; FAIL=$((FAIL + 1))
+fi
 TOTAL=$((TOTAL + 1))
 if printf '%s' "$out8" | grep -q 'respawned'; then
   echo "  PASS: respawn command output 'respawned' present in stdout"; PASS=$((PASS + 1))
@@ -242,6 +251,17 @@ else
   echo "  FAIL: handoff message missing — out: $out9"; FAIL=$((FAIL + 1))
 fi
 rm -rf "$TMP9"
+
+# Test 10: N24 soliton-fix — failing QL_RESPAWN_CMD propagates non-zero exit code
+echo ""
+echo "Test 10: wrap_orchestrator_dispatch failing QL_RESPAWN_CMD propagates rc=42"
+TMP10=$(mktemp -d)
+( cd "$TMP10" && git init -q && git config user.email "t@t.t" && git config user.name "t" \
+  && echo "init" > README.md && git add README.md && git commit -qm "init" ) >/dev/null 2>&1
+rc10=0
+out10=$(cd "$TMP10" && QL_RESPAWN_CMD="exit 42" bash -c "source '$LIB' && wrap_orchestrator_dispatch 2 1" 2>&1) || rc10=$?
+assert "Test 10: failing QL_RESPAWN_CMD propagates rc=42" "42" "$rc10"
+rm -rf "$TMP10"
 
 echo ""
 echo "=== Results: $PASS/$TOTAL passed, $FAIL failed ==="


### PR DESCRIPTION
## Summary

- **N24** (`lib/orchestrator-liveness.sh`) — `wrap_orchestrator_dispatch` gains `QL_RESPAWN_CMD` auto-respawn branch: on STALE, executes `bash -c "${QL_RESPAWN_CMD}"` + returns its rc instead of emitting manual-takeover handoff. Closes the 5-layer recovery infrastructure. Tests 8+9 (4 new assertions). 18 → 22 liveness tests.
- **G22 second calibration pass** (`references/severity-rubric-calibration-v0.7.2.md`) — updated empirical tables (8-cycle / 57-finding baseline) + bundle-tier comparison axis: patch-tier HIGH=4.1% vs minor-tier HIGH=12.5% (n=1), directionally confirming HIGH under-classification was patch-tier-skew driven. `CLAUDE.md` reference updated v0.7.0 → v0.7.2.
- **Retrospective** — PIPELINE_REPORT_v13 + IDEA_REPORT_v13 + version bump 0.7.1 → 0.7.2 (3 manifests).

**Eighth multi-cycle populated-CSV run**: 21 → 24 rows. G30 self-validation: score=10 tier=LOW files=4 sensitive=0 → skip (`automated:true`). 8 consecutive LOW-tier self-validations.

## Test plan

- [x] `bash tests/test_orchestrator_liveness.sh` → 22/22 PASS (18 baseline + 4 N24 Tests 8+9)
- [x] `bash tests/test_ql_execute_liveness_wrapping.sh` → 6/6 PASS
- [x] `bash tests/test_audit.sh` → 45/45 PASS
- [x] All 3 manifest version fields bumped to 0.7.2
- [x] CHANGELOG [0.7.2] entry present
- [x] G30 self-validation: tier=LOW score=10
- [x] Advisory hooks: design=2LOW, prd=1LOW, plan=1LOW (CSV at 24 rows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)