### PR TITLE
chore: v0.10.0 design spike synthesis (research only; awaiting scope decision)

### DIFF
--- a/idea-stage/v0.10.0-design-spike-2026-05-01.md
+++ b/idea-stage/v0.10.0-design-spike-2026-05-01.md
@@ -1,0 +1,159 @@
+# v0.10.0 design spike synthesis (2026-05-01)
+
+**Date:** 2026-05-01 (post-v0.9.4 ship; master HEAD `63586f2`)
+**Source:** 3 parallel architect spike agents per `idea-stage/IDEA_REPORT_v31.md` § "v0.10.0 candidate slate" pre-cycle design framework.
+**Output:** spike synthesis + refined v0.10.0 slate. Research only — no code changes; no cycle kickoff yet.
+
+## Headline
+
+**v0.10.0 effort is ~5 hours — much smaller than originally framed.** The "outer-loop replacement" framing in IDEA_REPORT_v30 was unscoped; the spikes reveal:
+
+1. **Decomposition** is mechanical extraction (~2.5 hr; SMALL-MEDIUM lift).
+2. **Daemon-style runner** is **over-engineering** for the actual problem; the existing cron `/loop` pattern already solves it. Recommend downgrading to a documentation task (~30 min).
+3. **Parent-side `guard_head_advance`** is small + high-value defense-in-depth (~1.5 hr).
+
+This reframes v0.10.0 from "significant architectural work" to "patch-tier defensive hardening + decomposition refactor." Single 5-story cycle is sufficient.
+
+## Spike 1: Decompose `quantum-loop.sh` (1837 LOC)
+
+**Verdict:** SMALL-MEDIUM lift. Mechanical extraction; no logic changes.
+
+**Proposed file map:**
+
+| File | Content extracted | Est. LOC |
+|------|------------------|----------|
+| `quantum-loop.sh` (stays) | Shebang, defaults, CLI parsing, dependency checks, sourcing, pre-loop setup, main banner, mode dispatch | ~330 |
+| `lib/audit.sh` (NEW) | All `_audit_*` functions + `do_audit` + test-mode guard | ~420 |
+| `lib/iteration-loop.sh` (NEW) | Sequential/coordinator iteration loop body | ~400 |
+| `lib/loop-helpers.sh` (NEW) | `print_summary_table`, `detect_stale_stories`, `validate_and_run_test_cmd`, `final_verification_sweep`, `generate_observations` | ~300 |
+
+`quantum-loop.sh` drops 1837 → ~330 LOC. Each new lib stays within project's ~400-line norm.
+
+**Risks:**
+- **Shell-global variable coupling (mitigated)** — 15+ globals shared between CLI parse, pre-loop setup, and iteration loop. Survives via `source` scope-sharing; no refactor to explicit parameter passing required for initial extraction. Mitigation: document the global contract in lib header comments.
+- **`local` vs implicit-global vars (LOW)** — extract loop body as `run_iteration_loop()` function so `local` declarations work properly.
+- **Parallel mode scope (MEDIUM)** — parallel-mode block (~390 LOC) is separate concern; scope US-001 to sequential/coordinator loop only. Parallel extraction is follow-up.
+
+**Effort breakdown:** 6 mechanical sub-tasks summing to ~2.5 hours including test verification.
+
+**Source-order dependency chain (post-decomposition):**
+```
+quantum-loop.sh sources (in order):
+  1. lib/audit.sh           (for --audit shortcut; before arg parsing)
+  2. lib/common.sh
+  3. lib/json-atomic.sh
+  4. lib/runner.sh
+  5. lib/orchestrator-liveness.sh
+  6. lib/loop-helpers.sh    (after runner_load; uses RUNNER_* vars)
+  7. lib/dag-query.sh       (conditional: PARALLEL or COORDINATOR)
+  8. lib/spawn.sh           (conditional: PARALLEL or COORDINATOR)
+  9. lib/worktree.sh etc.   (conditional: PARALLEL only)
+ 10. lib/iteration-loop.sh  (after all above; last before dispatch)
+```
+
+## Spike 2: Daemon-style runner — DON'T BUILD IT
+
+**Verdict:** OVER-ENGINEERING. Recommend ADR (Architecture Decision Record), not code.
+
+**Architecture options compared:**
+
+| Option | Recommendation | Why |
+|--------|---------------|-----|
+| **A: Persistent daemon** | NO | New PID lockfile + signal handling + MSYS bugs; no demonstrated operational gain. |
+| **B: Cron `/loop` (current)** | YES — already in production | Proven empirically through v0.9.3 + v0.9.4 (zero manual takeover). Trivial signal handling (process exits). Cross-platform robust. |
+| **C: Inotify/fswatch** | NO | Not Windows-compatible; debounce complexity; disqualified by cross-platform requirement. |
+| **D: Hybrid (`while true` wrapper)** | DEFER | Marginal value over Option B; only consider if cron pattern fails. |
+
+**Root cause of the unscoped term:** "daemon-style runner" was introduced in `IDEA_REPORT_v30:52` as a vague aspiration BEFORE the autonomous `/loop` cron pattern proved itself in v0.9.3. By v0.9.4, the cron pattern empirically solved the original motivating problem ("operator must manually re-run quantum-loop.sh after MAX_ITERATIONS"), but nobody updated the forward-looking recommendation. Stale design aspiration.
+
+**Recommendation:**
+1. **Downgrade spike 2 to an ADR** — write `references/adr-001-outer-loop-architecture.md` (~30 min) documenting:
+   - Cron-triggered (`/loop`) is the chosen outer-loop architecture.
+   - Rationale: empirically proven; zero PID/signal complexity; cross-platform; trivial stop semantics.
+   - Future revisit triggers: Claude Code `/loop` deprecation; demonstrated operational failure of cron pattern.
+2. **Remove "daemon-style runner" from forward-looking docs** — update IDEA_REPORT_v30/v31 references to point at the new ADR.
+
+## Spike 3: Parent-side `guard_head_advance` (defense-in-depth)
+
+**Verdict:** SMALL lift; HIGH value. Closes the "LLM instruction-following dependency" gap from arc audit.
+
+**Insertion point:** `quantum-loop.sh:~1672` (after the v0.9.3 timeout override, before the v0.9.2 STORY_* redirect, before the case branch).
+
+**Implementation sketch:**
+
+```bash
+# Before dispatch (~line 1594, inside COORDINATOR_MODE==true block):
+HEAD_BEFORE_COORD=$(git rev-parse HEAD)
+
+# After dispatch + runner_parse_output + timeout override (~line 1672):
+if [[ "$COORDINATOR_MODE" == "true" ]]; then
+  source "$SCRIPT_DIR/lib/coordinator-guard.sh"
+  if ! guard_head_advance "$HEAD_BEFORE_COORD"; then
+    printf "ERROR: Parent-side HEAD guard fired. HEAD_BEFORE=%s, HEAD_AFTER=%s\n" \
+      "$HEAD_BEFORE_COORD" "$(git rev-parse HEAD)" >&2
+    SIGNAL_RESULT="WAVE_FAILED"
+  fi
+fi
+```
+
+**Defense-in-depth: keep BOTH layers.**
+- LLM-side (existing `agents/coordinator.md` step 2): finer granularity — knows WHICH implementer caused reset; can pass unaffected stories individually.
+- Parent-side (new): coarser — sees "HEAD was reset sometime during this wave"; marks entire wave failed. Removes LLM-trust dependency for the safety-critical check.
+
+**Test coverage:** new Test 8 in `tests/test_coordinator_e2e.sh` with `head_reset` stub mode (does `git reset --hard HEAD~1` then echoes WAVE_PASSED). Asserts parent-side ERROR + stories failed.
+
+**Effort:** ~1.5 hours (10 LOC quantum-loop.sh + 40 LOC test + 3 LOC docs + manual verification).
+
+## Refined v0.10.0 candidate slate
+
+Reframed from "significant architectural work" to **patch-tier defensive hardening + decomposition refactor**. 5 stories totaling ~5 hours.
+
+| Story | Title | Spike source | Effort |
+|-------|-------|:---:|:---:|
+| US-001 | Decompose `quantum-loop.sh` — extract `lib/audit.sh` + `lib/loop-helpers.sh` + `lib/iteration-loop.sh`; main file → ~330 LOC | Spike 1 | medium (~2.5 hr) |
+| US-002 | Parent-side `guard_head_advance` defense-in-depth + Test 8 | Spike 3 | small (~1.5 hr) |
+| US-003 | ADR-001: Outer-loop architecture decision record (cron pattern as canonical); update IDEA_REPORT references; remove "daemon-style runner" from forward-looking docs | Spike 2 | small (~30 min) |
+| US-004 | Multi-perspective post-merge review (architect + code-reviewer + security; 7th application) | pattern | small |
+| US-005 | Retrospective + IDEA_REPORT_v32 + version bump 0.9.4 → 0.10.0 (or 0.9.5; tier debatable — see below) | cycle close | small |
+
+### Tier debate: minor (0.10.0) vs patch (0.9.5)?
+
+The original IDEA_REPORT_v30 framing called this "minor" (architect-recommended outer-loop replacement). The spikes reveal the actual work is:
+- 1 decomposition refactor (no behavioral change)
+- 1 small defensive hardening (no new feature)
+- 1 ADR (documentation)
+- Standard review + retrospective
+
+Per `feedback_version_tier_calibration.md` from operator memory: "default to patch unless genuinely architectural." The decomposition is a refactor with NO new architecture — same flow, just split across files. The parent-side guard is defensive hardening (incremental over v0.9.2 + v0.9.3 patterns).
+
+**Recommendation:** v0.9.5 patch-tier is more accurate than v0.10.0 minor. The architect's original framing was based on the (now-debunked) "daemon-style runner" assumption. Without that, the cycle is patch-tier.
+
+**Operator decision:** v0.10.0 minor (for symbolic milestone) OR v0.9.5 patch (for accuracy). Both are defensible.
+
+## Open questions for operator
+
+1. **Approve v0.9.5/v0.10.0 cycle scope?** Refined slate above (5 stories; ~5 hours). Should it kick off autonomously per the loop pattern, or wait for explicit go-ahead?
+2. **Tier framing — patch (0.9.5) or minor (0.10.0)?** The work is patch-tier in nature. Minor framing is symbolic.
+3. **Should US-003 (ADR) be standalone or absorbed into US-005 retrospective?** Either works; ADR is more discoverable as standalone.
+4. **Defense-in-depth for parent-side guard: keep BOTH layers OR replace LLM instruction?** Spike 3 recommends keeping both. Operator should confirm — replacing LLM instruction would be simpler but loses per-story attribution.
+
+## After v0.9.5/v0.10.0
+
+**v0.9.x track is operationally CLOSED.** Post-v0.9.5/v0.10.0 plausible directions:
+- **v0.10.0 / v0.11.0** — return to feature work (real-feature dispatch through `--coordinator`; new pipeline capabilities).
+- **N47 bundle cleanup** — operator-decision-pending destructive work; not autonomous-loop-appropriate.
+- **N40, N43, N46, N48, N49, N50** — all LOW; absorb into housekeeping cycles as they accumulate.
+
+No more architectural backlog. The autonomous-loop quantum-loop infrastructure is mature.
+
+## References
+
+- Spike 1 architect output (file: this synthesis); ag-id `a4cb7c647af3081fe`
+- Spike 2 architect output (file: this synthesis); ag-id `aa872e1e58b48cf48`
+- Spike 3 architect output (file: this synthesis); ag-id `a1f11c8722436e207`
+- `idea-stage/IDEA_REPORT_v31.md` § "v0.10.0 candidate slate"
+- `idea-stage/v0.9.x-arc-audit-2026-04-30.md` § "Latent risks for v0.10.0"
+- `quantum-loop.sh:1447-1838` — sequential/coordinator iteration loop (decomposition target)
+- `quantum-loop.sh:1672` — parent-side guard insertion point (after timeout override)
+- `lib/coordinator-guard.sh:33-41` — `guard_head_advance` (already exists; v0.9.2 US-001)
+- `idea-stage/PIPELINE_REPORT_v31.md` § "Manual-takeover streak" — empirical proof cron pattern works


