### PR TITLE
feat: v0.7.6 — patch-tier reactive (N34 untracked-design-prd audit)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Universal CLI orchestrator with multi-runner support. Autonomous spec-driven development pipeline with dependency DAG, parallel worktree execution, two-stage review gates, DAG intelligence validation, and modular merge hardening",
-    "version": "0.7.5"
+    "version": "0.7.6"
   },
   "plugins": [
     {
       "name": "quantum-loop",
       "source": "./",
       "description": "6 skills (brainstorm, spec, plan, execute, verify, review) and 5 agents for autonomous spec-driven development with multi-runner support, DAG intelligence, and modular merge hardening",
-      "version": "0.7.5",
+      "version": "0.7.6",
       "keywords": [
         "autonomous",
         "prd",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "quantum-loop",
   "description": "Universal CLI orchestrator with multi-runner support. Autonomous spec-driven development with dependency DAG, parallel worktree execution, two-stage review gates, and modular merge hardening.",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "author": {
     "name": "andyzengmath"
   }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "quantum-loop",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "Spec-driven autonomous development loop with DAG-based execution, parallel worktree agents, two-stage review gates, and Iron Law verification. Turns a feature description into verified, reviewed, autonomously-implemented code.",
   "author": {
     "name": "andyzengmath"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ Format: [Semantic Versioning](https://semver.org/). Bump per PR:
 - **Minor** (0.x.0): new features, backward-compatible
 - **Major** (x.0.0): breaking changes
 
+## [0.7.6] - 2026-04-28
+
+### Added
+
+2-story compact reactive patch closing N34 (untracked design+PRD docs audit). **Smallest cycle yet** (2 stories, ~15 min wall-clock). **11 consecutive LOW-tier self-validations** expected.
+
+- **N34 — `--audit` untracked-design-prd check** (US-001) — `quantum-loop.sh` adds `_audit_untracked_design_prd_docs` helper using `git ls-files --others --exclude-standard docs/plans/ tasks/`. WARN-level when matching files are untracked; OK otherwise. Mirrors v0.7.5 N29 csv-uncommitted pattern. +2 audit tests in `tests/test_audit.sh`. Closes the v0.7.4 + v0.7.5 process gap where design+PRD docs were repeatedly authored locally but never staged before squash-merge (caught at v0.7.5 housekeeping).
+
+### Test-suite delta
+
+- `tests/test_audit.sh` +2 (Tests 39 + 39b)
+- `quantum-loop.sh` +1 helper + 1 ROWS invocation
+
+### Reactive-cycle wrap-up
+
+v0.7.4 (dogfood) → v0.7.5 (N29+N31) → v0.7.6 (N34) sequence has now closed all known process gaps surfaced by the dogfood cycle. Patch-tier track is genuinely drained. v0.8.0 minor-tier requires operator-defined substantive scope (N30 multi-runner first integration is the natural anchor). Full retrospective: `idea-stage/PIPELINE_REPORT_v17.md`.
+
 ## [0.7.5] - 2026-04-28
 
 ### Added

--- a/docs/plans/2026-04-28-v0.7.6-bundle-design.md
+++ b/docs/plans/2026-04-28-v0.7.6-bundle-design.md
@@ -1,0 +1,38 @@
+# Design: v0.7.6 — patch-tier reactive (N34 untracked-design-prd audit)
+
+**Date:** 2026-04-28
+**Status:** Approved
+**Source:** `idea-stage/IDEA_REPORT_v16.md` v0.7.6 candidates
+**Approach:** 2-story compact reactive — 1 audit check + retrospective
+**Target version:** 0.7.6
+**Branch:** `ql/v0.7.6-bundle`
+**Target effort:** ~15 min
+
+## Overview
+
+v0.7.4 + v0.7.5 cycles repeatedly left design+PRD docs untracked (caught at v0.7.5 housekeeping). N34 adds an audit check that warns when `docs/plans/*-design.md` or `tasks/prd-*.md` files are untracked, mirroring N29's csv-uncommitted pattern.
+
+## Stories
+
+| # | ID | Title |
+|:-:|---|---|
+| 1 | US-001 | N34 — `quantum-loop.sh --audit` adds `untracked-design-prd` check |
+| 2 | US-002 | Retrospective + IDEA_REPORT_v17 + version bump 0.7.5 → 0.7.6 |
+
+## US-001 design
+
+`_audit_untracked_design_prd_docs`:
+- `git ls-files --others --exclude-standard docs/plans/ tasks/` → any matches?
+- WARN-level if found; OK if none.
+- Drill = first untracked path.
+- Add to `do_audit` ROWS array (after `_audit_csv_uncommitted`).
+
+Test: existence + ROWS invocation grep (mirrors N29 Test 38/38b pattern).
+
+## Risk
+
+- Operators with intentional untracked draft docs may see WARN. Acceptable — advisory only.
+
+## Next steps
+
+Advisory hooks → quantum.json → execute → review → squash-merge → tag v0.7.6.

--- a/idea-stage/IDEA_REPORT_v17.md
+++ b/idea-stage/IDEA_REPORT_v17.md
@@ -1,0 +1,40 @@
+# IDEA_REPORT_v17 — what's still open after v0.7.6
+
+**Date:** 2026-04-28
+**Source:** `ql/v0.7.6-bundle` retrospective
+**Predecessor:** `idea-stage/IDEA_REPORT_v16.md`
+
+## Closed in v0.7.6
+
+| ID | Story | Notes |
+|---|---|---|
+| **N34** | US-001 | `_audit_untracked_design_prd_docs` helper added to `quantum-loop.sh`; +2 audit tests. |
+
+## Still open
+
+### N30 — Multi-runner first integration (v0.8.0 anchor)
+Foundation in v0.7.4. Needs ≥1 real consumer.
+
+### N32, N33 — unchanged from v0.7.5
+
+### G19/G21/G24/P5.* frontier — defer indefinitely
+
+## New gaps from v0.7.6
+
+None substantive. Patch-tier track is now genuinely drained for known process gaps.
+
+## Recommendation for next
+
+**Stop the patch-tier loop.** The 3-cycle reactive sequence (v0.7.4 dogfood → v0.7.5 N29+N31 → v0.7.6 N34) has closed all known process gaps surfaced in the dogfood cycle. Continued patch-tier cycles will be value-light churn.
+
+**v0.8.0 minor-tier requires operator-defined scope:**
+- N30 multi-runner first integration (which runner? what depth?)
+- N33 worktree mode root-cause investigation (substantive process work)
+- Or substantive new feature
+
+## Recurring observations
+
+- **11 consecutive LOW G30 self-validations** (v0.6.5..v0.7.6).
+- **9 consecutive manual-takeover cycles** with 0-retry.
+- **Bundle size: 7-7-7-7-5-6-5-3-7-3-2.** v0.7.6 is the smallest bundle yet (2 stories).
+- **Patch-tier track explicitly drained** as of this report. v0.8.0 needs operator scope.

--- a/idea-stage/PIPELINE_REPORT_v17.md
+++ b/idea-stage/PIPELINE_REPORT_v17.md
@@ -1,0 +1,36 @@
+# PIPELINE_REPORT_v17 — v0.7.6 reactive retrospective
+
+**Date:** 2026-04-28
+**Bundle:** `ql/v0.7.6-bundle` (release tag v0.7.6)
+**Predecessor:** `idea-stage/PIPELINE_REPORT_v16.md`
+**Master parent:** `66e4f43` (v0.7.5 ship state)
+
+## Overview
+
+v0.7.6 closes N34 (untracked-design-prd audit check). 2-story compact reactive — smallest cycle yet.
+
+## Stories
+
+| # | ID | Title | Outcome |
+|:-:|---|---|:-:|
+| 1 | US-001 | N34 — untracked-design-prd audit | first-attempt PASS |
+| 2 | US-002 | Retrospective + IDEA_REPORT_v17 + 0.7.5 → 0.7.6 | this report |
+
+## G30 — 11th LOW expected
+
+Score expected ~5-7 (2 files modified + 4 doc additions). Captured at execution time.
+
+## Test-suite delta
+
+- `tests/test_audit.sh` +2 (Test 39 + 39b — mirrors N29 Test 38/38b pattern)
+- `quantum-loop.sh` +1 helper + 1 ROWS invocation
+
+## Notes
+
+- **Smallest cycle yet:** 2 stories, ~15 min wall-clock.
+- **Pattern reuse:** `_audit_untracked_design_prd_docs` mirrors `_audit_csv_uncommitted` (N29). Same WARN-level, drill-by-first-path approach.
+- **Self-validating:** the audit warned about its own design+PRD docs at first run (now staged in this very cycle's commits).
+
+## codebasePatterns
+
+No new patterns harvested.

--- a/metrics/pre-impl-review-findings.csv
+++ b/metrics/pre-impl-review-findings.csv
@@ -26,3 +26,6 @@ timestamp,stage,source_path,count,critical,high,medium,low
 2026-04-28T18:36:43Z,design,docs/plans/2026-04-28-v0.7.5-bundle-design.md,1,0,0,0,1
 2026-04-28T18:36:55Z,prd,tasks/prd-v0.7.5-bundle.md,1,0,0,0,1
 2026-04-28T18:37:37Z,plan,quantum.json,1,0,0,0,1
+2026-04-28T18:52:35Z,design,docs/plans/2026-04-28-v0.7.6-bundle-design.md,1,0,0,0,1
+2026-04-28T18:52:39Z,prd,tasks/prd-v0.7.6-bundle.md,1,0,0,0,1
+2026-04-28T18:52:42Z,plan,quantum.json,1,0,0,0,1

--- a/quantum-loop.sh
+++ b/quantum-loop.sh
@@ -274,6 +274,23 @@ _audit_cpc_files() {
   fi
 }
 
+# _audit_untracked_design_prd_docs
+# N34 / US-001 (v0.7.6) — warns when docs/plans/*-design.md or tasks/prd-*.md
+# files are untracked. v0.7.4/v0.7.5 cycles repeatedly left these uncommitted
+# until housekeeping caught them. Mirrors _audit_csv_uncommitted pattern.
+_audit_untracked_design_prd_docs() {
+  local untracked
+  untracked=$(git ls-files --others --exclude-standard docs/plans/ tasks/ 2>/dev/null \
+              | grep -E '^(docs/plans/.+-design\.md|tasks/prd-.+\.md)$' || true)
+  if [[ -z "$untracked" ]]; then
+    printf 'untracked-design-prd|0|0|OK|\n'
+  else
+    local n
+    n=$(printf '%s\n' "$untracked" | grep -c .)
+    printf 'untracked-design-prd|%d|0|WARN|%s\n' "$n" "$(printf '%s' "$untracked" | head -1)"
+  fi
+}
+
 # _audit_csv_uncommitted
 # N29 / US-001 (v0.7.5) — warns when metrics/pre-impl-review-findings.csv has
 # uncommitted changes. v0.7.2 + v0.7.3 advisory hooks fired but their CSV
@@ -445,6 +462,7 @@ do_audit() {
   ROWS+=("$(_audit_test_suites)")
   ROWS+=("$(_audit_pre_impl_review_coverage)")
   ROWS+=("$(_audit_csv_uncommitted)")
+  ROWS+=("$(_audit_untracked_design_prd_docs)")
   # Test-only injection hook: replace the helper-driven ROWS with synthetic
   # newline-delimited rows so tests can exercise the split-summary arithmetic
   # + exit-semantics against the real do_audit, not a private re-implementation.

--- a/tasks/prd-v0.7.6-bundle.md
+++ b/tasks/prd-v0.7.6-bundle.md
@@ -1,0 +1,45 @@
+# PRD: v0.7.6 — patch-tier reactive (N34)
+
+**Status:** Approved
+**Date:** 2026-04-28
+**Design doc:** `docs/plans/2026-04-28-v0.7.6-bundle-design.md`
+**Branch:** `ql/v0.7.6-bundle`
+**Target version:** 0.7.6
+
+## Section 1: Overview
+
+2-story compact reactive closing N34 (untracked design+PRD docs audit check) + retrospective.
+
+## Section 2: Goals
+
+- Close N34 from IDEA_REPORT_v16.
+- Bump 0.7.5 → 0.7.6.
+- 11th LOW G30 expected.
+
+## Section 3: User Stories
+
+### US-001: N34 — untracked-design-prd audit
+
+**Acceptance Criteria:**
+- [ ] `quantum-loop.sh` adds `_audit_untracked_design_prd_docs` helper using `git ls-files --others --exclude-standard docs/plans/ tasks/`. WARN if any matches; OK otherwise.
+- [ ] Helper invoked from `do_audit` ROWS array (after `_audit_csv_uncommitted`).
+- [ ] `tests/test_audit.sh` adds Test 39 + 39b verifying helper definition + invocation (mirrors Test 38/38b pattern from N29).
+- [ ] Existing 47+ audit tests remain green.
+
+### US-002: Retrospective + IDEA_REPORT_v17 + version bump 0.7.5 → 0.7.6
+
+**Acceptance Criteria:**
+- [ ] `idea-stage/PIPELINE_REPORT_v17.md` documents v0.7.6.
+- [ ] `idea-stage/IDEA_REPORT_v17.md` lists open after v0.7.6.
+- [ ] CHANGELOG [0.7.6] entry.
+- [ ] All 4 manifest version fields → 0.7.6.
+
+## Section 4-9
+
+Cross-platform: bash 4.3+. WARN-level only. No env var changes.
+
+Non-Goals: auto-staging the docs (out of scope), gating the warn (operators may legitimately have draft docs untracked), promoting to FAIL.
+
+## Next Steps
+
+Advisory hooks → execute → review → squash → tag v0.7.6.

--- a/tests/test_audit.sh
+++ b/tests/test_audit.sh
@@ -863,5 +863,23 @@ else
 fi
 
 echo ""
+echo "Test 39: N34 / US-001 (v0.7.6) — _audit_untracked_design_prd_docs helper present"
+TOTAL=$((TOTAL + 1))
+if grep -qE '_audit_untracked_design_prd_docs' "$REPO_ROOT/quantum-loop.sh"; then
+  echo "  PASS: _audit_untracked_design_prd_docs helper defined"; PASS=$((PASS + 1))
+else
+  echo "  FAIL: _audit_untracked_design_prd_docs helper not found"; FAIL=$((FAIL + 1))
+fi
+
+echo ""
+echo "Test 39b: untracked-design-prd row invoked from do_audit ROWS array"
+TOTAL=$((TOTAL + 1))
+if grep -E 'ROWS\+=' "$REPO_ROOT/quantum-loop.sh" | grep -q untracked_design_prd_docs; then
+  echo "  PASS: untracked-design-prd invoked from do_audit"; PASS=$((PASS + 1))
+else
+  echo "  FAIL: untracked-design-prd not invoked from do_audit"; FAIL=$((FAIL + 1))
+fi
+
+echo ""
 echo "=== Results: $PASS/$TOTAL passed, $FAIL failed ==="
 exit $((FAIL > 0 ? 1 : 0))


### PR DESCRIPTION
Smallest cycle yet (2 stories, ~15 min). N34 closes the v0.7.4/v0.7.5 process gap where design+PRD docs were authored locally but never staged.

G30: score=5 tier=LOW (11th consecutive, smallest score yet).

After this, patch-tier track is genuinely drained — v0.8.0 minor-tier needs operator scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)