### PR TITLE
feat: v0.9.3 — patch-tier (operational hardening; iter-3 hang closed)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Universal CLI orchestrator with multi-runner support. Autonomous spec-driven development pipeline with dependency DAG, parallel worktree execution, two-stage review gates, DAG intelligence validation, and modular merge hardening",
-    "version": "0.9.2"
+    "version": "0.9.3"
   },
   "plugins": [
     {
       "name": "quantum-loop",
       "source": "./",
       "description": "6 skills (brainstorm, spec, plan, execute, verify, review) and 5 agents for autonomous spec-driven development with multi-runner support, DAG intelligence, and modular merge hardening",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "keywords": [
         "autonomous",
         "prd",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "quantum-loop",
   "description": "Universal CLI orchestrator with multi-runner support. Autonomous spec-driven development with dependency DAG, parallel worktree execution, two-stage review gates, and modular merge hardening.",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "author": {
     "name": "andyzengmath"
   }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "quantum-loop",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Spec-driven autonomous development loop with DAG-based execution, parallel worktree agents, two-stage review gates, and Iron Law verification. Turns a feature description into verified, reviewed, autonomously-implemented code.",
   "author": {
     "name": "andyzengmath"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ Format: [Semantic Versioning](https://semver.org/). Bump per PR:
 - **Minor** (0.x.0): new features, backward-compatible
 - **Major** (x.0.0): breaking changes
 
+## [0.9.3] - 2026-04-30
+
+### Added — patch-tier (operational hardening — closes v0.9.2 iter-3 hang)
+
+4-story patch closing v0.9.2's documented operational gap (coordinator subagent stuck mid-`eval` for 3+ hours during dogfood iteration 3). v0.9.3 self-validated: tier=LOW (G30 in retrospective). **24 consecutive LOW-tier self-validations** (v0.6.5..v0.9.3).
+
+**Headline result: v0.9.2 iter-3 hang — CLOSED (engineered).** New parent-side wallclock timeout wraps `eval "$COORD_CMD"` with `timeout(1)` from coreutils. Default 30 min ceiling; configurable via `QL_COORDINATOR_TIMEOUT_S` env var. On `timeout`'s rc=124 (SIGTERM kill), parent forces `SIGNAL_RESULT=WAVE_FAILED` so per-story review-field aggregation runs.
+
+### Stories shipped
+
+- **US-001 + US-002 (atomic) — parent-side wallclock timeout + KEEP-OFF rationale documentation** — `quantum-loop.sh:~1592` wraps coord dispatch with `timeout --kill-after=10s ${QL_COORDINATOR_TIMEOUT_S:-1800}s bash -c "$COORD_CMD"`. After `runner_parse_output`: if `RUNNER_EXIT==124`, force `SIGNAL_RESULT=WAVE_FAILED` + ERROR (pattern: `Coordinator subagent exceeded.*timeout`). `ql_wrap_subagent_dispatch` gate stays OFF under coordinator mode (US-002 comment expansion documents rationale: STALE detection unsafe under coordinator mode + cross-ref to `QL_COORDINATOR_TIMEOUT_S`). New `tests/test_coordinator_e2e.sh` Test 6: stub `hung_coordinator` mode (sleep 30s) + `QL_COORDINATOR_TIMEOUT_S=5`; asserts ERROR + per-story aggregation marks both stories failed. 13/13 → 16/16 (+3).
+- **US-003 — multi-perspective post-merge review + 2 score-≥85 inline fixes** — 3 parallel reviewers (architect + code-reviewer + security). Verdicts: architect SHIP, code-reviewer REQUEST CHANGES, security SHIP. **2 inline fixes:** (1) HIGH score 90 — missing `timeout` availability guard per FR-1; added `command -v timeout` check matching `lib/dep-manifest.sh:255`; on missing, WARN + degrade to plain `bash -c` (v0.9.2 behavior). (2) MEDIUM score 88 — numeric validation on `QL_COORDINATOR_TIMEOUT_S`; non-numeric input → WARN + default 1800. New Test 7 validates the fixes. 16/16 → 18/18 (+2).
+- **US-004 — retrospective + IDEA_REPORT_v30 + version bump 0.9.2 → 0.9.3** — this entry.
+
+### Test-suite delta
+
+| Test file | v0.9.2 | v0.9.3 | delta |
+|---|---:|---:|---:|
+| `tests/test_coordinator_e2e.sh` (+Test 6 + Test 7) | 13 | 18 | +5 |
+| **Total v0.9.3 added:** | | | **+5** |
+
+### Architectural observations
+
+**v0.9.x track has reached operational + structural maturity.** v0.9.0 shipped per-wave coordinator dispatch wires. v0.9.1 validated empirically (streak BROKEN). v0.9.2 closed 5a HIGH (engineered guard). v0.9.3 closes operational iter-3 hang (engineered timeout). The next significant cycle would be **v0.10.0** (architect-recommended outer-loop replacement; deferred from v0.9.0).
+
+**v0.9.4 candidate slate** (in `idea-stage/IDEA_REPORT_v30.md`): cosmetic housekeeping + 1 optional real-feature dogfood. Mostly LOW severity. May skip and pivot to v0.10.0 design phase.
+
+### Honest scope drift
+
+- US-003 review surfaced 1 HIGH (FR-1 violation). Reviewer originally said REQUEST CHANGES; INLINE FIX brought it to SHIP. The HIGH was a real PRD AC violation (FR-1 said "fallback if `timeout` missing" but the v0.9.3 commit-1 implementation lacked the guard). Inline fix closed it cleanly.
+
+### Dogfood milestone (v0.9.3)
+
+**4/4 user-facing stories shipped first-attempt PASS.** **Multi-cycle CSV milestone**: 58 → 61 rows (3 advisory rows). **G30 self-validation captured.** **Manual-takeover streak BROKEN through v0.9.3** — cron-driven /loop pattern handled v0.9.3 end-to-end with no operator intervention. Full retrospective: `idea-stage/PIPELINE_REPORT_v30.md`. v0.9.4 backlog: `idea-stage/IDEA_REPORT_v30.md`.
+
 ## [0.9.2] - 2026-04-30
 
 ### Added — patch-tier (defensive hardening — closes v0.9.1 5a HIGH advisory + 2 reviewer MEDIUMs)

--- a/docs/plans/2026-04-30-v0.9.3-bundle-design.md
+++ b/docs/plans/2026-04-30-v0.9.3-bundle-design.md
@@ -1,0 +1,137 @@
+# Design: v0.9.3 — patch-tier (operational hardening — closes v0.9.2 iter-3 hang)
+
+**Date:** 2026-04-30
+**Status:** Approved
+**Source:** `idea-stage/IDEA_REPORT_v29.md` § "v0.9.3 candidate slate" (primary: 5a iter-3 hang).
+**Approach:** 4-story patch — parent-side wallclock timeout on `eval "$COORD_CMD"`; re-evaluate `ql_wrap_subagent_dispatch` gating; multi-perspective review; retrospective.
+**Target version:** 0.9.3 (patch from 0.9.2)
+**Target effort:** ~2-3 hours
+**Bundle branch:** `ql/v0.9.3-bundle` from master HEAD `6230577`
+
+## Overview
+
+v0.9.2 dogfood iteration 3 hung mid-`eval "$COORD_CMD"` for 3+ hours; operator killed parent shell. The HEAD-snapshot guard worked correctly across iterations 1-2 — operational concern, not architectural. v0.9.3 ships an engineered timeout so a hung coordinator subagent surfaces as STORY_FAILED rather than blocking the parent loop indefinitely.
+
+**Patch-tier framing:** No new architecture. Adds a parent-side wallclock guard around the existing `eval` invocation. Reverts to documented `timeout(1)` behavior from coreutils. Mirrors v0.9.2's defensive-hardening pattern.
+
+## The 4 stories at a glance
+
+| # | ID | Title | Effort | Tier |
+|:-:|---|---|:-:|:-:|
+| 1 | US-001 | Parent-side wallclock timeout on `eval "$COORD_CMD"` in `quantum-loop.sh`; configurable via `QL_COORDINATOR_TIMEOUT_S` env (default 1800s = 30 min); on timeout: surface as STORY_FAILED for all wave members | small-medium | MEDIUM |
+| 2 | US-002 | Re-evaluate `ql_wrap_subagent_dispatch` gating under coordinator mode — KEEP OFF (the v0.9.3 timeout from US-001 covers the operational gap that motivated re-enabling); update inline comment with explicit rationale + cross-ref to US-001 | small | LOW |
+| 3 | US-003 | Multi-perspective post-merge review (architect + code-reviewer + security via Agent tool) — STANDARD pattern; v0.9.2 skipped this (US-004 was dogfood); v0.9.3 resumes it as 5th application | small | LOW |
+| 4 | US-004 | Retrospective + IDEA_REPORT_v30 + version bump 0.9.2 → 0.9.3 | small | LOW |
+
+## Wave plan
+
+US-001 and US-002 file-disjoint (US-001 modifies `quantum-loop.sh:1572-1585` spawn block; US-002 modifies `quantum-loop.sh:1657-1661` ql_wrap gate). Same file but different code regions — adjacent edits possible. `dependsOn = []` for both. US-003 dependsOn US-001+US-002 (review the diff). US-004 dependsOn all.
+
+Realized order (sequential under manual takeover):
+1. US-001: timeout helper
+2. US-002: ql_wrap comment update
+3. US-003: 3-reviewer trio
+4. US-004: retrospective + bump
+
+## File map
+
+| File | Stories |
+|---|---|
+| `quantum-loop.sh` | US-001 (timeout wrap) + US-002 (comment update on ql_wrap gate) |
+| `tests/test_coordinator_e2e.sh` | US-001 (Test 6: hung-coordinator timeout fires) |
+| `idea-stage/PIPELINE_REPORT_v30.md` (NEW) | US-004 |
+| `idea-stage/IDEA_REPORT_v30.md` (NEW) | US-004 |
+| `CHANGELOG.md` + 4 manifests | US-004 |
+
+## Per-story design
+
+### US-001 — Parent-side wallclock timeout on `eval "$COORD_CMD"`
+
+**Problem:** v0.9.2 dogfood iteration 3 hung 3+ hours; parent shell blocked indefinitely on `eval "$COORD_CMD"` waiting for the coordinator subagent to exit.
+
+**Decision:** wrap `eval` in `timeout(1)` from coreutils:
+
+```bash
+# v0.9.3 / US-001: wallclock timeout guard. Default 30 min ceiling
+# (configurable via QL_COORDINATOR_TIMEOUT_S). On timeout: kill the
+# coord subprocess and surface as WAVE_FAILED so per-story aggregation
+# runs from review fields (which the coordinator may have written
+# partially before hanging).
+QL_COORDINATOR_TIMEOUT_S="${QL_COORDINATOR_TIMEOUT_S:-1800}"
+OUTPUT=$(timeout --kill-after=10s "${QL_COORDINATOR_TIMEOUT_S}s" bash -c "$COORD_CMD" 2>&1) || RUNNER_EXIT=$?
+if [[ "$RUNNER_EXIT" == "124" ]]; then
+  printf "ERROR: Coordinator subagent exceeded %ss timeout; marking wave failed.\n" "$QL_COORDINATOR_TIMEOUT_S" >&2
+  SIGNAL_RESULT="WAVE_FAILED"
+fi
+```
+
+`timeout` returns 124 on SIGTERM kill (per `timeout(1)` man page). The `--kill-after=10s` adds a 10-second grace period before SIGKILL.
+
+**Acceptance Criteria:**
+- [ ] `quantum-loop.sh:1572-1585` wraps `eval "$COORD_CMD"` with `timeout`. Default 30 min; configurable via `QL_COORDINATOR_TIMEOUT_S` env var.
+- [ ] On timeout (rc=124): `SIGNAL_RESULT="WAVE_FAILED"` set + ERROR message printed to stderr (pattern matching `Coordinator subagent exceeded.*timeout`).
+- [ ] Tests/test_coordinator_e2e.sh adds Test 6: stub `claude` script that sleeps > timeout; assert ERROR printed + per-story aggregation falls through to WAVE_FAILED branch. Set `QL_COORDINATOR_TIMEOUT_S=5` for the test to keep wallclock bounded.
+- [ ] Existing tests (1-5) continue to pass.
+- [ ] `bash -n quantum-loop.sh` clean.
+
+### US-002 — Re-evaluate `ql_wrap_subagent_dispatch` gating under coordinator mode
+
+**Problem:** v0.9.0 US-001 gated `ql_wrap_subagent_dispatch` OFF under coordinator mode (rationale: respawn would re-spawn entire wave with stale single-story args). v0.9.3 US-001 adds an alternative timeout-based mechanism; should the wrap be re-enabled?
+
+**Analysis:**
+- `ql_wrap_subagent_dispatch` polls for git commits during subagent run; fires STALE if no commits within ceiling.
+- Under coordinator mode, the coordinator may legitimately spend time aggregating signals + writing review fields without producing new commits — STALE would false-positive.
+- US-001's wallclock timeout is blanket-ceiling (kills entire process). Less granular but safer for coordinator mode.
+
+**Decision:** **KEEP OFF** under coordinator mode. Update inline comment to explicitly document:
+1. Why STALE detection is unsafe under coordinator mode (false-positive on aggregation pauses).
+2. Cross-reference v0.9.3 US-001's timeout as the operational alternative.
+3. Reaffirm N46 (respawn output re-parsing) still unresolved.
+
+**Acceptance Criteria:**
+- [ ] `quantum-loop.sh:~1657-1661` ql_wrap gate has updated comment explaining the rationale (the file already has v0.9.0 / US-001 comments; add v0.9.3 / US-002 follow-up note).
+- [ ] Comment includes explicit cross-reference to `QL_COORDINATOR_TIMEOUT_S` from US-001.
+- [ ] Behavioral change: NONE (the gate stays OFF; this is documentation only).
+
+### US-003 — Multi-perspective post-merge review (architect + code-reviewer + security)
+
+**Approach:** STANDARD pattern across v0.8.1, v0.8.2, v0.8.3, v0.8.4, v0.9.1. v0.9.2 skipped this (US-004 was dogfood). v0.9.3 resumes it as 5th application.
+
+3 parallel review agents on the v0.9.3 cycle diff (master..HEAD). Synthesize. Apply score-≥85 fixes inline.
+
+**Acceptance Criteria:**
+- [ ] 3 reviewer agents invoked in parallel via Agent tool.
+- [ ] Each agent's findings logged in retrospective.
+- [ ] Synthesis section: which findings addressed inline + which deferred.
+- [ ] No score-≥85 finding deferred.
+
+### US-004 — Retrospective + IDEA_REPORT_v30 + version bump 0.9.2 → 0.9.3
+
+**Approach:** Standard cycle close. PIPELINE_REPORT_v30 + IDEA_REPORT_v30 + CHANGELOG [0.9.3] + 4 manifest bumps.
+
+**Acceptance Criteria:**
+- [ ] Both new docs exist with cycle outcomes.
+- [ ] CHANGELOG `[0.9.3]` entry.
+- [ ] All 4 manifest version fields = "0.9.3".
+- [ ] G30 self-validation captured.
+
+## Test-suite delta
+
+| Test file | v0.9.2 | v0.9.3 | delta |
+|---|---:|---:|---:|
+| `tests/test_coordinator_e2e.sh` (+Test 6) | 13 | 14 | +1 |
+| **Total v0.9.3 added:** | | | **+1** |
+
+## Cross-cutting risk surface
+
+1. **`timeout` availability** — coreutils on Git Bash. Standard. No new dependency.
+2. **30 min default may be too short for real-feature dispatch** — operator can override via `QL_COORDINATOR_TIMEOUT_S` env. Document in CHANGELOG.
+3. **`bash -c "$COORD_CMD"` vs `eval "$COORD_CMD"`** — slight difference in scoping, but both evaluate the string as shell. Inherits command construction from `spawn_coordinator`.
+
+## Non-goals
+
+- No N43 (parallel-with-dispatch wrap pattern).
+- No N46 (respawn output re-parsing).
+- No real-feature dogfood (deferred to v0.10.0+).
+- No PowerShell parity.
+- No N47 bundle cleanup.

--- a/idea-stage/IDEA_REPORT_v30.md
+++ b/idea-stage/IDEA_REPORT_v30.md
@@ -1,0 +1,68 @@
+# IDEA_REPORT_v30 — what's open after v0.9.3
+
+**Date:** 2026-04-30
+**Source:** v0.9.3 ships parent-side wallclock timeout closing v0.9.2's iter-3 hang. 18/18 tests green. Multi-perspective review surfaced 1 HIGH + 1 MEDIUM (both inline-fixed).
+**Branch:** `ql/v0.9.3-bundle` (release tag v0.9.3 — pending)
+**Predecessor:** `idea-stage/IDEA_REPORT_v29.md`
+
+## Closed in v0.9.3
+
+| ID | Story | Notes |
+|---|---|---|
+| **5a iter-3 hang** | US-001 | Parent-side `timeout` wrap; default 1800s; configurable. |
+| **ql_wrap re-evaluation** | US-002 | KEEP OFF documented; rationale + cross-ref to US-001. |
+| **Code-reviewer HIGH (FR-1)** | US-003 | `command -v timeout` guard with WARN fallback. |
+| **Code-reviewer MEDIUM (numeric validation)** | US-003 | Regex check + WARN + default on bad input. |
+
+## Persistent canon
+
+p001-p012 carried forward. No new patterns. Multi-perspective review pattern at 5 applications (post-v0.8.1, v0.8.2, v0.8.3, v0.8.4, v0.9.1, v0.9.3).
+
+## v0.9.4 candidate slate (low-priority housekeeping)
+
+The substantive v0.9.x work is largely complete. v0.9.4 would be a smaller housekeeping cycle if pursued.
+
+| Story | Content | Severity |
+|-------|---------|----------|
+| US-001 | (Optional) Real-feature dogfood — pick small task (e.g., one of the LOW backlog items) and dispatch through `--coordinator` end-to-end. Validates non-synthetic behavior. | MEDIUM |
+| US-002 | Architect MEDIUM (~70): one-line `bash -c "$COORD_CMD"` comment in quantum-loop.sh noting subshell-scoping constraint for future runner authors. | LOW |
+| US-003 | Code-reviewer LOW: simplify `${RUNNER_EXIT:-0}` to `$RUNNER_EXIT` (RUNNER_EXIT initialized at line ~1578; default redundant). | LOW |
+| US-004 | Multi-perspective post-merge review (architect + code-reviewer + security). 6th application. | LOW |
+| US-005 | Retrospective + IDEA_REPORT_v31 + version bump 0.9.3 → 0.9.4. | LOW |
+
+**Honest framing:** v0.9.4 candidate slate is mostly cosmetic + 1 optional dogfood. The v0.9.x track has reached structural maturity. The next significant cycle would be **v0.10.0** (architect-recommended outer-loop replacement; deferred from v0.9.0).
+
+## Still open (carried forward)
+
+### N46 (respawn output not re-parsed)
+
+**Status:** unchanged. `ql_wrap_subagent_dispatch` gated OFF under coordinator mode (rationale documented in v0.9.3 US-002 comment). The v0.9.3 US-001 wallclock timeout is the operational alternative.
+**Severity:** MEDIUM. **Path:** v0.9.4+ if wrap re-enabled (currently no compelling reason).
+
+### N43, N47, N48, N49, N50
+
+All unchanged. LOW priority.
+
+### N40, N38, copilot rate-limit observability, N41, N44, N45
+
+All unchanged. LOW priority.
+
+## v0.10.0 candidate slate (next major arc)
+
+Architect-recommended in v0.9.0 retrospective: **outer-loop replacement**. Replace `quantum-loop.sh`'s for-loop iteration mechanism with a daemon-style runner. Out of scope for v0.9.x. Significant architectural work.
+
+**Why deferred:** v0.9.x focused on per-wave coordinator dispatch + closing operational gaps. v0.10.0 would tackle the outer iteration loop itself.
+
+## Recurring observations
+
+- **24 consecutive LOW G30 self-validations** (v0.6.5..v0.9.3).
+- **Bundle size: 7-7-7-7-5-6-5-3-7-3-2-4-3-3-7-7-5-5-4-4-7-5-5-4.** v0.9.3 is 4-story (smallest in 25 cycles).
+- **Manual-takeover streak: BROKEN through v0.9.3.** Cron-driven /loop pattern handled v0.9.3 end-to-end.
+- **Multi-perspective review pattern validated 5th time** (architectural-tier + post-merge-review combined). p013 candidate (after 1 more application).
+- **Operator-staged kickoff** at `11a033e` (design + PRD + advisory hooks) — 4th application of pattern (after v0.9.0/v0.9.1/v0.9.2 kickoffs). Should be formalized as p013.
+
+## v0.9.x track outlook
+
+v0.9.0 (architectural minor — wires) → v0.9.1 (validation patch — streak BROKEN) → v0.9.2 (defensive hardening — 5a CLOSED engineered) → **v0.9.3 (operational hardening — iter-3 hang CLOSED engineered)** → v0.9.4 (optional housekeeping; minor cleanup) → **v0.10.0** (architect-recommended outer-loop replacement; significant architectural work; not yet scoped).
+
+The v0.9.x track has reached operational + structural maturity. Time to consider whether v0.9.4 housekeeping is worth a cycle, OR pivot directly to v0.10.0 design phase.

--- a/idea-stage/PIPELINE_REPORT_v30.md
+++ b/idea-stage/PIPELINE_REPORT_v30.md
@@ -1,0 +1,93 @@
+# PIPELINE_REPORT_v30 — v0.9.3 retrospective (operational hardening; iter-3 hang closed)
+
+**Date:** 2026-04-30
+**Bundle:** `ql/v0.9.3-bundle` (release tag v0.9.3 — pending push/PR/merge/tag/release)
+**Predecessor report:** `idea-stage/PIPELINE_REPORT_v29.md`
+**Master parent:** `6230577` (v0.9.2 ship state)
+**Source:** Operator-staged plan from `idea-stage/IDEA_REPORT_v29.md` § "v0.9.3 candidate slate" (primary: 5a iter-3 hang).
+
+## Overview
+
+v0.9.3 closes v0.9.2's documented operational gap — coordinator subagent stuck mid-`eval "$COORD_CMD"` for 3+ hours during dogfood iteration 3. Adds parent-side wallclock timeout via `timeout(1)` from coreutils. 4-story cycle (smallest v0.9.x cycle so far).
+
+## Headline result
+
+**v0.9.2 iter-3 hang — CLOSED (engineered).** `quantum-loop.sh` now wraps `eval "$COORD_CMD"` with `timeout --kill-after=10s ${QL_COORDINATOR_TIMEOUT_S:-1800}s bash -c "$COORD_CMD"`. On rc=124 (SIGTERM kill), `SIGNAL_RESULT` is forced to `WAVE_FAILED` with an explicit ERROR; the parent's per-story aggregation runs from review fields. Default 30 min ceiling; configurable via env. Test 6 in `test_coordinator_e2e.sh` validates the timeout fires.
+
+## The 4 stories
+
+| # | ID | Title | Outcome |
+|:-:|---|---|:-:|
+| 0 | (cycle setup) | chore: v0.9.3 cycle kickoff (design + PRD + advisory hooks) | committed at `11a033e` |
+| 1 | US-001 + US-002 (atomic) | Parent-side wallclock timeout + KEEP-OFF rationale documentation | first-attempt PASS at `1563e1d` |
+| 2 | US-003 | Multi-perspective post-merge review + 2 score-≥85 inline fixes | first-attempt PASS at `faf6f59` |
+| 3 | US-004 | Retrospective + IDEA_REPORT_v30 + version bump 0.9.2 → 0.9.3 | this report |
+
+## Multi-perspective review synthesis
+
+| Reviewer | Verdict | Key finding |
+|---|---|---|
+| **Architect** | SHIP | 1 MEDIUM (~70) re bash -c subshell scoping comment — DEFER. 5 LOW positive observations. No reworks needed. |
+| **Code-reviewer** | REQUEST CHANGES → SHIP | **1 HIGH score 90 INLINE FIXED:** missing `timeout` availability guard per FR-1 (matched `lib/dep-manifest.sh:255` pattern). **1 MEDIUM score 88 INLINE FIXED:** numeric validation on `QL_COORDINATOR_TIMEOUT_S` (non-numeric input now WARN + default). 2 LOWs deferred (cosmetic). |
+| **Security** | SHIP | 1 LOW (covered by code-reviewer's HIGH fix). No CRITICAL/HIGH; no injection surface change; no secret exposure. |
+
+US-003 review pattern: **5th application** (post-v0.8.1, v0.8.2, v0.8.3, v0.8.4, v0.9.1; SKIPPED in v0.9.2 because US-004 was dogfood; resumed in v0.9.3). Pattern continues to surface real findings on small cycles.
+
+## v0.9.3 fixes shipped + deferrals
+
+### Closed
+
+| Finding | Severity | Closure |
+|---|---|---|
+| **5a iter-3 hang (v0.9.2 retro)** | MEDIUM | CLOSED. Parent-side `timeout` wrap; default 1800s. |
+| **Code-reviewer HIGH (FR-1)** | HIGH | CLOSED INLINE. `command -v timeout` guard with WARN fallback. |
+| **Code-reviewer MEDIUM (numeric validation)** | MEDIUM | CLOSED INLINE. Regex `^[0-9]+$` check; WARN + default on bad input. |
+| **`ql_wrap_subagent_dispatch` re-evaluation** | DOCUMENTATION | CLOSED. Comment expansion clarifies KEEP-OFF rationale + cross-ref to US-001. |
+
+### Deferred to v0.9.4+
+
+| Finding | Severity | Path |
+|---|---|---|
+| Architect MEDIUM (bash -c subshell scoping comment) | MEDIUM (~70) | One-line code comment for future runner authors. |
+| Code-reviewer LOWs (redundant default, unreachable test echo) | LOW | Cosmetic; v0.9.4 housekeeping. |
+| **N46** (respawn output not re-parsed) | MEDIUM | Unchanged. v0.9.4+ if wrap re-enabled (unlikely given US-001 alternative). |
+| **N40, N43, N47, N49, N50** | LOW | Carried forward. |
+
+## Wave plan vs realized
+
+US-001 and US-002 share `quantum-loop.sh` (fileConflict declared). US-001+US-002 committed atomically (54 LOC; both touch lines ~1592 and ~1670 respectively). US-003 dependsOn US-001+US-002 (review the diff). US-004 dependsOn all.
+
+Realized order:
+1. cycle kickoff at `11a033e`
+2. US-001+US-002 atomic at `1563e1d`
+3. US-003 review + inline fixes at `faf6f59`
+4. US-004 (this retrospective)
+
+## G30 self-validation — 24th consecutive LOW
+
+`bash lib/deep-review.sh score $BASE $HEAD` → tier=LOW (small diff: 26 LOC quantum-loop.sh + 60 LOC tests + 470 LOC docs). 24 consecutive LOW (v0.6.5..v0.9.3).
+
+## CSV milestone
+
+`metrics/pre-impl-review-findings.csv` → 61 rows. Advisory hook findings for v0.9.3: design + prd + plan all 1 LOW each.
+
+## Test-suite delta vs v0.9.2
+
+| Test file | v0.9.2 | v0.9.3 | delta |
+|---|---:|---:|---:|
+| `tests/test_coordinator_e2e.sh` (+Test 6 + Test 7) | 13 | 18 | +5 |
+| **Total v0.9.3 added:** | | | **+5** |
+
+Cumulative: ~111 → ~116 assertions.
+
+## Manual-takeover streak
+
+v0.9.3 was driven via the autonomous /loop pattern (cron every 10 min). All 4 stories first-attempt PASS. No mid-cycle operator intervention required (the dogfood iter-3 hang from v0.9.2 was the LAST manual-takeover instance). **Streak: BROKEN through v0.9.3.**
+
+## codebasePatterns
+
+p001-p012 carried forward. No new patterns this cycle.
+
+## Recommendation pointer
+
+See `idea-stage/IDEA_REPORT_v30.md` for what's open after v0.9.3.

--- a/metrics/pre-impl-review-findings.csv
+++ b/metrics/pre-impl-review-findings.csv
@@ -56,3 +56,6 @@ timestamp,stage,source_path,count,critical,high,medium,low
 2026-04-30T05:38:22Z,design,docs/plans/2026-04-30-v0.9.2-bundle-design.md,1,0,0,0,1
 2026-04-30T05:38:46Z,prd,tasks/prd-v0.9.2-bundle.md,1,0,0,0,1
 2026-04-30T05:39:10Z,plan,quantum.json,1,0,0,0,1
+2026-04-30T11:29:51Z,design,docs/plans/2026-04-30-v0.9.3-bundle-design.md,1,0,0,0,1
+2026-04-30T11:30:10Z,prd,tasks/prd-v0.9.3-bundle.md,1,0,0,0,1
+2026-04-30T11:30:29Z,plan,quantum.json,1,0,0,0,1

--- a/quantum-loop.sh
+++ b/quantum-loop.sh
@@ -1594,8 +1594,20 @@ for ITERATION in $(seq 1 "$MAX_ITERATIONS"); do
     # kill from `timeout`), the override below sets SIGNAL_RESULT to
     # WAVE_FAILED so per-story aggregation runs from review fields. Closes
     # v0.9.2 dogfood iter-3 hang (coordinator subagent stuck > 3 hours).
+    # v0.9.3 / US-003 review fixes: validate numeric (default 1800 on bad
+    # input) + degrade gracefully if `timeout` is not on PATH (warn + run
+    # without wallclock guard).
     QL_COORDINATOR_TIMEOUT_S="${QL_COORDINATOR_TIMEOUT_S:-1800}"
-    OUTPUT=$(timeout --kill-after=10s "${QL_COORDINATOR_TIMEOUT_S}s" bash -c "$COORD_CMD" 2>&1) || RUNNER_EXIT=$?
+    if ! [[ "$QL_COORDINATOR_TIMEOUT_S" =~ ^[0-9]+$ ]]; then
+      printf "WARN: QL_COORDINATOR_TIMEOUT_S must be a non-negative integer (got '%s'); using default 1800.\n" "$QL_COORDINATOR_TIMEOUT_S" >&2
+      QL_COORDINATOR_TIMEOUT_S=1800
+    fi
+    if command -v timeout >/dev/null 2>&1; then
+      OUTPUT=$(timeout --kill-after=10s "${QL_COORDINATOR_TIMEOUT_S}s" bash -c "$COORD_CMD" 2>&1) || RUNNER_EXIT=$?
+    else
+      printf "WARN: timeout(1) not on PATH; coordinator dispatch running without wallclock guard. v0.9.2 iter-3 hang scenario possible.\n" >&2
+      OUTPUT=$(bash -c "$COORD_CMD" 2>&1) || RUNNER_EXIT=$?
+    fi
   elif [[ "$RUNNER_NAME" == "claude" ]]; then
     # Claude Code: preserve original command structure — CLAUDE.md via -p, story instruction via --
     PROMPT_FILE="$SCRIPT_DIR/CLAUDE.md"

--- a/quantum-loop.sh
+++ b/quantum-loop.sh
@@ -1589,7 +1589,13 @@ for ITERATION in $(seq 1 "$MAX_ITERATIONS"); do
       continue
     }
     printf "Spawning coordinator for %s with %d story/stories: %s\n" "$WAVE_ID" "$(echo "$WAVE_STORY_IDS_JSON" | jq 'length')" "$STORY_IDS_STR"
-    OUTPUT=$(eval "$COORD_CMD" 2>&1) || RUNNER_EXIT=$?
+    # v0.9.3 / US-001: wallclock timeout guard. Default 30 min ceiling
+    # (configurable via QL_COORDINATOR_TIMEOUT_S env). On rc=124 (SIGTERM
+    # kill from `timeout`), the override below sets SIGNAL_RESULT to
+    # WAVE_FAILED so per-story aggregation runs from review fields. Closes
+    # v0.9.2 dogfood iter-3 hang (coordinator subagent stuck > 3 hours).
+    QL_COORDINATOR_TIMEOUT_S="${QL_COORDINATOR_TIMEOUT_S:-1800}"
+    OUTPUT=$(timeout --kill-after=10s "${QL_COORDINATOR_TIMEOUT_S}s" bash -c "$COORD_CMD" 2>&1) || RUNNER_EXIT=$?
   elif [[ "$RUNNER_NAME" == "claude" ]]; then
     # Claude Code: preserve original command structure — CLAUDE.md via -p, story instruction via --
     PROMPT_FILE="$SCRIPT_DIR/CLAUDE.md"
@@ -1633,6 +1639,16 @@ for ITERATION in $(seq 1 "$MAX_ITERATIONS"); do
   # Parse runner output for signals (uses heuristics if enabled for non-Claude runners)
   runner_parse_output "$OUTPUT" "$RUNNER_EXIT"
 
+  # v0.9.3 / US-001: timeout override. If `timeout` killed the coordinator
+  # subagent (rc=124), force SIGNAL_RESULT=WAVE_FAILED regardless of what
+  # runner_parse_output classified the (possibly empty/partial) output as.
+  # This ensures the WAVE_FAILED branch's per-story review-field aggregation
+  # runs uniformly. Closes v0.9.2 dogfood iter-3 hang.
+  if [[ "$COORDINATOR_MODE" == "true" && "${RUNNER_EXIT:-0}" == "124" ]]; then
+    printf "ERROR: Coordinator subagent exceeded %ss timeout; marking wave failed.\n" "$QL_COORDINATOR_TIMEOUT_S" >&2
+    SIGNAL_RESULT="WAVE_FAILED"
+  fi
+
   # v0.8.1 / US-001 (N39 dogfood) — wire ql_wrap_subagent_dispatch into the
   # production runner loop. The function was defined in v0.8.0 US-001 but
   # had zero callers in quantum-loop.sh — exactly N33 root cause #1
@@ -1654,6 +1670,14 @@ for ITERATION in $(seq 1 "$MAX_ITERATIONS"); do
   # designed for single-story respawn — re-running it under coordinator
   # mode would re-spawn the entire wave with stale story arguments.
   # N46 (respawn output re-parsing) is the proper v0.9.1+ fix.
+  # v0.9.3 / US-002 follow-up: re-evaluation kept gate OFF.
+  # Rationale: STALE detection unsafe under coordinator mode — the coordinator
+  # may legitimately spend minutes aggregating signals + writing review
+  # fields without producing new commits, which would false-positive STALE.
+  # The v0.9.3 US-001 wallclock timeout (QL_COORDINATOR_TIMEOUT_S, default
+  # 1800s) is the operational alternative: blanket wallclock kill rather
+  # than commit-progress poll. N46 (respawn output re-parsing) remains
+  # unresolved as of v0.9.3.
   if [[ "$COORDINATOR_MODE" != "true" \
         && "${SIGNAL_RESULT:-}" == "STORY_FAILED" \
         && "${SIGNAL_CONFIDENCE:-}" != "exact" ]]; then

--- a/tasks/prd-v0.9.3-bundle.md
+++ b/tasks/prd-v0.9.3-bundle.md
@@ -1,0 +1,98 @@
+# PRD: v0.9.3 — patch-tier (operational hardening — closes v0.9.2 iter-3 hang)
+
+**Status:** Approved
+**Date:** 2026-04-30
+**Design doc:** `docs/plans/2026-04-30-v0.9.3-bundle-design.md`
+**Source:** `idea-stage/IDEA_REPORT_v29.md` § "v0.9.3 candidate slate"
+**Branch:** `ql/v0.9.3-bundle`
+**Target version:** 0.9.3 (patch from 0.9.2)
+**Total effort estimate:** ~2-3 hours
+
+## Section 1: Introduction / Overview
+
+4-story patch closing the operational gap surfaced by v0.9.2's dogfood iteration 3 hang (coordinator subagent stuck > 3 hours mid-`eval "$COORD_CMD"`). Adds a parent-side wallclock timeout; re-evaluates the v0.9.0 `ql_wrap_subagent_dispatch` gating decision; resumes the post-merge multi-perspective review pattern (5th application; SKIPPED in v0.9.2 because US-004 was dogfood).
+
+## Section 2: Goals
+
+- Add `timeout`-based wallclock guard around `eval "$COORD_CMD"` in `quantum-loop.sh`.
+- Configurable via `QL_COORDINATOR_TIMEOUT_S` env var (default 1800 = 30 min).
+- On timeout: surface as `WAVE_FAILED` for per-story aggregation.
+- Update `ql_wrap_subagent_dispatch` gate comment with explicit rationale (KEEP OFF) + cross-ref to US-001.
+- Spawn 3 parallel reviewers (architect + code-reviewer + security) on the v0.9.3 diff.
+- Bump plugin version 0.9.2 → 0.9.3 (4 manifest fields).
+- Populate `metrics/pre-impl-review-findings.csv` with 3 new rows (total ≥61).
+
+## Section 3: User Stories
+
+### US-001: Parent-side wallclock timeout on `eval "$COORD_CMD"`
+
+**Acceptance Criteria:**
+- [ ] `quantum-loop.sh` line ~1585 (the `eval "$COORD_CMD"` invocation) wrapped with `timeout --kill-after=10s "${QL_COORDINATOR_TIMEOUT_S}s" bash -c "$COORD_CMD"`.
+- [ ] `QL_COORDINATOR_TIMEOUT_S` env var with default 1800 (30 min) read at top of the spawn block.
+- [ ] On timeout (rc=124 from `timeout`): set `SIGNAL_RESULT="WAVE_FAILED"`; print ERROR to stderr (pattern: `Coordinator subagent exceeded.*timeout`).
+- [ ] `tests/test_coordinator_e2e.sh` adds Test 6 (`hung_coordinator` mode): stub `claude` script that sleeps > timeout; uses `QL_COORDINATOR_TIMEOUT_S=5` to keep test wallclock < 30s; asserts ERROR pattern + per-story aggregation runs.
+- [ ] Existing Tests 1-5 in `test_coordinator_e2e.sh` continue to pass (13/13 → 14/14).
+- [ ] `bash -n quantum-loop.sh` clean.
+
+### US-002: Re-evaluate `ql_wrap_subagent_dispatch` gating under coordinator mode
+
+**Acceptance Criteria:**
+- [ ] `quantum-loop.sh:~1657-1661` ql_wrap gate has updated multi-line comment explaining:
+   1. Why STALE detection is unsafe under coordinator mode (false-positive on aggregation pauses where the coordinator legitimately doesn't commit for minutes).
+   2. Cross-reference to `QL_COORDINATOR_TIMEOUT_S` from US-001 as the operational alternative.
+   3. Reaffirm N46 (respawn output re-parsing) still unresolved.
+- [ ] Behavioral change: NONE (the gate stays OFF — this is documentation only).
+- [ ] `bash -n quantum-loop.sh` clean.
+
+### US-003: Multi-perspective post-merge review (architect + code-reviewer + security)
+
+**Acceptance Criteria:**
+- [ ] 3 reviewer agents invoked in parallel via Agent tool: `oh-my-claudecode:architect`, `oh-my-claudecode:code-reviewer`, `oh-my-claudecode:security-reviewer`.
+- [ ] Each agent receives the v0.9.3 cycle diff (`git diff origin/master...HEAD`) as scope.
+- [ ] Each agent's findings logged in retrospective.
+- [ ] Synthesis: which findings addressed inline + which deferred.
+- [ ] No score-≥85 finding deferred.
+
+### US-004: Retrospective + IDEA_REPORT_v30 + version bump 0.9.2 → 0.9.3
+
+**Acceptance Criteria:**
+- [ ] `idea-stage/PIPELINE_REPORT_v30.md` documents v0.9.3 (4 stories, outcomes, US-003 review synthesis).
+- [ ] `idea-stage/IDEA_REPORT_v30.md` lists open after v0.9.3; carries forward N40, N43, N46, N47, N49, N50.
+- [ ] `CHANGELOG.md [0.9.3]` entry.
+- [ ] 4 plugin manifest version fields bumped 0.9.2 → 0.9.3.
+- [ ] G30 self-validation captured.
+
+## Section 4: Functional Requirements
+
+- **FR-1:** `timeout` from coreutils MUST be available (validated at install time; falls back to no-timeout with warning if missing — but this is unlikely on Git Bash + Linux).
+- **FR-2:** `QL_COORDINATOR_TIMEOUT_S` MUST be respected when set; default 1800 otherwise.
+- **FR-3:** Test 6 in `test_coordinator_e2e.sh` MUST exercise the actual `timeout` rc=124 path.
+- **FR-4:** US-002 is documentation-only; no behavioral change.
+- **FR-5:** CSV ≥61 rows; plugin version 0.9.2 → 0.9.3.
+
+## Section 5: Non-Goals
+
+- No N43, N46, N47, N48, N49, N50.
+- No real-feature dogfood (defer to v0.10.0+).
+- No PowerShell parity for the new timeout.
+
+## Section 6: Design Notes
+
+See `docs/plans/2026-04-30-v0.9.3-bundle-design.md`.
+
+## Section 7: Technical Notes
+
+`timeout(1)` from GNU coreutils. Available on Git Bash + Linux + macOS. Returns 124 on SIGTERM kill, 137 on SIGKILL. `--kill-after=10s` adds grace before SIGKILL.
+
+## Section 8: Success Metrics
+
+- All 4 stories first-attempt PASS.
+- CSV at ≥61 rows.
+- Test count: 111 → 112 (+1 from Test 6).
+- US-003 review trio runs without surfacing score-≥85 findings (or ≥85 findings addressed inline).
+- v0.9.2 iter-3 hang: CLOSED (engineered).
+
+## Section 9: Open Questions
+
+- **Q1:** What's the right default timeout? **Decision:** 1800s (30 min). Rationale: v0.9.1 dogfood completed in ~18 min; v0.9.2 dogfood iters 1+2 each ~10-30 min; iter 3 hung > 3 hours. 30 min ceiling catches hangs without false-positive on legitimate slow waves.
+- **Q2:** Should US-002 actually re-enable `ql_wrap_subagent_dispatch`? **Decision:** No. The new timeout is sufficient + simpler. Document rationale only.

--- a/tests/test_coordinator_e2e.sh
+++ b/tests/test_coordinator_e2e.sh
@@ -125,6 +125,14 @@ case "$MODE" in
     )' quantum.json > quantum.json.tmp && mv quantum.json.tmp quantum.json
     echo "<quantum>STORY_PASSED</quantum>"
     ;;
+  hung_coordinator)
+    # v0.9.3 / US-001 — simulate a hung coordinator subagent. Sleep longer
+    # than QL_COORDINATOR_TIMEOUT_S so the parent's timeout wrap fires.
+    # The stub does NOT write review.* fields (parent's per-story
+    # aggregation defaults stories to failed under WAVE_FAILED branch).
+    sleep 30
+    echo "<quantum>WAVE_PASSED</quantum>"
+    ;;
   *)
     echo "<quantum>WAVE_FAILED</quantum>"
     ;;
@@ -288,6 +296,27 @@ US_B_STATUS=$(jq -r '.stories[] | select(.id == "US-B") | .status' "$TEST_ROOT/w
 assert_contains "Test 5: WARNING about unexpected STORY_* signal" "Unexpected STORY_PASSED under coordinator mode" "$OUT"
 assert_eq "Test 5: US-A status=passed (review fields drove via WAVE_FAILED branch)" "passed" "$US_A_STATUS"
 assert_eq "Test 5: US-B status=passed (review fields drove via WAVE_FAILED branch)" "passed" "$US_B_STATUS"
+
+rm -rf "$TEST_ROOT/work"
+
+# ─ Test 6: hung coordinator -> wallclock timeout fires (US-001) ───────────
+# v0.9.3 / US-001 — parent-side wallclock timeout on eval "$COORD_CMD".
+# Stub coordinator sleeps 30s; QL_COORDINATOR_TIMEOUT_S=5 fires the
+# timeout. Parent should print ERROR + redirect to WAVE_FAILED branch
+# (per-story aggregation: stories with no review fields -> failed).
+echo ""
+echo "Test 6: hung coordinator -> wallclock timeout fires (US-001)"
+mkdir -p "$TEST_ROOT/work"
+write_2story_plan "$TEST_ROOT/work/quantum.json"
+printf 'hung_coordinator' > "$TEST_ROOT/work/.test-coord-mode"
+
+OUT=$(cd "$TEST_ROOT/work" && QL_COORDINATOR_TIMEOUT_S=5 PATH="$STUB_DIR:$PATH" bash "$QL_BIN" --coordinator --tool claude --max-iterations 1 --non-interactive 2>&1)
+
+US_A_STATUS=$(jq -r '.stories[] | select(.id == "US-A") | .status' "$TEST_ROOT/work/quantum.json")
+US_B_STATUS=$(jq -r '.stories[] | select(.id == "US-B") | .status' "$TEST_ROOT/work/quantum.json")
+assert_contains "Test 6: ERROR about timeout exceeded" "Coordinator subagent exceeded" "$OUT"
+assert_eq "Test 6: US-A status=failed (no review fields after timeout)" "failed" "$US_A_STATUS"
+assert_eq "Test 6: US-B status=failed (no review fields after timeout)" "failed" "$US_B_STATUS"
 
 rm -rf "$TEST_ROOT/work"
 

--- a/tests/test_coordinator_e2e.sh
+++ b/tests/test_coordinator_e2e.sh
@@ -320,6 +320,26 @@ assert_eq "Test 6: US-B status=failed (no review fields after timeout)" "failed"
 
 rm -rf "$TEST_ROOT/work"
 
+# ─ Test 7: invalid QL_COORDINATOR_TIMEOUT_S triggers WARN + default ──────
+# v0.9.3 / US-003 review fix (code-reviewer MEDIUM score 88): validate
+# numeric. Set non-numeric env value; assert WARN printed + dispatch runs
+# successfully (using default 1800). Stub uses `passed` mode so the wave
+# completes normally (no actual timeout fires; just validates the WARN
+# path doesn't break dispatch).
+echo ""
+echo "Test 7: invalid QL_COORDINATOR_TIMEOUT_S -> WARN + default (US-003 review fix)"
+mkdir -p "$TEST_ROOT/work"
+write_2story_plan "$TEST_ROOT/work/quantum.json"
+printf 'passed' > "$TEST_ROOT/work/.test-coord-mode"
+
+OUT=$(cd "$TEST_ROOT/work" && QL_COORDINATOR_TIMEOUT_S=thirty PATH="$STUB_DIR:$PATH" bash "$QL_BIN" --coordinator --tool claude --max-iterations 1 --non-interactive 2>&1)
+
+assert_contains "Test 7: WARN about non-numeric" "QL_COORDINATOR_TIMEOUT_S must be a non-negative integer" "$OUT"
+US_A_STATUS=$(jq -r '.stories[] | select(.id == "US-A") | .status' "$TEST_ROOT/work/quantum.json")
+assert_eq "Test 7: dispatch still completed (US-A passed)" "passed" "$US_A_STATUS"
+
+rm -rf "$TEST_ROOT/work"
+
 echo ""
 echo "=== Results: $PASS/$TOTAL passed, $FAIL failed ==="
 if (( FAIL > 0 )); then


### PR DESCRIPTION
## Summary
- Patch-tier operational-hardening cycle closing v0.9.2 iter-3 hang (coordinator subagent stuck > 3 hours mid-eval).
- New parent-side wallclock timeout via `timeout(1)` from coreutils. Default 30 min ceiling; configurable via `QL_COORDINATOR_TIMEOUT_S`.
- 4 stories first-attempt PASS; +5 test asserts (13 → 18 in test_coordinator_e2e.sh).

## Test plan
- [x] All 6 v0.9.0 test suites green; test_coordinator_e2e.sh: 18/18 (Tests 6 + 7 new for US-001 + US-003 review fix)
- [x] Version bump consistent across 4 manifest fields
- [x] Multi-perspective review trio (architect + code-reviewer + security) — 5th application: 1 HIGH (FR-1 violation; INLINE FIXED) + 1 MEDIUM (numeric validation; INLINE FIXED) + 1 architect MEDIUM (DEFER); SHIP verdict from all 3 after fixes
- [x] `bash -n quantum-loop.sh` clean

## Honest framing
v0.9.x track has reached operational + structural maturity. v0.9.4 candidate slate (in IDEA_REPORT_v30) is mostly cosmetic housekeeping. Next significant cycle = v0.10.0 (architect-recommended outer-loop replacement).

Manual-takeover streak: BROKEN through v0.9.3 — cron-driven `/loop` pattern handled v0.9.3 end-to-end with no operator intervention.