### PR DESCRIPTION
## Summary

Pre-cycle 3-architect design spike per `idea-stage/IDEA_REPORT_v31.md` § "v0.10.0 candidate slate". Research output only — no code changes; no cycle kickoff.

**Headline finding: v0.10.0 effort is ~5 hours — much smaller than the "significant architectural work" framing in `IDEA_REPORT_v30`.**

## Spike outputs (synthesized into `idea-stage/v0.10.0-design-spike-2026-05-01.md`)

| Spike | Verdict | Effort |
|---|---|---|
| 1. Decompose `quantum-loop.sh` (1837 LOC) | SMALL-MED — extract `lib/audit.sh` + `lib/iteration-loop.sh` + `lib/loop-helpers.sh`; main file → ~330 LOC | ~2.5 hr |
| 2. Daemon-style runner | **OVER-ENGINEERING** — cron `/loop` already proven; downgrade to ADR | ~30 min |
| 3. Parent-side `guard_head_advance` | SMALL — slot at `quantum-loop.sh:1672`; defense-in-depth (keep both layers) | ~1.5 hr |

## Refined cycle slate (5 stories; ~5 hours)

1. US-001: Decompose `quantum-loop.sh`
2. US-002: Parent-side `guard_head_advance` + Test 8
3. US-003: ADR-001 outer-loop architecture decision record
4. US-004: Multi-perspective post-merge review (7th application)
5. US-005: Retrospective + IDEA_REPORT_v32 + version bump

## Operator decisions needed

1. **Tier framing — v0.9.5 patch OR v0.10.0 minor?** Per `feedback_version_tier_calibration.md` (default to patch unless genuinely architectural), the work is patch-tier in nature. Original "minor" framing was based on the (now-debunked) "daemon-style runner" assumption. v0.10.0 minor would be symbolic; v0.9.5 patch is more accurate.
2. **Approve cycle scope?** 5-story slate above. Auto-kickoff via `/loop` cron OR explicit go-ahead?
3. **Defense-in-depth vs replacement** for parent-side guard? (Recommendation: keep both layers.)

## Test plan
- [x] No code changes; spike doc only
- [x] References cite line numbers + file paths verifiable in master HEAD `63586f2` (v0.9.4)
- [x] Spike doc captures 3 architect outputs into single synthesis

## Honest caveat
Merging this PR commits the synthesis doc to master. It does NOT commit to v0.10.0 cycle kickoff. The cycle scope decision (questions above) should happen before any v0.10.0 / v0.9.5 branch is created.