### PR TITLE
chore: gitignore .omc/*.tmp.* (copilot review v0.7.6 finding)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ desktop.ini
 *~
 .omc/state/
 .omc/project-memory.json
+.omc/*.tmp.*


### PR DESCRIPTION
Copilot review surfaced LOW finding: .omc/.project-memory.json.tmp.* tmp files were not covered by the existing .omc/project-memory.json ignore rule, so review sessions saw them as untracked working-tree changes. Adds .omc/*.tmp.* glob.

Chore-tier: no version bump.