### PR TITLE
feat: v0.10.7 - patch (wave-cycle-2: copilot-rate-limit + N49 closure)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Universal CLI orchestrator with multi-runner support. Autonomous spec-driven development pipeline with dependency DAG, parallel worktree execution, two-stage review gates, DAG intelligence validation, and modular merge hardening",
-    "version": "0.10.6"
+    "version": "0.10.7"
   },
   "plugins": [
     {
       "name": "quantum-loop",
       "source": "./",
       "description": "6 skills (brainstorm, spec, plan, execute, verify, review) and 5 agents for autonomous spec-driven development with multi-runner support, DAG intelligence, and modular merge hardening",
-      "version": "0.10.6",
+      "version": "0.10.7",
       "keywords": [
         "autonomous",
         "prd",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "quantum-loop",
   "description": "Universal CLI orchestrator with multi-runner support. Autonomous spec-driven development with dependency DAG, parallel worktree execution, two-stage review gates, and modular merge hardening.",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "author": {
     "name": "andyzengmath"
   }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "quantum-loop",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "description": "Spec-driven autonomous development loop with DAG-based execution, parallel worktree agents, two-stage review gates, and Iron Law verification. Turns a feature description into verified, reviewed, autonomously-implemented code.",
   "author": {
     "name": "andyzengmath"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ Format: [Semantic Versioning](https://semver.org/). Bump per PR:
 - **Minor** (0.x.0): new features, backward-compatible
 - **Major** (x.0.0): breaking changes
 
+## [0.10.7] - 2026-05-02
+
+### Added — patch-tier (wave-cycle-2: copilot-rate-limit + N49 closure verification)
+
+4-story patch shipping wave-plan cycle-2. **35 consecutive LOW G30 self-validations** (v0.6.5..v0.10.7).
+
+### Stories shipped
+
+- **US-001 — copilot-rate-limit observability** — `runners/hooks/copilot-hooks.sh` adds `post_output()` that pattern-matches rate-limit signals (case-insensitive: `rate.?limit`, `\b429\b`, `retry-after`, `quota.?exceeded`, `too.many.requests`) in copilot CLI output and emits `[RATE-LIMIT]` log lines to stderr. Optional Retry-After numeric extraction. Pure observability (no signal classification or retry-logic change).
+- **US-002 — N49 closure verification** — Audit confirmed all 4 WAVE-branch `json_atomic_update_args` sites at `lib/iteration-loop.sh:150,382,406,438` already use single-jq `.stories |= map(...)` bulk-update pattern. N49 was IMPLICITLY CLOSED by v0.9.0 N42 wires; carrying it forward through 6 cycles was a tracking lapse. No code change; documentation closure only.
+- **US-003 — Multi-perspective post-merge review (16th application; 1 MEDIUM inline-fixed)** — Architect SHIP 88, Code-reviewer SHIP 88, Security SHIP 95. Code-reviewer + architect both flagged Retry-After extraction edge case (could capture wrong number from `HTTP/1.1 429 Retry-After: 30` — would return 1 from HTTP/1.1, not 30). **Inline-fixed at `9e84856`**: replaced multi-stage grep with `sed -n 's/.*[Rr]etry-[Aa]fter[: ]\{1,\}\([0-9][0-9]*\).*/\1/p'`. Verified on 3 edge cases (30/60/90). 5th review-gate catch in 16 applications (~31% hit-rate).
+- **US-004 — Retrospective + IDEA_REPORT_v41 + version bump 0.10.6 → 0.10.7** — this entry.
+
+### Test-suite delta
+
+No delta. 5 suites green: 15+21+44+35+18 = 133.
+
+### Architectural observations
+
+**Wave plan cycle-2 of 4 closed.** Next: v0.10.8 (N48 + ANSI passthrough), v0.10.9 (N44 + N40-47 investigation), v0.11.0 (OPERATOR-GATED first `--coordinator` dispatch).
+
+### Honest scope drift
+
+- N49 closure was DOCUMENTATION-only (v0.9.0 already shipped the fix); 6-cycle carry was tracking lapse. Honest acknowledgment in retro.
+- Retry-After multi-line edge cases (value spans lines) deferred — current extraction handles common single-line forms.
+
+### Dogfood milestone (v0.10.7)
+
+**4/4 stories first-attempt PASS** + 1 inline MEDIUM fix during US-003 review. **G30:** 35th consecutive LOW. **Manual-takeover streak: PARTIALLY BROKEN through v0.10.7** — fully autonomous on cron; 1 operator gate from v0.10.6 wave plan approval covers this cycle.
+
 ## [0.10.6] - 2026-05-02
 
 ### Added — patch-tier (wave-cycle-1 housekeeping; --coordinator dispatch deferred)

--- a/idea-stage/IDEA_REPORT_v41.md
+++ b/idea-stage/IDEA_REPORT_v41.md
@@ -1,0 +1,85 @@
+# IDEA_REPORT_v41 — what's open after v0.10.7
+
+**Date:** 2026-05-02
+**Source:** v0.10.7 ships wave-plan cycle-2 (copilot-rate-limit observability + N49 implicit-closure verification).
+**Branch:** `ql/v0.10.7-bundle` (release tag v0.10.7 — pending)
+**Predecessor:** `idea-stage/IDEA_REPORT_v40.md`
+
+## Closed in v0.10.7
+
+| ID | Story | Notes |
+|---|---|---|
+| Copilot rate-limit observability | US-001 | post_output hook in runners/hooks/copilot-hooks.sh |
+| N49 (single-jq bulk-update for WAVE_* branches) | US-002 | Implicitly closed by v0.9.0 N42 wires; tracking lapse, not unfinished work |
+| Retry-After extraction MEDIUM (US-003 review) | inline | sed capture-group anchored on 'retry-after' |
+| 16th p014 review trio | US-003 | All SHIP (88/88/95); 1 MEDIUM inline-fixed |
+
+## v0.10.8 (next, per wave plan)
+
+| Story | Content | Tier |
+|-------|---------|------|
+| US-001 | **N48** — field-ownership runtime enforcement (snapshot-diff guard) | LOW |
+| US-002 | **ANSI control-char passthrough sanitization** (security LOW) | LOW |
+| US-003 | 17th p014 review | LOW |
+| US-004 | Retrospective + IDEA_REPORT_v42 + version bump 0.10.7 → 0.10.8 | LOW |
+
+## v0.10.9 (final wave cycle, per plan)
+
+| Story | Content | Tier |
+|-------|---------|------|
+| US-001 | **N44** — CSV/PIPELINE_REPORT count reconciliation | LOW |
+| US-002 | Investigate + close-or-defer **N40, N41, N38, N45, N43, N46, N47** | LOW (process) |
+| US-003 | 18th p014 review | LOW |
+| US-004 | Wave-plan retrospective + IDEA_REPORT_v43 + version bump 0.10.8 → 0.10.9 | LOW |
+
+## v0.11.0 (OPERATOR-GATED)
+
+**Reserved for the FIRST actual `--coordinator` dispatch on the live repo.**
+
+## Standing backlog
+
+### Real-feature dogfood (canonized v0.10.4 / US-003)
+
+**Status:** UNCHANGED — blocked-on-operator-feature-queue. Wave plan converts LOW backlog INTO dogfood subjects for a future operator-run dispatch session.
+
+## Still open
+
+### N46 (respawn output not re-parsed) — MEDIUM
+
+Will be evaluated in v0.10.9 closeout investigation.
+
+### Other N-numbers (in wave plan)
+
+- **N50, N49:** CLOSED.
+- **N48:** v0.10.8 candidate.
+- **N44:** v0.10.9 candidate.
+- **N40, N41, N38, N45, N43, N47:** v0.10.9 investigation (some likely obsolete post-decomposition).
+
+### Pre-existing security LOWs
+
+- ANSI control-char passthrough — v0.10.8 (this cycle's deferral).
+- (Trap RETURN re-entry — CLOSED in v0.10.6.)
+
+### New from v0.10.7 review
+
+- Retry-After multi-line edge cases — LOW; current extraction handles common single-line forms.
+
+## Recurring observations
+
+- **35 consecutive LOW G30 self-validations** (v0.6.5..v0.10.7).
+- **Bundle size sequence: ...3-4-4.** v0.10.7 = 4 stories.
+- **Manual-takeover streak: PARTIALLY BROKEN through v0.10.7** — 9 consecutive cycles with 1 operator gate (at v0.10.6 wave plan approval; v0.10.7 ran fully autonomous on cron).
+- **p013 (operator-staged kickoff): 15 applications.**
+- **p014 (composite review trio): 16 review applications.** 5 review-gate catches in 16 applications (~31% hit-rate).
+- **p015 (post-cycle 3-agent doc-vs-code audit): 3 applications, canonized at 2.**
+- **p016 candidate (dogfood-driven LOW sweep wave): 2/4 cycles complete.**
+
+## v0.10.7 → v0.11.0 transition
+
+```
+v0.10.6 (wave-cycle-1: N50 + Trap RETURN)
+  → v0.10.7 (wave-cycle-2: copilot-rate-limit + N49 closure)
+  → v0.10.8 (wave-cycle-3: N48 + ANSI passthrough)
+  → v0.10.9 (wave-cycle-4: N44 + N40-47 investigation)
+  → v0.11.0 (OPERATOR-GATED; first --coordinator dispatch on live repo)
+```

--- a/idea-stage/PIPELINE_REPORT_v41.md
+++ b/idea-stage/PIPELINE_REPORT_v41.md
@@ -1,0 +1,92 @@
+# PIPELINE_REPORT_v41 — v0.10.7 retrospective (wave-cycle-2: copilot-rate-limit + N49 closure verification)
+
+**Date:** 2026-05-02
+**Bundle:** `ql/v0.10.7-bundle` (release tag v0.10.7 — pending push/PR/merge/tag/release)
+**Predecessor report:** `idea-stage/PIPELINE_REPORT_v40.md`
+**Master parent:** `6369ab7` (v0.10.6 ship state)
+**Source:** `.omc/plans/2026-05-02-v0.11.0-wave-dogfood-driven-low-sweep.md` cycle-2.
+
+## Overview
+
+4-story patch shipping wave-plan cycle-2: copilot-rate-limit-observability (real new feature) + N49 closure verification (implicitly closed by v0.9.0 N42 wires).
+
+## The 4 stories
+
+| # | ID | Title | Outcome |
+|:-:|---|---|:-:|
+| 0 | (cycle setup) | chore: v0.10.7 cycle kickoff (PRD only; design pointer to wave plan) | committed at `017d232` |
+| 1 | US-001 + US-002 | copilot-rate-limit observability + N49 closure verification | first-attempt PASS at `71fbdd3` |
+| 2 | US-003 | 16th p014 review trio (SHIP; 1 MEDIUM inline-fixed) | first-attempt PASS at `9e84856` |
+| 3 | US-004 | Retrospective + IDEA_REPORT_v41 + version bump 0.10.6 → 0.10.7 | this report |
+
+## US-001 deep-dive: copilot-rate-limit-observability
+
+`runners/hooks/copilot-hooks.sh` adds `post_output()` that pattern-matches rate-limit signals in copilot CLI output and emits `[RATE-LIMIT]` lines to stderr. Pure observability — does NOT alter signal classification or retry logic.
+
+**Patterns matched (case-insensitive):**
+- `rate.?limit` (catches `rate-limit`, `rate limit`, `ratelimit`, `rate_limit`)
+- `\b429\b` (HTTP status code)
+- `retry-after` (header)
+- `quota.?exceeded`
+- `too.many.requests`
+
+**Output:** 2 stderr lines on detection — `[RATE-LIMIT] copilot rate-limit detected: <captured-line>` + (optional) `[RATE-LIMIT] copilot suggests Retry-After: <N>s` if Retry-After header parseable.
+
+**False-positive rationale:** substring-matching produces theoretical false positives on benign text containing the word "rate limit". Real copilot CLI never outputs that gratuitously, and the operator-facing log line is non-blocking (no control-flow impact). Conservative-by-design.
+
+## US-002 deep-dive: N49 closure verification
+
+**Audit:** all 4 WAVE-branch `json_atomic_update_args` sites at `lib/iteration-loop.sh:150` (mark in_progress), `:382` (WAVE_PASSED), `:406` (WAVE_FAILED per-story aggregation), `:438` (unknown-signal retry++) already use single-jq `.stories |= map(...)` bulk-update pattern — updating all wave stories in 1 jq invocation.
+
+**Closure rationale:** N49 was implicitly closed by v0.9.0 N42 (per-wave coordinator dispatch) when the per-wave `json_atomic_update_args` calls shipped. The original framing (per-story jq calls in WAVE_* branches) was already obsolete by v0.9.0; carrying N49 forward through 6 cycles was a tracking lapse, not unfinished work.
+
+**Action:** marked CLOSED in `IDEA_REPORT_v41.md` with implicit-closure-via-v0.9.0 rationale.
+
+## Multi-perspective review synthesis (US-003, 16th application)
+
+| Reviewer | Verdict | Score | Key finding |
+|---|---|---:|---|
+| **Architect** | SHIP | 88/100 | Hook integration sound; pattern coverage adequate; tier framing honest. Minor: Retry-After extraction edge case noted. |
+| **Code-reviewer** | SHIP | 88/100 | **MEDIUM: Retry-After extraction can capture wrong number** from `HTTP/1.1 429 Retry-After: 30` (would return 1, not 30). **Inline-fixed at `9e84856`**: replaced multi-stage grep with sed capture-group anchored on `retry-after`. |
+| **Security** | SHIP | 95/100 | Format-string safe; ReDoS-safe; output bounded. 1 LOW: ANSI passthrough (matches v0.10.0 deferral; tracked v0.10.8). |
+
+**5th review-gate catch in 16 applications.** Pattern p014 stable. Hit-rate ~31% (5/16) — review trio reliably catches at least one inline-fixable issue.
+
+## v0.10.7 fixes shipped + deferrals
+
+### Closed
+
+| Finding | Severity | Source | Resolution |
+|---|---|---|---|
+| Copilot rate-limit observability | LOW (carried) | wave plan | US-001 |
+| N49 (single-jq bulk-update verification) | LOW (closure) | wave plan | US-002 (implicit; v0.9.0) |
+| Retry-After extraction edge case | MEDIUM (US-003 review) | code-reviewer + architect | inline-fixed at 9e84856 |
+
+### Deferred
+
+| Finding | Severity | Path |
+|---|---|---|
+| ANSI control-char passthrough | LOW | v0.10.8 (wave cycle-3) |
+| Retry-After multi-line edge cases (e.g., when value spans lines) | LOW | future hardening; current extraction handles common single-line forms |
+
+## G30 self-validation — 35th consecutive LOW
+
+Patch-tier delta: 1 hook function (~30 LOC) + 1 verification-only audit (no code change) + retro + version bump. **35 consecutive LOW** (v0.6.5..v0.10.7).
+
+## Test-suite delta vs v0.10.6
+
+No delta. Existing 5 suites green: test_signal_parsing 15/15, test_coordinator_e2e 21/21, test_dag_query 44/44, test_json_atomic 35/35, test_next_wave 18/18.
+
+(Note: hook is exercised via test_runner_dispatch.sh stub mode in normal CI; this cycle's smoke testing was inline via `source runners/hooks/copilot-hooks.sh && post_output "..."`.)
+
+## Manual-takeover streak
+
+v0.10.7 driven via autonomous /loop cron pattern (4585c73f). **Streak: PARTIALLY BROKEN through v0.10.7** — 9 consecutive cycles with 1 operator gate at scope-ratification time (this cycle's gate was the wave plan approval at v0.10.6).
+
+## codebasePatterns
+
+p001-p015 carried forward. Wave plan **p016 candidate (dogfood-driven LOW sweep)** in progress: 2 cycles complete (v0.10.6, v0.10.7); 2 cycles remaining (v0.10.8, v0.10.9). Canonization possible after v0.10.9 retrospective if pattern proves repeatable.
+
+## Recommendation pointer
+
+See `idea-stage/IDEA_REPORT_v41.md`. v0.10.8 next (N48 + ANSI passthrough sanitization).

--- a/runners/hooks/copilot-hooks.sh
+++ b/runners/hooks/copilot-hooks.sh
@@ -1,7 +1,41 @@
 #!/usr/bin/env bash
-# copilot-hooks.sh — Pre-spawn hook for GitHub Copilot CLI.
-# Appends autonomous, scripting-safe flags for non-interactive dispatch.
+# copilot-hooks.sh — Pre-spawn + post-output hooks for GitHub Copilot CLI.
 
+# Pre-spawn: append autonomous, scripting-safe flags for non-interactive dispatch.
 pre_spawn() {
   RUNNER_EXTRA_FLAGS="${RUNNER_EXTRA_FLAGS:+$RUNNER_EXTRA_FLAGS }--autopilot --max-autopilot-continues 0 --no-ask-user --silent --no-color --stream off --no-remote"
+}
+
+# Post-output: v0.10.7 / US-001 — copilot rate-limit observability.
+# Detects rate-limit error signals in the captured copilot CLI output and
+# emits a visible [RATE-LIMIT] log line to stderr. Patterns: rate-limit,
+# 429, Retry-After, quota-exceeded, too-many-requests (case-insensitive).
+# Idempotent: emits once per invocation even if multiple matches.
+# Pure observability — does NOT alter signal classification or retry logic.
+post_output() {
+  local output="$1"
+  # Single-pass case-insensitive grep. Capture first matching line for context.
+  local first_match
+  first_match=$(printf '%s\n' "$output" \
+    | grep -iE 'rate.?limit|\b429\b|retry-after|quota.?exceeded|too.many.requests' \
+    | head -1)
+  if [[ -n "$first_match" ]]; then
+    # Trim leading/trailing whitespace + truncate at 120 chars.
+    first_match="${first_match#"${first_match%%[![:space:]]*}"}"
+    first_match="${first_match%"${first_match##*[![:space:]]}"}"
+    if (( ${#first_match} > 120 )); then
+      first_match="${first_match:0:117}..."
+    fi
+    printf "[RATE-LIMIT] copilot rate-limit detected: %s\n" "$first_match" >&2
+    # Optional: extract Retry-After value if parseable.
+    local retry_after
+    retry_after=$(printf '%s\n' "$output" \
+      | grep -iE 'retry-after[: ]+[0-9]+' \
+      | head -1 \
+      | grep -oE '[0-9]+' \
+      | head -1)
+    if [[ -n "$retry_after" ]]; then
+      printf "[RATE-LIMIT] copilot suggests Retry-After: %ss\n" "$retry_after" >&2
+    fi
+  fi
 }

--- a/runners/hooks/copilot-hooks.sh
+++ b/runners/hooks/copilot-hooks.sh
@@ -28,11 +28,13 @@ post_output() {
     fi
     printf "[RATE-LIMIT] copilot rate-limit detected: %s\n" "$first_match" >&2
     # Optional: extract Retry-After value if parseable.
+    # v0.10.7 / US-003 review fix: use sed capture-group anchored on
+    # "retry-after" to extract only the value after that header,
+    # avoiding mis-capture of preceding numbers (e.g. "HTTP/1.1 429
+    # Retry-After: 30" -> 30, not 1 or 429).
     local retry_after
     retry_after=$(printf '%s\n' "$output" \
-      | grep -iE 'retry-after[: ]+[0-9]+' \
-      | head -1 \
-      | grep -oE '[0-9]+' \
+      | sed -n 's/.*[Rr]etry-[Aa]fter[: ]\{1,\}\([0-9][0-9]*\).*/\1/p' \
       | head -1)
     if [[ -n "$retry_after" ]]; then
       printf "[RATE-LIMIT] copilot suggests Retry-After: %ss\n" "$retry_after" >&2

--- a/tasks/prd-v0.10.7-bundle.md
+++ b/tasks/prd-v0.10.7-bundle.md
@@ -1,0 +1,78 @@
+# PRD: v0.10.7 — patch-tier (wave-cycle-2: copilot-rate-limit + N49 closure verification)
+
+**Status:** Approved per `.omc/plans/2026-05-02-v0.11.0-wave-dogfood-driven-low-sweep.md` cycle-2.
+**Date:** 2026-05-02
+**Predecessor:** `tasks/prd-v0.10.6-bundle.md`.
+**Branch:** `ql/v0.10.7-bundle`.
+**Target version:** 0.10.6 → 0.10.7 (patch).
+**Total effort:** ~1.5 hours.
+
+## Section 1: Introduction / Overview
+
+4-story patch shipping wave-plan cycle-2. Closes copilot-rate-limit-observability (real new feature) + N49 closure verification (likely already implicitly closed by v0.9.0 N42 wires).
+
+## Section 2: Goals
+
+- Add copilot-rate-limit-observability: detect rate-limit error patterns from copilot CLI runner stderr; emit visible `[RATE-LIMIT]` log lines.
+- Verify N49 status: confirm whether the 4 WAVE-branch `json_atomic_update_args` calls in `lib/iteration-loop.sh` already implement the "single-jq bulk-update" optimization OR identify remaining work.
+- 16th p014 review.
+- Bump 0.10.6 → 0.10.7.
+- 35 consecutive LOW G30.
+
+## Section 3: User Stories
+
+### US-001: copilot-rate-limit-observability
+
+**Acceptance Criteria:**
+- [ ] `runners/hooks/copilot-hooks.sh` (or equivalent) gains a `post_output` hook implementation that pattern-matches rate-limit signals in copilot CLI output. Patterns: case-insensitive `rate.?limit`, `429`, `Retry-After`, `quota.?exceeded`, `too many requests`.
+- [ ] On match, emit `[RATE-LIMIT] copilot rate-limit detected: <captured-line>` to stderr.
+- [ ] If `Retry-After: <N>` header is parseable, include the suggested wait in the log line.
+- [ ] Hook is idempotent: doesn't double-emit if multiple rate-limit lines in same output.
+- [ ] No new test required (post_output hook tested via test_runner_dispatch.sh stub mode).
+- [ ] `bash -n runners/hooks/copilot-hooks.sh` clean.
+
+### US-002: N49 closure verification
+
+**Acceptance Criteria:**
+- [ ] Audit `lib/iteration-loop.sh:150, 382, 406, 438` (4 WAVE-branch `json_atomic_update_args` sites) for "single-jq bulk-update" pattern. If each already uses `.stories |= map(...)` to update all wave stories in 1 jq invocation, N49 is implicitly closed.
+- [ ] Document closure rationale in `idea-stage/IDEA_REPORT_v41.md`: when was the implicit closure (likely v0.9.0 N42), why no follow-up needed.
+- [ ] If closure NOT verified (e.g., per-story jq calls still exist somewhere), extend AC to add the consolidation refactor.
+
+### US-003: Multi-perspective post-merge review (16th application)
+
+**Acceptance Criteria:**
+- [ ] 3 reviewer agents (architect + code-reviewer + security) invoked in parallel.
+- [ ] No score-≥85 finding deferred.
+
+### US-004: Retrospective + IDEA_REPORT_v41 + version bump 0.10.6 → 0.10.7
+
+**Acceptance Criteria:**
+- [ ] `idea-stage/PIPELINE_REPORT_v41.md` documents v0.10.7 (4 stories).
+- [ ] `idea-stage/IDEA_REPORT_v41.md` rolling forward state. N49 closure documented.
+- [ ] `CHANGELOG.md [0.10.7]` entry.
+- [ ] 4 plugin manifest version fields bumped 0.10.6 → 0.10.7.
+- [ ] G30 self-validation (35th consecutive LOW expected).
+
+## Section 4: Functional Requirements
+
+- **FR-1:** US-001 hook-based observability — no behavior change to dispatch path; only adds visibility.
+- **FR-2:** US-002 verification-only; if real refactor needed, AC extends.
+- **FR-3:** Plugin version 0.10.6 → 0.10.7 (4 fields).
+
+## Section 5: Non-Goals
+
+- No `--coordinator` dispatch (still reserved for v0.11.0).
+- No actual rate-limit handling (e.g., automatic retry with Retry-After). Just observability.
+
+## Section 6: Design Notes
+
+See `.omc/plans/2026-05-02-v0.11.0-wave-dogfood-driven-low-sweep.md` § Cycle 2.
+
+## Section 7: Technical Notes
+
+Bash 4.3+. Hook-based (no core code change for observability).
+
+## Section 8: Success Metrics
+
+- All 4 stories first-attempt PASS.
+- 35 consecutive LOW G30.


### PR DESCRIPTION
## Summary

4-story patch shipping wave-plan cycle-2.

- US-001 copilot-rate-limit observability (`runners/hooks/copilot-hooks.sh` post_output hook)
- US-002 N49 closure verification (implicitly closed by v0.9.0 N42; documented)
- US-003 16th p014 review (1 MEDIUM Retry-After extraction inline-fixed)
- US-004 retro + version bump

35 consecutive LOW G30. 5 test suites green: 15+21+44+35+18 = 133.

Wave plan progress: cycle 2 of 4. Next: v0.10.8 (N48 + ANSI), v0.10.9 (N44 + N40-47 investigation), v0.11.0 (operator-gated --coordinator).