### PR TITLE
v0.10.14 — patch (career hit-rate audit + p014 range disambiguation)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Universal CLI orchestrator with multi-runner support. Autonomous spec-driven development pipeline with dependency DAG, parallel worktree execution, two-stage review gates, DAG intelligence validation, and modular merge hardening",
-    "version": "0.10.13"
+    "version": "0.10.14"
   },
   "plugins": [
     {
       "name": "quantum-loop",
       "source": "./",
       "description": "6 skills (brainstorm, spec, plan, execute, verify, review) and 5 agents for autonomous spec-driven development with multi-runner support, DAG intelligence, and modular merge hardening",
-      "version": "0.10.13",
+      "version": "0.10.14",
       "keywords": [
         "autonomous",
         "prd",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "quantum-loop",
   "description": "Universal CLI orchestrator with multi-runner support. Autonomous spec-driven development with dependency DAG, parallel worktree execution, two-stage review gates, and modular merge hardening.",
-  "version": "0.10.13",
+  "version": "0.10.14",
   "author": {
     "name": "andyzengmath"
   }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "quantum-loop",
-  "version": "0.10.13",
+  "version": "0.10.14",
   "description": "Spec-driven autonomous development loop with DAG-based execution, parallel worktree agents, two-stage review gates, and Iron Law verification. Turns a feature description into verified, reviewed, autonomously-implemented code.",
   "author": {
     "name": "andyzengmath"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ Format: [Semantic Versioning](https://semver.org/). Bump per PR:
 - **Minor** (0.x.0): new features, backward-compatible
 - **Major** (x.0.0): breaking changes
 
+## [0.10.14] - 2026-05-02
+
+### Added — patch-tier (career hit-rate audit + p014 range disambiguation)
+
+4-story patch closing 2 pre-existing notational artifacts deferred at v0.10.12 review. Documentation-only; 0 LOC code change. **42 consecutive LOW G30 self-validations** (v0.6.5..v0.10.14).
+
+### Stories shipped
+
+- **US-001 — Career catch-count off-by-one correction** — Audit traced off-by-one origin to PR_v44:43 (v0.10.10 ship) which said "6th catch in 19" when v0.10.10's review trio caught a convergent MEDIUM (should have been 7th). Off-by-one propagated through PR_v45/v46/v47. True career stat: 9 catches.
+- **US-002 — p014 range notation disambiguation** — CLAUDE.md range enumeration matched stated count after restoring v0.9.1 to the listed range (was incorrectly excluded; v0.9.1 had a full 3-reviewer trio per PR_v28:33-39 and is explicitly counted at PR_v33:76). Total: 23 applications (4+1+4+14 = 23).
+- **US-003 — Multi-perspective post-merge review (23rd application; 1 MEDIUM inline-fixed)** — Architect REVISE→SHIP 72 (caught initial v0.9.1 misattribution: my first pass excluded v0.9.1 based on v0.10.12 code-reviewer's unverified claim; architect re-grounded against PR_v28/PR_v33 historical record). Code-reviewer SHIP 93. Security SHIP 98. **10th p014 catch in 23 applications career; ~43% career hit-rate (incorporating this cycle).**
+- **US-004 — Retrospective + IDEA_REPORT_v48 + version bump 0.10.13 → 0.10.14** — this entry.
+
+### Test-suite delta
+
+No delta. 6 suites green: 15+21+44+39+18+38 = 175.
+
+### Architectural observations
+
+**14-cycle hardening arc complete (v0.10.6..v0.10.14).** Autonomous backlog truly exhausted. Lessons learned: cascading misattribution risk demonstrated (v0.10.12 reviewer surfaced real anomaly with wrong root cause; v0.10.14 implementer adopted the diagnosis verbatim; architect re-grounded against historical sources). v0.11.0 still operator-gated.
+
 ## [0.10.13] - 2026-05-02
 
 ### Added — patch-tier (LOW idle-ticker batch: OSC body strip + Retry-After multi-line fallback)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -353,14 +353,17 @@ without depending on quantum.json carryover.
   architects scoping decomposition vs daemon-style vs parent-side
   guard). Post-cycle: 3 parallel reviewers (architect + code-reviewer +
   security) on the cycle diff with score-≥85 inline-fix gate.
-  Empirical track record: **22 review applications** (post-v0.8.x:
-  v0.8.1-v0.8.4, v0.9.3-v0.9.6, v0.10.0-v0.10.13; v0.9.1 + v0.9.2 NOT
-  counted — v0.9.1 was foundational scaffolding with no review trio,
-  v0.9.2 SKIPPED with rationale because US-004 was the dogfood;
-  updated v0.10.14). Enumerated: 4 + 4 + 14 = 22 ✓.
-  Career score-≥85 inline-fix hit rate: **9/22 ≈ 41%** (audited +
-  corrected v0.10.14; PR_v44 introduced off-by-one at v0.10.10 ship that
-  propagated through PR_v45/v46/v47).
+  Empirical track record: **23 review applications** (post-v0.8.x:
+  v0.8.1-v0.8.4, v0.9.1, v0.9.3-v0.9.6, v0.10.0-v0.10.13; v0.9.2 SKIPPED
+  with rationale because US-004 was the dogfood; updated v0.10.14).
+  Enumerated: 4 + 1 + 4 + 14 = 23 ✓ (v0.9.1 had a full 3-reviewer trio
+  per `idea-stage/PIPELINE_REPORT_v28.md:33-39`; explicitly counted as
+  one of 8 applications at `idea-stage/PIPELINE_REPORT_v33.md:76`).
+  Career score-≥85 inline-fix hit rate: **9/23 ≈ 39%** (audited +
+  corrected v0.10.14; PR_v44 introduced off-by-one at v0.10.10 ship
+  that propagated through PR_v45/v46/v47; v0.10.12 review additionally
+  misattributed v0.9.1 as non-application — corrected v0.10.14 by
+  re-grounding against PR_v28/PR_v33 historical record).
   Pre-cycle architect-design count: 5 applications
   (v0.9.0 minor, v0.10.0 design spike, plus 3 mid-arc applications).
   Canonical retrospectives:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -338,7 +338,7 @@ without depending on quantum.json carryover.
   doc + PRD + advisory hooks (pre-impl review CSV) on the cycle branch
   BEFORE the autonomous /loop fires. The autonomous loop then drives
   US-001 through US-N to first-attempt PASS. Empirical track record:
-  **17 applications** (v0.9.0 → v0.9.6, v0.10.0 → v0.10.9; updated v0.10.12 — note: v0.10.10 + v0.10.11 are autonomous-kickoff deviations per IDEA_REPORT_v45:62 and do NOT count toward p013).
+  **17 applications** (v0.9.0 → v0.9.6, v0.10.0 → v0.10.9; updated v0.10.14 — note: v0.10.10 → v0.10.14 are autonomous-kickoff deviations per IDEA_REPORT_v47 and do NOT count toward p013; pattern p013 itself is unchanged at 17).
   The 1 deviation
   (v0.9.6 first-attempt autonomous-kickoff at `5de3bbc`) was rolled
   back the same /loop tick once source-doc reading revealed scope
@@ -353,10 +353,14 @@ without depending on quantum.json carryover.
   architects scoping decomposition vs daemon-style vs parent-side
   guard). Post-cycle: 3 parallel reviewers (architect + code-reviewer +
   security) on the cycle diff with score-≥85 inline-fix gate.
-  Empirical track record: **20 review applications** (post-v0.8.x:
-  v0.8.1-v0.8.4, v0.9.1, v0.9.3-v0.9.6, v0.10.0-v0.10.11; v0.9.2 SKIPPED
-  with rationale because US-004 was the dogfood; updated v0.10.12).
-  Career score-≥85 inline-fix hit rate: 7/20 ≈ 35%.
+  Empirical track record: **22 review applications** (post-v0.8.x:
+  v0.8.1-v0.8.4, v0.9.3-v0.9.6, v0.10.0-v0.10.13; v0.9.1 + v0.9.2 NOT
+  counted — v0.9.1 was foundational scaffolding with no review trio,
+  v0.9.2 SKIPPED with rationale because US-004 was the dogfood;
+  updated v0.10.14). Enumerated: 4 + 4 + 14 = 22 ✓.
+  Career score-≥85 inline-fix hit rate: **9/22 ≈ 41%** (audited +
+  corrected v0.10.14; PR_v44 introduced off-by-one at v0.10.10 ship that
+  propagated through PR_v45/v46/v47).
   Pre-cycle architect-design count: 5 applications
   (v0.9.0 minor, v0.10.0 design spike, plus 3 mid-arc applications).
   Canonical retrospectives:

--- a/idea-stage/IDEA_REPORT_v47.md
+++ b/idea-stage/IDEA_REPORT_v47.md
@@ -62,7 +62,7 @@ The autonomous /loop cron will continue firing per its schedule. Each tick will:
 - **Bundle size sequence: ...3-4-4-4-4-4-4-4-4.** v0.10.13 = 4 stories.
 - **Manual-takeover streak: PARTIALLY BROKEN through v0.10.13** — 15 consecutive cycles with 1 operator gate (at v0.10.6 wave plan approval).
 - **p013 (operator-staged kickoff): 17 applications.** (v0.10.10/v0.10.11/v0.10.12/v0.10.13 are 2nd-5th autonomous-kickoff deviations.)
-- **p014 (composite review trio): 22 review applications.** 8 review-gate catches in 22 applications (~36% career hit-rate).
+- **p014 (composite review trio): 22 review applications.** **9 review-gate catches in 22 applications (~41% career hit-rate; corrected at v0.10.14 from previously-stated 8/22 — PR_v44 introduced off-by-one at v0.10.10 ship that propagated through PR_v45/v46/v47).**
 - **p015 (post-cycle 3-agent doc-vs-code audit): 5 applications**, canonized at 2; 18 gaps closed.
 - **p016 (dogfood-driven LOW sweep wave): 1 application**, canonized at 1.
 

--- a/idea-stage/IDEA_REPORT_v47.md
+++ b/idea-stage/IDEA_REPORT_v47.md
@@ -62,7 +62,7 @@ The autonomous /loop cron will continue firing per its schedule. Each tick will:
 - **Bundle size sequence: ...3-4-4-4-4-4-4-4-4.** v0.10.13 = 4 stories.
 - **Manual-takeover streak: PARTIALLY BROKEN through v0.10.13** — 15 consecutive cycles with 1 operator gate (at v0.10.6 wave plan approval).
 - **p013 (operator-staged kickoff): 17 applications.** (v0.10.10/v0.10.11/v0.10.12/v0.10.13 are 2nd-5th autonomous-kickoff deviations.)
-- **p014 (composite review trio): 22 review applications.** **9 review-gate catches in 22 applications (~41% career hit-rate; corrected at v0.10.14 from previously-stated 8/22 — PR_v44 introduced off-by-one at v0.10.10 ship that propagated through PR_v45/v46/v47).**
+- **p014 (composite review trio): 23 review applications.** **9 review-gate catches in 23 applications (~39% career hit-rate; corrected at v0.10.14 from previously-stated 8/22. Two errors compounded: PR_v44 introduced catch-count off-by-one at v0.10.10 ship that propagated through PR_v45/v46/v47; v0.10.12 review additionally misattributed v0.9.1 as non-application. v0.10.14 re-grounded both against historical record at PR_v28:33-39 + PR_v33:76 which explicitly count v0.9.1 with full review trio.)**
 - **p015 (post-cycle 3-agent doc-vs-code audit): 5 applications**, canonized at 2; 18 gaps closed.
 - **p016 (dogfood-driven LOW sweep wave): 1 application**, canonized at 1.
 

--- a/idea-stage/IDEA_REPORT_v48.md
+++ b/idea-stage/IDEA_REPORT_v48.md
@@ -1,0 +1,76 @@
+# IDEA_REPORT_v48 — what's open after v0.10.14
+
+**Date:** 2026-05-02
+**Source:** v0.10.14 closes 2 pre-existing notational artifacts (career hit-rate off-by-one + v0.9.1 misattribution); 41 → 42 consecutive LOW G30.
+**Branch:** `ql/v0.10.14-bundle` (release tag v0.10.14 — pending)
+**Predecessor:** `idea-stage/IDEA_REPORT_v47.md`
+
+## Closed in v0.10.14
+
+| ID | Story | Notes |
+|---|---|---|
+| Career catch-count off-by-one (PR_v44 origin) | US-001 | true count 9/23 ≈ 39% (not 8/22 ≈ 36%) |
+| p014 range notation enumeration mismatch | US-002 | v0.9.1 explicitly listed; range = 23 (4+1+4+14) |
+| v0.9.1 historical-record misattribution | US-003 architect MEDIUM | inline-fixed; restored v0.9.1 to range per PR_v28/PR_v33 |
+
+## Autonomous backlog: TRULY exhausted (confirmed post-v0.10.14)
+
+All notational, code, and process-pattern artifacts closed. Only items remaining open are:
+- **Operator-gated**: N43, N48 stub-coord test, real-feature dogfood, branch cleanup
+- **Below maintainability threshold**: test_orchestrator_liveness.sh split (defer to ~600 LOC)
+
+## Expected next state: idle-tick mode (PERMANENT until operator acts)
+
+The autonomous /loop cron will continue firing per its schedule. Each tick will:
+1. Read this IDEA_REPORT.
+2. Confirm no actionable autonomous work.
+3. Hold without spinning a new cycle.
+
+**Resume conditions:**
+- Operator stages real-feature dispatch → v0.11.0 entry.
+- 3+ new findings accumulate → v0.10.15.
+- Operator decides to address operator-gated items → v0.11.x entry.
+
+## v0.11.0 (OPERATOR-GATED — UNCHANGED)
+
+Reserved for the FIRST actual `--coordinator` dispatch on the live repo.
+
+## Standing backlog
+
+### Real-feature dogfood (canonized v0.10.4 / US-003)
+
+**Status:** UNCHANGED — blocked-on-operator-feature-queue.
+
+## v0.11.x backlog (post-v0.10.14)
+
+| Item | Severity | Path |
+|------|----------|------|
+| N43 — Parallel-with-dispatch wrap | MEDIUM | v0.11.x (operator-gated) |
+| N48 stub-coordinator test coverage | MEDIUM (sub-threshold) | v0.11.0 dogfood |
+| N47 — branch cleanup | operator | operator-decision-pending |
+| test_orchestrator_liveness.sh split | LOW | defer; trigger at ~600 LOC |
+
+## Recurring observations (corrected baseline)
+
+- **42 consecutive LOW G30 self-validations** (v0.6.5..v0.10.14).
+- **Bundle size sequence: ...3-4-4-4-4-4-4-4-4-4.** v0.10.14 = 4 stories.
+- **Manual-takeover streak: PARTIALLY BROKEN through v0.10.14** — 16 consecutive cycles with 1 operator gate.
+- **p013 (operator-staged kickoff): 17 applications.** (v0.10.10..v0.10.14 are 2nd-6th autonomous-kickoff deviations.)
+- **p014 (composite review trio): 23 review applications. 10 review-gate catches in 23 applications (~43% career hit-rate; corrected baseline post-v0.10.14 audit).**
+- **p015 (post-cycle 3-agent doc-vs-code audit): 5 applications**, canonized at 2; 18 gaps closed.
+- **p016 (dogfood-driven LOW sweep wave): 1 application**, canonized at 1.
+
+## v0.10.14 → idle-tick → v0.11.0 transition
+
+```
+v0.10.6..v0.10.9 (p016 wave plan: N50/N49/N48/N44/N40-47 + LOWs) ✓
+v0.10.10 (4th p015; CLAUDE.md p016 canonization) ✓
+v0.10.11 (N46 closure) ✓
+v0.10.12 (5th p015 closure; CLAUDE.md count refresh) ✓
+v0.10.13 (LOW idle-ticker batch: OSC + Retry-After multi-line) ✓
+v0.10.14 (career hit-rate audit + p014 range disambiguation) ✓ ← THIS CYCLE
+[idle-tick mode — autonomous backlog truly exhausted]
+v0.11.0 (operator-gated --coordinator dispatch) ← OPERATOR-STAGED
+```
+
+**14-cycle hardening arc complete.** v0.11.0 entry requires operator action.

--- a/idea-stage/PIPELINE_REPORT_v48.md
+++ b/idea-stage/PIPELINE_REPORT_v48.md
@@ -1,0 +1,101 @@
+# PIPELINE_REPORT_v48 — v0.10.14 retrospective (career hit-rate audit + p014 range disambiguation)
+
+**Date:** 2026-05-02
+**Bundle:** `ql/v0.10.14-bundle` (release tag v0.10.14 — pending push/PR/merge/tag/release)
+**Predecessor report:** `idea-stage/PIPELINE_REPORT_v47.md`
+**Master parent:** `1e581a0` (v0.10.13 ship state)
+**Source:** `tasks/prd-v0.10.14-bundle.md` (auto-approved per `/loop` step 4-5; closes 2 pre-existing notational artifacts deferred at v0.10.12 review).
+
+## Overview
+
+4-story patch closing 2 pre-existing notational artifacts compounded into 1 audit cycle. Documentation-only; 0 LOC code change. **42nd consecutive LOW G30 self-validation.**
+
+## The 4 stories
+
+| # | ID | Title | Outcome |
+|:-:|---|---|:-:|
+| 0 | (cycle setup) | chore: v0.10.14 cycle kickoff (PRD only) | committed at `12a54d7` |
+| 1 | US-001 + US-002 | career hit-rate audit + p014 range disambiguation (initial pass: 9/22) | first-attempt PASS at `b4d71eb` |
+| 2 | US-003 | 23rd p014 review trio (REVISE→SHIP; 1 MEDIUM inline-fixed: v0.9.1 exclusion was historically incorrect; restored to 9/23) | committed at `f31bb90` |
+| 3 | US-004 | Retrospective + IDEA_REPORT_v48 + version bump 0.10.13 → 0.10.14 | this report |
+
+## US-001 + US-002 deep-dive: two compounding errors corrected
+
+### Error 1: catch-count off-by-one (originated at PR_v44)
+
+PR_v43 (v0.10.9 ship): "6th review-gate catch in 18 applications" — correct (v0.10.9's own review trio was the 6th catch).
+
+PR_v44 (v0.10.10 ship): "6th p014 catch in 19 applications career" — **WRONG**. v0.10.10's review trio caught a convergent MEDIUM (IDEA_REPORT_v43:84-85 propagation gap), which should have incremented the count from 6 to 7. The PR_v44 author wrote "6th" instead of "7th".
+
+Off-by-one propagated through PR_v45/v46/v47:
+- PR_v45: "7th in 20" → should be 8th
+- PR_v46: "7/21 ≈ 33%" → should be 8/21
+- PR_v47: "8th in 22" → should be 9th
+
+### Error 2: v0.9.1 misattribution (originated at PR_v46/v0.10.12 review)
+
+v0.10.12 code-reviewer noted CLAUDE.md p014 range "v0.8.1-v0.8.4, v0.9.1, v0.9.3-v0.9.6, v0.10.0-v0.10.11" enumerates to 21 but stated count is 20. They concluded v0.9.1 was "listed for context but not itself an application" — a **MISATTRIBUTION** unverified against historical record.
+
+Architect's v0.10.14 review caught this: PR_v28:33-39 explicitly documents v0.9.1's full 3-reviewer trio; PR_v33:76 explicitly lists v0.9.1 as one of 8 p014 applications. v0.9.1 is a legitimate application; the count of 21 was correct (and the stated 20 was the actual error).
+
+### Combined correction
+
+Pre-v0.10.14 (stated): 8 catches in 22 applications ≈ 36%.
+Post-v0.10.14 (corrected): **9 catches in 23 applications ≈ 39%**.
+
+The +1 catch comes from re-counting v0.10.10's convergent MEDIUM as a catch.
+The +1 application comes from restoring v0.9.1 to the count.
+
+## Multi-perspective review synthesis (US-003; 23rd p014 application)
+
+| Reviewer | Verdict | Score | Key findings |
+|---|---|---:|---|
+| **Architect** | REVISE → SHIP | 72 → ≥85 | **1 MEDIUM (inline-fixed):** v0.9.1 exclusion was historically incorrect (PR_v28 + PR_v33 both authoritative for v0.9.1's full trio status). Audit's catch-count diagnosis (off-by-one origin at PR_v44) was independently verified correct. Recount yields 9 catches; combined with restored v0.9.1, true stat is **9/23 ≈ 39%**, not 9/22 ≈ 41%. Inline-fixed in this commit. |
+| **Code-reviewer** | SHIP | 93 | **0 MEDIUM.** Cycle-by-cycle independent recount confirmed 9 catches. PR_v44 off-by-one origin verified at line 43. Range arithmetic 4+1+4+14=23 verified ✓. **1 LOW (acceptable):** PIPELINE_REPORT_v47 not retroactively updated; implementation chose stricter snapshot-in-time convention than PRD AC suggested. Defensible. |
+| **Security** | SHIP | 98 | **0 findings.** Docs-only, zero attack surface. No secrets, no internal infra references. |
+
+**10th p014 catch in 23 applications career; ~43% career hit-rate (incorporating this cycle's catch).** Convergent strength: architect catching the v0.9.1 misattribution validates the review-gate's value beyond the implementer's local verification — the implementer adopted the v0.10.12 code-reviewer's claim without verifying against PR_v28/PR_v33.
+
+## Test-suite delta vs v0.10.13
+
+No delta. 6 suites green (carried forward): test_signal_parsing 15/15, test_coordinator_e2e 21/21, test_dag_query 44/44, test_json_atomic 39/39, test_next_wave 18/18, test_orchestrator_liveness 38/38 = **175 total**.
+
+## v0.10.14 fixes shipped + deferrals
+
+### Closed
+
+| Finding | Severity | Source | Resolution |
+|---|---|---|---|
+| Career catch-count off-by-one (since PR_v44) | LOW (pre-existing) | v0.10.12 architect audit | US-001 |
+| p014 range notation enumeration mismatch | MEDIUM (pre-existing notational) | v0.10.12 code-reviewer | US-002 |
+| v0.9.1 historical-record misattribution (introduced this cycle) | MEDIUM (review caught) | architect (this cycle's review) | inline-fixed in US-003 commit |
+
+### Deferred (unchanged)
+
+| Finding | Severity | Path |
+|---|---|---|
+| N43 — Parallel-with-dispatch wrap | MEDIUM | v0.11.x (operator-gated) |
+| N48 stub-coordinator test coverage | MEDIUM (sub-threshold) | v0.11.0 dogfood |
+| N47 — branch cleanup | operator | operator-decision-pending |
+| test_orchestrator_liveness.sh approaching split (~495 LOC / 16 tests) | LOW | defer; trigger at ~600 LOC |
+| PRD AC text vs implementation divergence | LOW | historical artifact |
+
+## G30 self-validation — 42nd consecutive LOW
+
+Patch-tier delta: 0 LOC code change (audit + documentation correction) + retro + version bump. **42 consecutive LOW** (v0.6.5..v0.10.14).
+
+## Manual-takeover streak
+
+v0.10.14 driven via autonomous /loop cron pattern. **Streak: PARTIALLY BROKEN through v0.10.14** — 16 consecutive cycles with 1 operator gate.
+
+## Lessons learned
+
+**Cascading misattribution:** v0.10.12's code-reviewer raised a real anomaly (range enumeration mismatch) but proposed an INCORRECT root cause (v0.9.1 not an application). The v0.10.14 implementer adopted that diagnosis verbatim without re-grounding against the historical record. Architect's v0.10.14 review caught the cascade by going one level deeper to PR_v28/PR_v33 source-of-truth. **Pattern: when correcting a notational anomaly, verify the proposed fix against ≥2 historical sources, not just the most recent reviewer's claim.**
+
+## codebasePatterns
+
+p001-p016 carried forward. **17 named patterns canonized** as of v0.10.14. No new pattern additions.
+
+## Recommendation pointer
+
+See `idea-stage/IDEA_REPORT_v48.md`. The 2 pre-existing notational artifacts are now CLOSED. Autonomous backlog state: TRULY exhausted (was already so post-v0.10.13; v0.10.14 closed the lingering metric-accuracy artifacts). Next /loop ticks expected to genuinely idle until operator action.

--- a/tasks/prd-v0.10.14-bundle.md
+++ b/tasks/prd-v0.10.14-bundle.md
@@ -1,0 +1,109 @@
+# PRD: v0.10.14 — patch-tier (career hit-rate audit + p014 range notation cleanup)
+
+**Status:** Auto-approved per `/loop` step 4-5; closes the 2 pre-existing notational artifacts surfaced by v0.10.12 review trio (architect LOW + code-reviewer MEDIUM, both deferred to "v0.10.13 or future p015 audit"; v0.10.13 closed different items so this is the next available cycle).
+**Date:** 2026-05-02
+**Predecessor:** `tasks/prd-v0.10.13-bundle.md`.
+**Branch:** `ql/v0.10.14-bundle`.
+**Target version:** 0.10.13 → 0.10.14 (patch).
+**Total effort:** ~45 min.
+
+## Section 1: Introduction / Overview
+
+4-story patch closing 2 pre-existing notational artifacts:
+1. **Career p014 hit-rate off-by-one** since v0.10.10 (architect LOW / code-reviewer MEDIUM at v0.10.12 review). Recount + propagate corrections through PIPELINE_REPORT_v44/v45/v46/v47, IDEA_REPORT_v44/v45/v46/v47, and CLAUDE.md.
+2. **p014 range notation ambiguity** — v0.9.1 listed in the application range but not itself a p014 application (it's gap context for v0.9.2 SKIPPED). Code-reviewer flagged the enumeration mismatch (range enumerates to 21, count says 20) at v0.10.12 review.
+
+## Section 2: Goals
+
+- Audit catch counts cycle-by-cycle from PR_v40..PR_v47 to determine true career stat.
+- Update all stale references (4 PIPELINE_REPORTs, 4 IDEA_REPORTs, CLAUDE.md) with corrected count.
+- Disambiguate p014 range notation: either remove v0.9.1 from the listed range OR explicitly mark it as "(non-application; gap context for v0.9.2 SKIPPED)".
+- 23rd p014 review.
+- Bump 0.10.13 → 0.10.14.
+- 42 consecutive LOW G30.
+
+## Section 3: User Stories
+
+### US-001: Career hit-rate audit + correction
+
+**Acceptance Criteria:**
+
+**Audit (verify counts):**
+- [ ] Recount cycle-by-cycle catches v0.10.6..v0.10.13 from each PIPELINE_REPORT's review-synthesis section (count "trios with ≥1 score-≥85 inline-fixable finding"). Expected:
+  - v0.10.6: 1 catch (cross-ref MEDIUM at code-reviewer 88)
+  - v0.10.7: 1 catch (Retry-After MEDIUM at code-reviewer 88 + architect 88)
+  - v0.10.8: 0 catches (sub-threshold MEDIUM + LOW deferred)
+  - v0.10.9: 1 catch (architect 88 N44-evidence + code-reviewer 88 ×2)
+  - v0.10.10: 1 catch (convergent IDEA_REPORT_v43:84-85 propagation MEDIUM)
+  - v0.10.11: 1 catch (architect set-e regression + security chmod 600 + traps)
+  - v0.10.12: 0 catches (pre-existing only)
+  - v0.10.13: 1 catch (test 16 encoding + awk gsub + OSC-ST docs + found-flag)
+- [ ] Wave segment (v0.10.6..v0.10.9) total: 3 catches.
+- [ ] Post-wave (v0.10.10..v0.10.13) total: 3 catches.
+- [ ] Pre-wave baseline (PR_v39 "3rd catch in 14"): 3/14.
+
+**True career stat by ship cycle:**
+- v0.10.6: 4/15 ✓ (matches PR_v40 implicit)
+- v0.10.7: 5/16 ✓ (matches PR_v41 "5/16")
+- v0.10.8: 5/17 ✓ (matches PR_v42 "5/17")
+- v0.10.9: 6/18 ✓ (matches PR_v43 "6th in 18")
+- v0.10.10: **7/19** (PR_v44 says 6/19 — OFF BY 1)
+- v0.10.11: **8/20** (PR_v45 says 7/20 — OFF BY 1)
+- v0.10.12: **8/21** (PR_v46 says 7/21 — OFF BY 1)
+- v0.10.13: **9/22 ≈ 41%** (PR_v47 says 8/22 — OFF BY 1)
+
+**Corrections (propagate latest stat as historical context, not retroactive rewrite):**
+- [ ] `idea-stage/IDEA_REPORT_v47.md` line ~75: "8 review-gate catches in 22 applications (~36% career hit-rate)" → "9 review-gate catches in 22 applications (~41% career hit-rate; corrects off-by-one in PR_v44 onward identified at v0.10.12 review)".
+- [ ] `idea-stage/PIPELINE_REPORT_v47.md` line ~88: "8th p014 catch in 22 applications career; ~36% career hit-rate" → "9th p014 catch in 22 applications career; ~41% career hit-rate (corrected from 8/22 per audit)".
+- [ ] `CLAUDE.md` line 359: "Career score-≥85 inline-fix hit rate: 7/20 ≈ 35%." → "Career score-≥85 inline-fix hit rate: 9/22 ≈ 41% (audited + corrected v0.10.14)."
+- [ ] Past PIPELINE_REPORTs (v44/v45/v46) and IDEA_REPORTs (v44/v45/v46): leave as-is per "snapshot in time" convention. The audit's correction lives in v48 going forward.
+
+### US-002: p014 range notation cleanup
+
+**Acceptance Criteria:**
+- [ ] `CLAUDE.md` lines 356-358 p014 range: "v0.8.1-v0.8.4, v0.9.1, v0.9.3-v0.9.6, v0.10.0-v0.10.11" → "v0.8.1-v0.8.4, v0.9.3-v0.9.6, v0.10.0-v0.10.13; v0.9.1 + v0.9.2 SKIPPED (v0.9.1 was foundational scaffolding, no review-trio applied; v0.9.2 SKIPPED with rationale per US-004 dogfood)". Includes v0.10.12 + v0.10.13 ranging update too.
+- [ ] Result: enumerated count = 4 + 4 + 14 = 22 ✓ matches stated "22 review applications".
+- [ ] Application count bumps 20 → 22 (covers v0.10.12 + v0.10.13).
+
+### US-003: Multi-perspective post-merge review (23rd application)
+
+**Acceptance Criteria:**
+- [ ] 3 reviewer agents (architect + code-reviewer + security) invoked in parallel.
+- [ ] No score-≥85 finding deferred.
+
+### US-004: Retrospective + IDEA_REPORT_v48 + version bump 0.10.13 → 0.10.14
+
+**Acceptance Criteria:**
+- [ ] `idea-stage/PIPELINE_REPORT_v48.md` documents v0.10.14 (4 stories) + audit findings.
+- [ ] `idea-stage/IDEA_REPORT_v48.md` rolling forward state.
+- [ ] `CHANGELOG.md [0.10.14]` entry.
+- [ ] 4 plugin manifest version fields bumped 0.10.13 → 0.10.14.
+- [ ] G30 self-validation (42nd consecutive LOW expected).
+
+## Section 4: Functional Requirements
+
+- **FR-1:** Audit identifies + corrects off-by-one error introduced at v0.10.10 PIPELINE_REPORT.
+- **FR-2:** No code change; documentation-only patch.
+- **FR-3:** Plugin version 0.10.13 → 0.10.14 (4 fields).
+
+## Section 5: Non-Goals
+
+- No `--coordinator` dispatch (still v0.11.0 reserved).
+- No retroactive rewrite of historical PIPELINE_REPORT/IDEA_REPORT (snapshot-in-time convention).
+- No N43 / N48 stub-coord work (operator-gated).
+
+## Section 6: Design Notes
+
+- **Off-by-one root cause:** PIPELINE_REPORT_v43 used phrase "6th catch in 18" referring to v0.10.9 itself being the 6th catch. PIPELINE_REPORT_v44 then said "6th catch in 19" — should have been "7th catch in 19" since v0.10.10 review trio also produced a catch (the IDEA_REPORT_v43:84-85 propagation MEDIUM caught convergently). Off-by-one propagated forward.
+- **Snapshot-in-time convention:** historical PIPELINE_REPORTs are treated as immutable artifacts. The audit's correction ships in v0.10.14's IDEA_REPORT_v48 + CLAUDE.md, with explicit cross-reference to where the off-by-one originated.
+
+## Section 7: Technical Notes
+
+Markdown-only. No new dependencies.
+
+## Section 8: Success Metrics
+
+- All 4 stories first-attempt PASS.
+- 6 test suites green (carried forward): 15+21+44+39+18+38 = 175.
+- 42 consecutive LOW G30.
+- Pre-existing notational artifacts closed; future stat references will use 9/22 baseline.


### PR DESCRIPTION
## Summary

4-story patch closing 2 pre-existing notational artifacts deferred at v0.10.12 review. Documentation-only; 0 LOC code change.

- **US-001** — Career catch-count off-by-one correction (origin: PR_v44:43; propagated through v45/v46/v47). True career stat: 9 catches (was stated 8).
- **US-002** — p014 range notation disambiguation. v0.9.1 restored to listed range (was incorrectly excluded; PR_v28 + PR_v33 confirm full review trio). Total: 23 applications (4+1+4+14).
- **US-003** — 23rd p014 review trio (architect REVISE→SHIP 72, code-reviewer 93, security 98). 1 MEDIUM inline-fixed: my v0.9.1 exclusion was based on unverified misattribution; architect re-grounded against historical record. Final stat: **9/23 ≈ 39%** career hit-rate.
- **US-004** — Retro + IDEA_REPORT_v48 + 4-manifest bump 0.10.13 → 0.10.14.

## Test plan

- [x] No code change (docs-only); 6 suites carried forward 15+21+44+39+18+38 = 175
- [x] 42 consecutive LOW G30 self-validations (v0.6.5..v0.10.14)
- [x] **14-cycle hardening arc complete (v0.10.6..v0.10.14)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)