### PR TITLE
v0.11.1 — patch (N43 parallel-with-dispatch wrap pattern)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Universal CLI orchestrator with multi-runner support. Autonomous spec-driven development pipeline with dependency DAG, parallel worktree execution, two-stage review gates, DAG intelligence validation, and modular merge hardening",
-    "version": "0.11.0"
+    "version": "0.11.1"
   },
   "plugins": [
     {
       "name": "quantum-loop",
       "source": "./",
       "description": "6 skills (brainstorm, spec, plan, execute, verify, review) and 5 agents for autonomous spec-driven development with multi-runner support, DAG intelligence, and modular merge hardening",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "keywords": [
         "autonomous",
         "prd",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "quantum-loop",
   "description": "Universal CLI orchestrator with multi-runner support. Autonomous spec-driven development with dependency DAG, parallel worktree execution, two-stage review gates, and modular merge hardening.",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "author": {
     "name": "andyzengmath"
   }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "quantum-loop",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Spec-driven autonomous development loop with DAG-based execution, parallel worktree agents, two-stage review gates, and Iron Law verification. Turns a feature description into verified, reviewed, autonomously-implemented code.",
   "author": {
     "name": "andyzengmath"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ Format: [Semantic Versioning](https://semver.org/). Bump per PR:
 - **Minor** (0.x.0): new features, backward-compatible
 - **Major** (x.0.0): breaking changes
 
+## [0.11.1] - 2026-05-02
+
+### Added — patch-tier (N43 parallel-with-dispatch wrap pattern; opt-in default OFF)
+
+4-story patch closing **N43** (parallel-with-dispatch wrap pattern; deferred MEDIUM since v0.8.1; tracked through 8+ IDEA_REPORTs). The genuinely architectural work from operator's Path A choice. **45 consecutive LOW G30 self-validations** (v0.6.5..v0.11.1).
+
+### Stories shipped
+
+- **US-001 — `dispatch_with_parallel_poll` function** — `lib/orchestrator-liveness.sh` adds new function (~70 LOC). Spawns CMD in background (`bash -c "$cmd" >"$tmpfile" 2>&1 &`); polls commits in foreground via existing `poll_orchestrator_commits`; kills child via SIGTERM → 2s grace → SIGKILL cascade if no commits within timeout window. Each new commit resets the window (commit-progress = liveness signal). tmpfile hardening: `chmod 600` + trap RETURN cleanup.
+- **US-002 — Wire opt-in + Tests 16/17/18** — `lib/iteration-loop.sh:247-253` legacy dispatch site gated on `QL_PARALLEL_POLL=true`. Default OFF preserves backwards compat (Git Bash bg-process supervision is fragile; opt-in lets operators try it on stable hosts). Coordinator mode NOT wired (already has `QL_COORDINATOR_TIMEOUT_S` wallclock kill via `timeout(1)`). 3 new tests: clean completion, STALE-kill, commit-progress reset. **Race fix discovered at Test 18:** child can exit DURING `poll_orchestrator_commits` blocking window; added post-poll `kill -0` re-check before STALE log + kill cascade.
+- **US-003 — Multi-perspective post-merge review (26th application; 2 MEDIUM inline-fixed)** — Architect SHIP 91 (caught worktree_path forwarding gap; inline-fixed via optional 4th arg). Code-reviewer SHIP 93 + Security SHIP 92 convergent on trap RETURN overwrite latent risk (currently safe; mutually exclusive call sites; documented as invariant). **13th p014 catch in 26 applications career; ~50% career hit-rate (crossed 50% threshold for first time).**
+- **US-004 — Retrospective + IDEA_REPORT_v51 + version bump 0.11.0 → 0.11.1** — this entry.
+
+### Test-suite delta
+
+`tests/test_orchestrator_liveness.sh`: 38 → 46 tests (+8 sub-asserts). 6 baseline suites total: 189.
+
+### Architectural observations
+
+**N43 closed — last autonomously-achievable architectural item.** Only one operator-gated MEDIUM remains: real-feature dispatch via `--coordinator` (blocked-on-operator-feature-queue). v0.11.x now has only sub-priority hardening (Path D: N48 negative-path test; Path E: test_orchestrator_liveness.sh split — file crossed 600 LOC threshold this cycle).
+
+**Lessons learned (canonized in PIPELINE_REPORT_v51):**
+1. **Race condition in bg-process supervision:** initial implementation passed clean-completion + STALE-kill smoke tests but failed Test 18. Standard pattern: re-check liveness at every transition point, not just loop-head.
+2. **Trap RETURN nesting fragility:** convergent finding from code-reviewer + security demonstrates p014's value for cross-cutting concerns visible only in inter-function context.
+
 ## [0.11.0] - 2026-05-02
 
 ### Added — minor-tier (FIRST `--coordinator` dispatch dogfood: N48 stub-coordinator test)

--- a/idea-stage/IDEA_REPORT_v51.md
+++ b/idea-stage/IDEA_REPORT_v51.md
@@ -1,0 +1,71 @@
+# IDEA_REPORT_v51 — what's open after v0.11.1
+
+**Date:** 2026-05-02
+**Source:** v0.11.1 closes N43 (parallel-with-dispatch wrap pattern; deferred MEDIUM since v0.8.1); 44 → 45 consecutive LOW G30.
+**Branch:** `ql/v0.11.1-bundle` (release tag v0.11.1 — pending)
+**Predecessor:** `idea-stage/IDEA_REPORT_v50.md`
+
+## Closed in v0.11.1
+
+| ID | Story | Notes |
+|---|---|---|
+| **N43 — Parallel-with-dispatch wrap pattern** | US-001 + US-002 | dispatch_with_parallel_poll; bg-process + commit-poll + kill-cascade; opt-in via QL_PARALLEL_POLL=true |
+| Race fix (child exits mid-poll) | self-caught at Test 18 | post-poll kill -0 re-check |
+| worktree_path forwarding gap | US-003 architect | inline-fixed (optional 4th arg) |
+| Trap RETURN overwrite latent risk | US-003 code-reviewer + security convergent | documentation-fixed (invariant comment) |
+
+## Open: v0.11.x backlog (post-N43 close)
+
+| Item | Severity | Path |
+|------|----------|------|
+| Real-feature dispatch via `--coordinator` | blocked | operator-queued multi-story feature |
+| N48 negative-path test | LOW | v0.11.2 candidate (~10 LOC) |
+| **test_orchestrator_liveness.sh split (NOW AT threshold)** | LOW | v0.11.2 candidate (~615 LOC; passed 600 threshold this cycle) |
+| N47 — branch cleanup | operator | operator-decision-pending |
+
+## v0.11.2 candidates
+
+The autonomous track has 2 NEW small-tier candidates this cycle:
+
+### Path D: N48 negative-path test
+- Add Test 10 to `tests/test_coordinator_e2e.sh` where stub coordinator does NOT violate field-ownership.
+- Assert `[FIELD-OWNERSHIP] WARN` does NOT appear in stderr.
+- Confirms N48 detection is symmetric (no false positives).
+- ~10 LOC test addition.
+
+### Path E: test_orchestrator_liveness.sh split
+- Architect's threshold (~600 LOC) crossed at v0.11.1 ship state (~615 LOC, 18 tests).
+- Natural split: Tests 14a/14c/15 (N46 respawn) + Tests 16/17/18 (N43 parallel-poll) → `test_dispatch_helpers.sh`. Original file keeps Tests 1-13 (poll_orchestrator_commits + wrap_orchestrator_dispatch).
+- ~150 LOC code movement; preserve test count.
+
+### Path B: Real-feature dispatch (UNCHANGED)
+- Awaits operator-queued real feature.
+
+## v0.11.0 → v0.11.1 → v0.11.x transition
+
+```
+v0.11.0 (FIRST --coordinator dispatch dogfood; N48 closure) ✓
+v0.11.1 (N43 parallel-with-dispatch wrap; opt-in default OFF) ✓ ← THIS CYCLE
+v0.11.2 (operator decides: Path B OR D OR E)
+```
+
+## Recurring observations
+
+- **45 consecutive LOW G30 self-validations** (v0.6.5..v0.11.1).
+- **Bundle size sequence: ...3-4-4-4-4-4-4-4-4-4-3-4-4.** v0.11.1 = 4 stories.
+- **Manual-takeover streak: maintained through v0.11.1** — operator gate at scope-decision; no autonomous deviation.
+- **p013 (operator-staged kickoff): 19 applications.** v0.11.1 operator-staged (Path A choice).
+- **p014 (composite review trio): 26 review applications. 13 review-gate catches in 26 applications (~50% career hit-rate).** Pattern crossed 50% threshold for first time.
+- **p015 (post-cycle 3-agent doc-vs-code audit): 6 applications**, canonized at 2; 25 gaps closed.
+- **p016 (dogfood-driven LOW sweep wave): 1 application**, canonized at 1.
+
+## v0.11.x architectural posture
+
+With N43 closed, only one operator-gated MEDIUM remains in the entire backlog:
+- **Real-feature dispatch via `--coordinator`** — blocked-on-operator-feature-queue.
+
+The infrastructure is now genuinely complete. v0.11.0 validated dispatch end-to-end via N48 dogfood; v0.11.1 added pre-emptive stuck-agent detection. Any remaining v0.11.x work is either:
+- Operator-staged real-feature dispatch (Path B)
+- Sub-priority hardening (Paths D + E)
+
+**Next /loop tick (when scheduled): operator decides v0.11.2 path.**

--- a/idea-stage/PIPELINE_REPORT_v51.md
+++ b/idea-stage/PIPELINE_REPORT_v51.md
@@ -1,0 +1,110 @@
+# PIPELINE_REPORT_v51 — v0.11.1 retrospective (N43 closure: parallel-with-dispatch wrap pattern)
+
+**Date:** 2026-05-02
+**Bundle:** `ql/v0.11.1-bundle` (release tag v0.11.1 — pending push/PR/merge/tag/release)
+**Predecessor report:** `idea-stage/PIPELINE_REPORT_v50.md`
+**Master parent:** `55c0b16` (v0.11.0 ship state)
+**Source:** `tasks/prd-v0.11.1-bundle.md` (operator-approved Path A; architectural follow-on to v0.11.0 first-dispatch milestone).
+
+## Overview
+
+4-story patch closing **N43** (parallel-with-dispatch wrap pattern; deferred MEDIUM since v0.8.1; tracked through 8+ IDEA_REPORTs). Adds `dispatch_with_parallel_poll` function: spawns CMD in background, polls commits in foreground via existing `poll_orchestrator_commits`, kills child on STALE detection. Opt-in via `QL_PARALLEL_POLL=true` env var (default OFF for backwards compat on Git Bash). **45th consecutive LOW G30 self-validation.**
+
+## The 4 stories
+
+| # | ID | Title | Outcome |
+|:-:|---|---|:-:|
+| 0 | (cycle setup) | chore: v0.11.1 cycle kickoff (PRD only) | committed at `efd8085` |
+| 1 | US-001 + US-002 | dispatch_with_parallel_poll function + opt-in wire + Tests 16/17/18 | first-attempt PASS at `95a91bc` (race fix discovered + applied during testing) |
+| 2 | US-003 | 26th p014 review trio (SHIP; 2 MEDIUM inline-fixed) | committed at `ce2ca3c` |
+| 3 | US-004 | Retrospective + IDEA_REPORT_v51 + version bump 0.11.0 → 0.11.1 | this report |
+
+## US-001 + US-002 deep-dive: N43 implementation
+
+**Function added (`lib/orchestrator-liveness.sh::dispatch_with_parallel_poll`):**
+- Signature: `dispatch_with_parallel_poll TIMEOUT_SEC INTERVAL_SEC CMD [WORKTREE_PATH]`.
+- Spawns `bash -c "$cmd" >"$tmpfile" 2>&1 &`; captures `$!` as child_pid.
+- Outer loop while `kill -0 child_pid`: invoke `poll_orchestrator_commits` (blocking up to TIMEOUT_SEC).
+  - On commit (return 0): reset base_sha + continue (commit-progress = liveness signal).
+  - On STALE (return 1): re-check `kill -0` (race fix; see below); if alive, emit STALE log + kill cascade.
+- Kill cascade: SIGTERM → 2s grace → SIGKILL.
+- Final `wait child_pid 2>/dev/null` captures rc; `cat tmpfile` emits captured output.
+
+**Wire site:** `lib/iteration-loop.sh:247-253` (legacy non-coordinator dispatch). Gated on `QL_PARALLEL_POLL=true`. Coordinator mode NOT wired (already has `QL_COORDINATOR_TIMEOUT_S` wallclock kill via `timeout(1)`).
+
+**Race fix (discovered via Test 18):**
+Initial implementation had a subtle race: child can complete DURING `poll_orchestrator_commits` blocking window. The outer loop's `kill -0` gate only checks before each poll iteration, so a child that exits mid-poll would be incorrectly classified as STALE — leading to spurious STALE log + wasted kill cascade against an already-dead PID.
+
+**Fix:** Added post-poll `kill -0` re-check before STALE log + kill cascade. If child already dead, skip kill and let `wait` capture rc cleanly.
+
+**Smoke results:**
+- Clean completion: 1s, rc=0, output captured ✓
+- STALE-kill: 5s wallclock (= 2s timeout + 2s SIGTERM grace + ~1s wait overhead), rc=143 (SIGTERM), STALE log emitted ✓
+- Commit-progress reset: 4s wallclock, rc=0, "new commit" log + no STALE log ✓
+
+## Multi-perspective review synthesis (US-003; 26th p014 application)
+
+| Reviewer | Verdict | Score | Key findings |
+|---|---|---:|---|
+| **Architect** | SHIP | 91 | **1 MEDIUM (inline-fixed):** missing `worktree_path` forwarding to `poll_orchestrator_commits` + `git rev-parse`. Currently safe (no worktree caller), but future-proofs against worktree wire site. Added optional 4th arg. |
+| **Code-reviewer** | SHIP | 93 | **1 MEDIUM (documentation-fixed):** trap RETURN overwrite latent risk. `wrap_orchestrator_dispatch` and `dispatch_with_parallel_poll` both use trap RETURN; bash REPLACES traps. Currently safe (mutually exclusive call sites). Added explicit non-nesting invariant comment. Convergent finding with security. |
+| **Security** | SHIP | 92 | **Same MEDIUM (convergent with code-reviewer):** trap nesting risk; classified as latent + non-active. **1 LOW:** PID reuse theoretical risk (microsecond window; 32k+ PID space; standard Unix pattern). No action. |
+
+**13th p014 catch in 26 applications career; ~50% career hit-rate (climbing).**
+Convergent finding (code-reviewer + security on trap nesting) strengthened confidence; both flagged as latent-not-active per current call graph; documentation invariant added.
+
+## Test-suite delta vs v0.11.0
+
+`tests/test_orchestrator_liveness.sh`: 38 → 46 tests (+8 sub-asserts across Tests 16/17/18).
+6 baseline suites: 15+27+44+39+18+46 = **189 total** (+8 vs v0.11.0).
+
+## v0.11.1 fixes shipped + deferrals
+
+### Closed
+
+| Finding | Severity | Source | Resolution |
+|---|---|---|---|
+| **N43 — Parallel-with-dispatch wrap pattern** | MEDIUM (deferred since v0.8.1) | wave plan | US-001 + US-002 |
+| Test 18 race: child exits during poll window | MEDIUM (caught during testing) | self-discovered | inline-fixed (post-poll kill -0 re-check) |
+| worktree_path forwarding gap | MEDIUM (review caught) | architect | inline-fixed |
+| Trap RETURN overwrite latent risk | MEDIUM (review caught) | code-reviewer + security convergent | documentation-fixed (invariant comment) |
+
+### Deferred (unchanged)
+
+| Finding | Severity | Path |
+|---|---|---|
+| Real-feature dogfood via `--coordinator` | blocked | operator-queued multi-story feature |
+| N48 negative-path test | LOW | future hardening |
+| N47 — branch cleanup | operator | operator-decision-pending |
+| test_orchestrator_liveness.sh split | LOW | defer; trigger ~600 LOC; currently ~605 LOC POST-v0.11.1 (now AT threshold) |
+
+### New (post-v0.11.1)
+
+**test_orchestrator_liveness.sh has crossed 600 LOC threshold** (was ~495 pre-v0.11.1; +120 with Tests 16/17/18 = ~615). Per architect's prior defer note, this is now actionable for v0.11.x.
+
+## G30 self-validation — 45th consecutive LOW
+
+Patch-tier delta: ~70 LOC core code + ~7 LOC wire + ~120 LOC tests + retro + version bump. **45 consecutive LOW** (v0.6.5..v0.11.1).
+
+## Manual-takeover streak
+
+v0.11.1 driven via operator-staged scope (Path A choice from v0.11.0 ship summary). **Streak: maintained through v0.11.1** — operator gate at scope-decision (no autonomous deviation).
+
+## Lessons learned
+
+**Race condition in bg-process supervision:** initial implementation passed clean-completion + STALE-kill smoke tests but failed Test 18 (commit-progress reset). Root cause: blocking nature of `poll_orchestrator_commits` allowed child to exit mid-poll without being detected by the outer loop. Standard pattern for bg-process supervision in shell: re-check liveness at every transition point, not just loop-head. Added to `dispatch_with_parallel_poll` via post-poll `kill -0` check.
+
+**Trap RETURN nesting fragility:** convergent code-reviewer + security finding surfaced an architectural-tier constraint not visible from looking at `dispatch_with_parallel_poll` in isolation. Both functions in `lib/orchestrator-liveness.sh` use trap RETURN for tmpfile cleanup; bash semantics mean the second trap silently replaces the first. Currently safe but documented as invariant for future maintainers. Demonstrates p014's value for cross-cutting concerns visible only in inter-function context.
+
+## codebasePatterns
+
+p001-p016 carried forward. **17 named patterns canonized** as of v0.11.1. No new pattern additions; this cycle exercises existing infrastructure (race-fix idiom + trap-invariant documentation).
+
+## Recommendation pointer
+
+See `idea-stage/IDEA_REPORT_v51.md`. **N43 closed.** Next operator-gated candidate (per IDEA_REPORT_v50:Path B/C):
+- **Path B:** Real-feature dispatch via `--coordinator` (operator-queued multi-story feature) — UNCHANGED.
+- **Path C:** N48 negative-path test (verify WARN does NOT fire when contract respected) — small, ~10 LOC.
+- **NEW: test_orchestrator_liveness.sh split** (~615 LOC; crossed 600 threshold this cycle).
+
+**Operator decision required for v0.11.2.**

--- a/lib/iteration-loop.sh
+++ b/lib/iteration-loop.sh
@@ -239,7 +239,18 @@ for ITERATION in $(seq 1 "$MAX_ITERATIONS"); do
       printf "ERROR: runner_build_cmd failed for %s\n" "$RUNNER_NAME" >&2
       continue
     }
-    OUTPUT=$(eval "$RUNNER_CMD" 2>&1) || RUNNER_EXIT=$?
+    # v0.11.1 / US-002 (N43): opt-in parallel-with-dispatch wrap.
+    # When QL_PARALLEL_POLL=true, dispatch runs in bg + commit-poll runs
+    # in fg + stuck child is killed via SIGTERM/SIGKILL cascade. Default
+    # OFF preserves backwards compat (Git Bash bg-process supervision is
+    # known fragile; opt-in lets operators try it on stable hosts).
+    if [[ "${QL_PARALLEL_POLL:-false}" == "true" ]]; then
+      local _ppoll_timeout="${QL_PARALLEL_POLL_TIMEOUT_S:-600}"
+      local _ppoll_interval="${QL_PARALLEL_POLL_INTERVAL_S:-60}"
+      OUTPUT=$(dispatch_with_parallel_poll "$_ppoll_timeout" "$_ppoll_interval" "$RUNNER_CMD" 2>&1) || RUNNER_EXIT=$?
+    else
+      OUTPUT=$(eval "$RUNNER_CMD" 2>&1) || RUNNER_EXIT=$?
+    fi
   fi
 
   # -------------------------------------------------------------------------

--- a/lib/orchestrator-liveness.sh
+++ b/lib/orchestrator-liveness.sh
@@ -179,6 +179,78 @@ HANDOFF
   return 1
 }
 
+# v0.11.1 / US-001 (N43): parallel-with-dispatch wrap pattern.
+#
+# Spawns CMD in background, polls commits in foreground, kills child if
+# STALE (no commits within timeout window). Each new commit resets the
+# timeout window — commit-progress signals liveness.
+#
+# Contract:
+#   dispatch_with_parallel_poll TIMEOUT_SEC INTERVAL_SEC CMD
+#     TIMEOUT_SEC   — max wallclock without commit progress (default 600)
+#     INTERVAL_SEC  — poll cadence (default 60)
+#     CMD           — shell command string (executed via bash -c)
+#   Output: child's stdout+stderr emitted on this function's stdout.
+#   Stderr logs:
+#     [LIVENESS] new commit XXXXXXXX observed at +Ns   (commit progress)
+#     [LIVENESS] STALE: no commits in Ns; killing PID X (kill cascade)
+#   Returns: child's rc on natural completion, or signal-kill rc (143/137).
+#
+# Opt-in only: caller (lib/iteration-loop.sh) gates on QL_PARALLEL_POLL=true.
+# Coordinator mode is NOT a wire site — it has its own wallclock kill via
+# QL_COORDINATOR_TIMEOUT_S (v0.9.3).
+#
+# Git Bash bg-process notes:
+#   - `kill -0 PID` reliably probes liveness.
+#   - SIGTERM may not deliver to all bg-spawned children; SIGKILL fallback.
+#   - `wait` after kill cascade may return early if process is already
+#     reaped — rc capture proceeds either way.
+#   - tmpfile cleanup via trap RETURN handles abort/SIGTERM-to-parent paths.
+dispatch_with_parallel_poll() {
+  local timeout_sec="${1:-600}"
+  local interval_sec="${2:-60}"
+  local cmd="${3:?dispatch_with_parallel_poll: cmd required}"
+
+  local tmpfile child_pid base_sha rc=0
+  tmpfile=$(mktemp)
+  chmod 600 "$tmpfile" 2>/dev/null || true
+  trap 'rm -f "$tmpfile"' RETURN
+
+  # Spawn CMD in background; capture stdout+stderr to tmpfile.
+  bash -c "$cmd" >"$tmpfile" 2>&1 &
+  child_pid=$!
+  base_sha=$(git rev-parse HEAD 2>/dev/null || echo "INIT")
+
+  # Poll loop: each window resets on new commit; STALE-kill if no commits.
+  while kill -0 "$child_pid" 2>/dev/null; do
+    if poll_orchestrator_commits "$timeout_sec" "$interval_sec" "$base_sha" >&2; then
+      # New commit observed — child is making progress, reset window.
+      base_sha=$(git rev-parse HEAD 2>/dev/null || echo "$base_sha")
+      continue
+    fi
+    # poll timed out. Race: child may have completed DURING the poll
+    # (poll blocks up to timeout_sec; child can exit mid-poll without
+    # being detected by the outer loop's `kill -0` gate). Re-check
+    # liveness before emitting STALE log + kill cascade — avoids
+    # false-positive STALE on natural completion.
+    if ! kill -0 "$child_pid" 2>/dev/null; then
+      break  # child already exited; let `wait` capture rc cleanly.
+    fi
+    # STALE: no commits within timeout window AND child still alive.
+    printf "[LIVENESS] STALE: no commits in %ds; killing PID %s\n" "$timeout_sec" "$child_pid" >&2
+    kill -TERM "$child_pid" 2>/dev/null || true
+    sleep 2
+    kill -KILL "$child_pid" 2>/dev/null || true
+    break
+  done
+
+  # Wait for child (natural or killed); capture rc.
+  wait "$child_pid" 2>/dev/null
+  rc=$?
+  cat "$tmpfile"
+  return "$rc"
+}
+
 fi  # ORCHESTRATOR_LIVENESS_LIB guard
 
 # CLI entry — only when invoked directly (bash lib/orchestrator-liveness.sh).

--- a/lib/orchestrator-liveness.sh
+++ b/lib/orchestrator-liveness.sh
@@ -206,10 +206,24 @@ HANDOFF
 #   - `wait` after kill cascade may return early if process is already
 #     reaped — rc capture proceeds either way.
 #   - tmpfile cleanup via trap RETURN handles abort/SIGTERM-to-parent paths.
+#
+# Trap RETURN constraint (v0.11.1 / US-003 review fix; convergent
+# code-reviewer + security MEDIUM): this function uses `trap RETURN`
+# for tmpfile cleanup. Bash REPLACES (not stacks) RETURN traps. Caller
+# must NOT invoke this function from a scope that has its own RETURN
+# trap relying on tmpfile cleanup (e.g., wrap_orchestrator_dispatch
+# also uses trap RETURN for its respawn tmpfile). Currently safe:
+# wrap_orchestrator_dispatch and dispatch_with_parallel_poll are called
+# from mutually exclusive branches in iteration-loop.sh.
 dispatch_with_parallel_poll() {
   local timeout_sec="${1:-600}"
   local interval_sec="${2:-60}"
   local cmd="${3:?dispatch_with_parallel_poll: cmd required}"
+  # v0.11.1 / US-003 review fix (architect MEDIUM): optional 4th arg
+  # forwards a worktree path to poll_orchestrator_commits + git rev-parse,
+  # matching wrap_orchestrator_dispatch's signature. Future-proofs against
+  # worktree callers; current legacy-dispatch wire passes "" (pwd HEAD).
+  local worktree_path="${4:-}"
 
   local tmpfile child_pid base_sha rc=0
   tmpfile=$(mktemp)
@@ -219,13 +233,21 @@ dispatch_with_parallel_poll() {
   # Spawn CMD in background; capture stdout+stderr to tmpfile.
   bash -c "$cmd" >"$tmpfile" 2>&1 &
   child_pid=$!
-  base_sha=$(git rev-parse HEAD 2>/dev/null || echo "INIT")
+  if [[ -n "$worktree_path" && "$worktree_path" != "." ]]; then
+    base_sha=$(git -C "$worktree_path" rev-parse HEAD 2>/dev/null || echo "INIT")
+  else
+    base_sha=$(git rev-parse HEAD 2>/dev/null || echo "INIT")
+  fi
 
   # Poll loop: each window resets on new commit; STALE-kill if no commits.
   while kill -0 "$child_pid" 2>/dev/null; do
-    if poll_orchestrator_commits "$timeout_sec" "$interval_sec" "$base_sha" >&2; then
+    if poll_orchestrator_commits "$timeout_sec" "$interval_sec" "$base_sha" "$worktree_path" >&2; then
       # New commit observed — child is making progress, reset window.
-      base_sha=$(git rev-parse HEAD 2>/dev/null || echo "$base_sha")
+      if [[ -n "$worktree_path" && "$worktree_path" != "." ]]; then
+        base_sha=$(git -C "$worktree_path" rev-parse HEAD 2>/dev/null || echo "$base_sha")
+      else
+        base_sha=$(git rev-parse HEAD 2>/dev/null || echo "$base_sha")
+      fi
       continue
     fi
     # poll timed out. Race: child may have completed DURING the poll

--- a/tasks/prd-v0.11.1-bundle.md
+++ b/tasks/prd-v0.11.1-bundle.md
@@ -1,0 +1,146 @@
+# PRD: v0.11.1 — patch-tier (N43: parallel-with-dispatch wrap pattern)
+
+**Status:** Operator-approved (Path A). Architectural follow-on to v0.11.0 first-dispatch milestone.
+**Date:** 2026-05-02
+**Predecessor:** `tasks/prd-v0.11.0-bundle.md`.
+**Branch:** `ql/v0.11.1-bundle`.
+**Target version:** 0.11.0 → 0.11.1 (patch; opt-in feature with backwards-compat default off).
+**Total effort:** ~2 hours.
+
+## Section 1: Introduction / Overview
+
+4-story patch closing **N43** (parallel-with-dispatch wrap pattern; deferred MEDIUM since v0.8.1; tracked through 8+ IDEA_REPORTs). Implements pre-emptive stuck-agent detection via background dispatch + foreground commit-poll + kill-on-STALE. Opt-in via env var to preserve backwards compatibility on Git Bash where bg-process supervision is fragile.
+
+**Architecture rationale:** Current `ql_wrap_subagent_dispatch` (v0.8.1) is post-dispatch — fires AFTER runner returns, only as diagnostic. N43's parallel-with-dispatch design proactively kills stuck agents before they exhaust the iteration budget.
+
+## Section 2: Goals
+
+- Add `lib/orchestrator-liveness.sh::dispatch_with_parallel_poll` function with contract:
+  - Spawns CMD in background; captures stdout+stderr to tmpfile.
+  - Polls commits in foreground via existing `poll_orchestrator_commits`.
+  - Resets poll window on each new commit (commit-progress = liveness signal).
+  - Kills child via `SIGTERM` then `SIGKILL` if no commits within timeout window.
+  - Returns child's rc (or 143/137 on signal-kill).
+- Wire opt-in via `QL_PARALLEL_POLL=true` env var at the LEGACY (non-coordinator) dispatch site in `lib/iteration-loop.sh`.
+- Default OFF: existing behavior preserved unless operator opts in.
+- Test coverage: hung-implementer scenario + clean-completion scenario.
+- 26th p014 review.
+- Bump 0.11.0 → 0.11.1.
+- 45 consecutive LOW G30.
+
+## Section 3: User Stories
+
+### US-001: `dispatch_with_parallel_poll` function
+
+**Acceptance Criteria:**
+- [ ] New function `dispatch_with_parallel_poll TIMEOUT_SEC INTERVAL_SEC CMD` in `lib/orchestrator-liveness.sh` (after `wrap_orchestrator_dispatch`).
+- [ ] Behavior:
+  - `mktemp` + `chmod 600` for tmpfile (security pattern from v0.10.11 N46).
+  - `trap 'rm -f "$tmpfile"' RETURN` (cleanup).
+  - `bash -c "$cmd" >"$tmpfile" 2>&1 &`; capture `$!` as child_pid.
+  - Outer loop: while child alive, run `poll_orchestrator_commits TIMEOUT_SEC INTERVAL_SEC BASE_SHA`. On commit (return 0), reset BASE_SHA + continue. On STALE (return 1), `kill -TERM child_pid`, `sleep 2`, `kill -KILL child_pid`, `break`.
+  - After loop: `wait child_pid 2>/dev/null`; capture rc.
+  - Print captured output via `cat "$tmpfile"`.
+  - Return child's rc.
+- [ ] Output captured + emitted on stdout (caller can capture with `$(...)`).
+- [ ] STALE log emitted to stderr: `[LIVENESS] STALE: no commits in Ns; killing PID X`.
+- [ ] Graceful when `poll_orchestrator_commits` not in scope (impossible by design; same lib file). N/A.
+- [ ] `bash -n lib/orchestrator-liveness.sh` clean.
+
+### US-002: Wire opt-in at legacy dispatch site + tests
+
+**Acceptance Criteria:**
+- [ ] `lib/iteration-loop.sh` legacy dispatch (~line 242, the `eval "$RUNNER_CMD"` site): conditional invocation via `QL_PARALLEL_POLL=true`. When set, replace `OUTPUT=$(eval "$RUNNER_CMD" 2>&1) || RUNNER_EXIT=$?` with a call to `dispatch_with_parallel_poll`.
+- [ ] Default OFF: when `QL_PARALLEL_POLL` is unset or empty, existing behavior unchanged.
+- [ ] New tests in `tests/test_orchestrator_liveness.sh`:
+  - Test 16: clean-completion path (CMD exits 0 with output; rc=0 propagates; output captured).
+  - Test 17: STALE-kill path (CMD `sleep 30`; timeout=2; assert rc != 0 + STALE log emitted within ~6 sec wallclock).
+  - Test 18: commit-progress reset (CMD makes commits during poll; verify each commit resets the timeout window; CMD completes naturally without kill).
+- [ ] `bash tests/test_orchestrator_liveness.sh` rc=0; 38 → 41 tests (3 new).
+
+### US-003: Multi-perspective post-merge review (26th application)
+
+**Acceptance Criteria:**
+- [ ] 3 reviewer agents (architect + code-reviewer + security) invoked in parallel.
+- [ ] Architect specifically: validate kill cascade is correct on Git Bash (SIGTERM with timeout vs SIGKILL fallback) + commit-progress reset semantics.
+- [ ] No score-≥85 finding deferred.
+
+### US-004: Retrospective + IDEA_REPORT_v51 + version bump 0.11.0 → 0.11.1
+
+**Acceptance Criteria:**
+- [ ] `idea-stage/PIPELINE_REPORT_v51.md` documents v0.11.1 (4 stories) + N43 closure + bg-process supervision design notes.
+- [ ] `idea-stage/IDEA_REPORT_v51.md` rolling forward state.
+- [ ] `CHANGELOG.md [0.11.1]` entry.
+- [ ] 4 plugin manifest version fields bumped 0.11.0 → 0.11.1.
+- [ ] G30 self-validation (45th consecutive LOW expected).
+
+## Section 4: Functional Requirements
+
+- **FR-1:** N43 implementation is opt-in (default OFF) for backwards compat.
+- **FR-2:** When opt-in active, dispatch is parallelized: child runs in bg, parent polls in fg, kill fires on STALE.
+- **FR-3:** Commit-progress signals liveness; timeout window resets on each new commit.
+- **FR-4:** Kill cascade: SIGTERM → 2-sec wait → SIGKILL fallback.
+- **FR-5:** Output capture preserved (stdout+stderr to tmpfile, cat'd to function stdout).
+- **FR-6:** Plugin version 0.11.0 → 0.11.1 (4 fields).
+
+## Section 5: Non-Goals
+
+- No coordinator-mode integration (coordinator already has wallclock kill via `QL_COORDINATOR_TIMEOUT_S`).
+- No retroactive rewrite of `ql_wrap_subagent_dispatch` post-dispatch wire (still useful as diagnostic).
+- No multi-child supervision (single child per dispatch).
+- No bg-job orchestration (no `wait -n`, no parallel children).
+
+## Section 6: Design Notes
+
+**Function signature:**
+```bash
+# dispatch_with_parallel_poll TIMEOUT_SEC INTERVAL_SEC CMD
+# Spawns CMD in bg, polls commits in fg, kills on STALE.
+# Output captured to tmpfile, emitted on stdout. Returns child's rc.
+dispatch_with_parallel_poll() {
+  local timeout_sec="$1" interval_sec="$2" cmd="$3"
+  local tmpfile child_pid base_sha rc=0
+  tmpfile=$(mktemp); chmod 600 "$tmpfile" 2>/dev/null || true
+  trap 'rm -f "$tmpfile"' RETURN
+  
+  bash -c "$cmd" >"$tmpfile" 2>&1 &
+  child_pid=$!
+  base_sha=$(git rev-parse HEAD 2>/dev/null || echo "INIT")
+  
+  while kill -0 "$child_pid" 2>/dev/null; do
+    if poll_orchestrator_commits "$timeout_sec" "$interval_sec" "$base_sha" >&2; then
+      base_sha=$(git rev-parse HEAD 2>/dev/null || echo "$base_sha")
+      continue
+    fi
+    printf "[LIVENESS] STALE: no commits in %ds; killing PID %s\n" "$timeout_sec" "$child_pid" >&2
+    kill -TERM "$child_pid" 2>/dev/null || true
+    sleep 2
+    kill -KILL "$child_pid" 2>/dev/null || true
+    break
+  done
+  
+  wait "$child_pid" 2>/dev/null; rc=$?
+  cat "$tmpfile"
+  return "$rc"
+}
+```
+
+**Git Bash bg-process gotchas (mitigated):**
+- `kill -0 PID` works on Git Bash for liveness check.
+- `kill -TERM` may not deliver to bg processes spawned via `bash -c` if the child has already established its own session; SIGKILL fallback handles this.
+- `wait` after `kill` may return 0 if the process is already reaped; that's why we capture rc separately.
+- tmpfile race: trap RETURN cleans up on all exit paths.
+
+**Wire site rationale:** legacy mode (line 242) is the right wire — coordinator mode (line 224) already has wallclock kill via `timeout(1)`. Wiring N43 there would be redundant.
+
+## Section 7: Technical Notes
+
+Bash 4.3+. POSIX `kill`, `wait`. `git rev-parse HEAD` (already a hard dep).
+
+## Section 8: Success Metrics
+
+- All 4 stories first-attempt PASS (or first-attempt-after-review).
+- `tests/test_orchestrator_liveness.sh`: 38 → 41 tests (3 new).
+- 6 baseline test suites green: 175 + 41 = 216.
+- 45 consecutive LOW G30.
+- N43 CLOSED (was deferred MEDIUM since v0.8.1).

--- a/tests/test_orchestrator_liveness.sh
+++ b/tests/test_orchestrator_liveness.sh
@@ -490,6 +490,120 @@ rc15=$(cd "$TMP15" && bash -c "
 assert "Test 15: respawn rc=0 propagates without runner_parse_output" "0" "$rc15"
 rm -rf "$TMP15"
 
+# Test 16: v0.11.1 / US-001 (N43) — dispatch_with_parallel_poll clean
+# completion path. CMD exits 0 with output; rc=0 propagates; output captured.
+echo ""
+echo "Test 16: dispatch_with_parallel_poll clean completion (CMD exits 0)"
+TMP16=$(mktemp -d)
+( cd "$TMP16" && git init -q && git config user.email "t@t.t" && git config user.name "t" \
+  && echo "init" > README.md && git add README.md && git commit -qm "init" ) >/dev/null 2>&1
+
+out16=$(cd "$TMP16" && bash -c "
+  source '$LIB'
+  dispatch_with_parallel_poll 5 1 'echo hello-from-child; exit 0'
+")
+rc16=$?
+
+TOTAL=$((TOTAL + 1))
+if printf '%s' "$out16" | grep -q "hello-from-child"; then
+  echo "  PASS: child output captured"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: child output missing — out: $out16"
+  FAIL=$((FAIL + 1))
+fi
+assert "Test 16: rc=0 propagates from clean completion" "0" "$rc16"
+rm -rf "$TMP16"
+
+# Test 17: v0.11.1 / US-001 (N43) — STALE-kill path. CMD `sleep 30`;
+# timeout=2; assert rc != 0 + STALE log emitted within ~6 sec wallclock.
+echo ""
+echo "Test 17: dispatch_with_parallel_poll STALE-kill (sleep 30 with timeout=2)"
+TMP17=$(mktemp -d)
+( cd "$TMP17" && git init -q && git config user.email "t@t.t" && git config user.name "t" \
+  && echo "init" > README.md && git add README.md && git commit -qm "init" ) >/dev/null 2>&1
+
+t0=$(date +%s)
+out17=$(cd "$TMP17" && bash -c "
+  source '$LIB'
+  dispatch_with_parallel_poll 2 1 'sleep 30; echo never-reached' 2>&1
+")
+rc17=$?
+t1=$(date +%s)
+elapsed17=$((t1 - t0))
+
+TOTAL=$((TOTAL + 1))
+if (( rc17 != 0 )); then
+  echo "  PASS: rc=$rc17 (non-zero from kill cascade)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: rc=0 (expected non-zero from kill)"
+  FAIL=$((FAIL + 1))
+fi
+
+TOTAL=$((TOTAL + 1))
+if printf '%s' "$out17" | grep -q "STALE: no commits in .* killing PID"; then
+  echo "  PASS: STALE-kill log emitted"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: STALE-kill log missing — out: $out17"
+  FAIL=$((FAIL + 1))
+fi
+
+TOTAL=$((TOTAL + 1))
+if (( elapsed17 <= 15 )); then
+  echo "  PASS: kill cascade completed in ${elapsed17}s (≤15s ceiling)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: kill cascade took ${elapsed17}s (>15s — investigate Git Bash jitter)"
+  FAIL=$((FAIL + 1))
+fi
+rm -rf "$TMP17"
+
+# Test 18: v0.11.1 / US-001 (N43) — commit-progress reset. CMD makes a
+# commit during the poll window; verify commit resets the timeout window
+# and CMD completes naturally without kill (rc=0).
+echo ""
+echo "Test 18: dispatch_with_parallel_poll commit-progress resets timeout window"
+TMP18=$(mktemp -d)
+( cd "$TMP18" && git init -q && git config user.email "t@t.t" && git config user.name "t" \
+  && echo "init" > README.md && git add README.md && git commit -qm "init" ) >/dev/null 2>&1
+
+# CMD: sleeps 3s, makes a commit (resets window), sleeps another 3s, exits 0.
+# With timeout=4, the first 3s + commit + 3s would naturally be 6s but the
+# commit at 3s resets the window; the second 3s falls within the new window.
+# Without the reset, the first 3s + commit at 3s would still fit within the
+# initial 4s window, so no kill — but Test 18 specifically validates that
+# the LIVENESS log emits a "new commit observed" line confirming the reset.
+PROGRESS_CMD="cd '$TMP18' && sleep 3 && echo step1 > marker.txt && git add marker.txt && git commit -qm step1 && sleep 1 && exit 0"
+t0=$(date +%s)
+out18=$(cd "$TMP18" && bash -c "
+  source '$LIB'
+  dispatch_with_parallel_poll 4 1 \"$PROGRESS_CMD\" 2>&1
+")
+rc18=$?
+t1=$(date +%s)
+elapsed18=$((t1 - t0))
+
+assert "Test 18: rc=0 from natural completion" "0" "$rc18"
+TOTAL=$((TOTAL + 1))
+if printf '%s' "$out18" | grep -q "new commit"; then
+  echo "  PASS: commit-progress log emitted (LIVENESS detected progress)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: commit-progress log missing — out: $out18"
+  FAIL=$((FAIL + 1))
+fi
+TOTAL=$((TOTAL + 1))
+if ! printf '%s' "$out18" | grep -q "STALE: no commits .* killing"; then
+  echo "  PASS: no STALE-kill log (child completed naturally)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: STALE-kill log appeared — out: $out18"
+  FAIL=$((FAIL + 1))
+fi
+rm -rf "$TMP18"
+
 echo ""
 echo "=== Results: $PASS/$TOTAL passed, $FAIL failed ==="
 [[ $FAIL -eq 0 ]] || exit 1


### PR DESCRIPTION
## Summary

4-story patch closing **N43** (parallel-with-dispatch wrap pattern; deferred MEDIUM since v0.8.1; tracked through 8+ IDEA_REPORTs).

- **US-001** — `lib/orchestrator-liveness.sh` adds `dispatch_with_parallel_poll`. Spawns CMD in bg, polls commits in fg via `poll_orchestrator_commits`, kills child on STALE (SIGTERM → 2s → SIGKILL). Commit-progress resets timeout window.
- **US-002** — `lib/iteration-loop.sh:247-253` opt-in wire via `QL_PARALLEL_POLL=true`. 3 new tests: clean completion, STALE-kill, commit-progress reset. Race fix discovered + applied during testing (post-poll `kill -0` re-check).
- **US-003** — 26th p014 review trio (architect SHIP 91, code-reviewer 93, security 92). 2 MEDIUM inline-fixed: worktree_path forwarding gap (architect); trap RETURN overwrite invariant comment (code-reviewer + security convergent). **13th p014 catch in 26 applications career (~50% — crossed 50% threshold).**
- **US-004** — Retro + IDEA_REPORT_v51 + 4-manifest bump 0.11.0 → 0.11.1.

## Test plan

- [x] `bash -n lib/orchestrator-liveness.sh lib/iteration-loop.sh` clean
- [x] `tests/test_orchestrator_liveness.sh`: 46/46 (was 38; +8 sub-asserts)
- [x] 5 baseline suites green (no regression)
- [x] 45 consecutive LOW G30 self-validations (v0.6.5..v0.11.1)
- [x] N43 closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)