### PR TITLE
v0.11.2 — patch (D-medium: N48 negative-path + CLAUDE.md doc updates)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Universal CLI orchestrator with multi-runner support. Autonomous spec-driven development pipeline with dependency DAG, parallel worktree execution, two-stage review gates, DAG intelligence validation, and modular merge hardening",
-    "version": "0.11.1"
+    "version": "0.11.2"
   },
   "plugins": [
     {
       "name": "quantum-loop",
       "source": "./",
       "description": "6 skills (brainstorm, spec, plan, execute, verify, review) and 5 agents for autonomous spec-driven development with multi-runner support, DAG intelligence, and modular merge hardening",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "keywords": [
         "autonomous",
         "prd",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "quantum-loop",
   "description": "Universal CLI orchestrator with multi-runner support. Autonomous spec-driven development with dependency DAG, parallel worktree execution, two-stage review gates, and modular merge hardening.",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "author": {
     "name": "andyzengmath"
   }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "quantum-loop",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Spec-driven autonomous development loop with DAG-based execution, parallel worktree agents, two-stage review gates, and Iron Law verification. Turns a feature description into verified, reviewed, autonomously-implemented code.",
   "author": {
     "name": "andyzengmath"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ Format: [Semantic Versioning](https://semver.org/). Bump per PR:
 - **Minor** (0.x.0): new features, backward-compatible
 - **Major** (x.0.0): breaking changes
 
+## [0.11.2] - 2026-05-02
+
+### Added — patch-tier (D-medium: N48 negative-path test + CLAUDE.md doc updates from comprehensive review)
+
+4-story patch closing **5 findings from post-v0.11.1 comprehensive review**: N48 negative-path test (Test 10 pairs with v0.11.0 Test 9) + 4 CLAUDE.md doc gaps (line refs stale; QL_PARALLEL_POLL undocumented; dispatch_with_parallel_poll unreferenced; trap-RETURN-nesting invariant uncanonized). **46 consecutive LOW G30 self-validations** (v0.6.5..v0.11.2).
+
+### Stories shipped
+
+- **US-001 — N48 negative-path test (Test 10)** — `tests/test_coordinator_e2e.sh:433-481` adds Test 10 reusing existing `passed` stub mode (already field-ownership-compliant by construction). 5 sub-asserts: positive control + WARN absence + before:/after: absence + US-A status=passed + US-B status=passed. Validates N48 detection symmetry (no false positives on compliant coordinators).
+- **US-002 — CLAUDE.md doc updates (4 gaps)** — Edit 1: line refs `iteration-loop.sh:~212/~215` → `~224/~227` (HIGH-1; v0.11.1 wire shifted). Edit 2: new `QL_PARALLEL_POLL` env var bullet in Coordinator-related section (MEDIUM-1). Edit 3: new `dispatch_with_parallel_poll` reference (MEDIUM-2). Edit 4: new "Bash trap RETURN is last-write-wins" Platform Notes entry (MEDIUM-3).
+- **US-003 — Multi-perspective post-merge review (27th application; 1 LOW retro-noted)** — Architect SHIP 94 + Security SHIP 95. Code-reviewer agent timed out twice mid-test-execution; coverage gap mitigated by architect convergence on same items. Architect's 1 LOW: PRD counter said +4, actual +5 sub-asserts; retro-noted. **14th p014 catch in 27 applications career; ~52% career hit-rate.**
+- **US-004 — Retrospective + IDEA_REPORT_v52 + version bump 0.11.1 → 0.11.2** — this entry.
+
+### Test-suite delta
+
+`tests/test_coordinator_e2e.sh`: 27 → 32 tests (+5 sub-asserts in Test 10). 6 baseline suites total: 194.
+
+### Architectural observations
+
+**Comprehensive review beats per-cycle p015 audits for cross-cutting concerns.** The post-v0.11.1 comprehensive review surfaced 4 doc gaps + 2 code coverage gaps that 6 prior p015 audits hadn't caught — p015 audits focus on rolling-forward IDEA_REPORT/PIPELINE_REPORT chain consistency, while comprehensive review walks the entire codebase + docs surface holistically. **Candidate p017** (comprehensive review at major version boundaries) — may warrant canonization if applied 2+ times.
+
+**v0.11.x autonomous backlog reducing.** Remaining: copilot-hooks::post_output coverage (v0.11.3 candidate, ~150 LOC), build_coordinator_prompt content assertions, Path E (test file split). Operator-gated: Path B (real-feature dispatch) + pre-Path-B field-ownership escalation policy decision.
+
 ## [0.11.1] - 2026-05-02
 
 ### Added — patch-tier (N43 parallel-with-dispatch wrap pattern; opt-in default OFF)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,6 +237,19 @@ the function comment so future readers aren't surprised.
 version-style numeric sort anywhere you're finding the "latest" of a
 set of numbered siblings.
 
+**Bash `trap RETURN` is last-write-wins per function scope:** unlike
+EXIT traps which can be stacked via care, `trap '...' RETURN` REPLACES
+the prior trap when set in the same function scope. Two functions in
+`lib/orchestrator-liveness.sh` (`wrap_orchestrator_dispatch` for
+N46 respawn re-parse, and `dispatch_with_parallel_poll` for N43
+parallel-with-dispatch wrap) both rely on `trap RETURN` for tmpfile
+cleanup. **Callers must NOT nest these two functions** in the same
+shell scope — the second trap silently overwrites the first, leaking
+the earlier function's tmpfile. Currently safe per call graph
+(mutually exclusive branches in `lib/iteration-loop.sh`); see inline
+invariant comment at `lib/orchestrator-liveness.sh:~211`. Convergent
+v0.11.1 review finding (architect+code-reviewer+security).
+
 ## Process references
 
 Operator-side workflow docs that the standard pipeline does not invoke
@@ -260,9 +273,10 @@ Operator-facing surface for the v0.9.x per-wave coordinator dispatch
 
 - **`QL_COORDINATOR_TIMEOUT_S`** (env var; default `1800` seconds = 30 min;
   v0.9.3 / US-001). Wallclock ceiling on the coordinator subagent's
-  `bash -c "$COORD_CMD"` invocation in `lib/iteration-loop.sh:~212`
-  (post-v0.9.5 decomposition; line 212 is the timeout-guarded dispatch,
-  line 215 is the no-timeout fallback). On `timeout`
+  `bash -c "$COORD_CMD"` invocation in `lib/iteration-loop.sh:~224`
+  (post-v0.11.1 decomposition; line ~224 is the timeout-guarded dispatch,
+  line ~227 is the no-timeout fallback; line numbers shift over time —
+  search for `QL_COORDINATOR_TIMEOUT_S` to locate). On `timeout`
   rc=124 (SIGTERM kill from `timeout(1)` + 10s `--kill-after` grace), the
   parent prints `ERROR: Coordinator subagent exceeded ${N}s timeout` and
   forces `<quantum>WAVE_FAILED</quantum>` so per-story review-field
@@ -283,9 +297,32 @@ Operator-facing surface for the v0.9.x per-wave coordinator dispatch
   whose `tasks[].filePaths` is empty in aggregate. Wired into
   `lib/dag-query.sh::next_wave` preamble. Never blocks. Closes v0.9.1
   architect MEDIUM (silent `filter_file_conflicts` bypass).
+- **`QL_PARALLEL_POLL`** (env var; default `false`; v0.11.1 / US-002).
+  **Note: applies to LEGACY (non-coordinator) dispatch path, not
+  `--coordinator`** (which uses `QL_COORDINATOR_TIMEOUT_S` above).
+  When `QL_PARALLEL_POLL=true`, the legacy dispatch at
+  `lib/iteration-loop.sh:~247` runs the runner CMD in background +
+  polls commits in foreground via `dispatch_with_parallel_poll` (see
+  next bullet); kills child on STALE (no commits within
+  `QL_PARALLEL_POLL_TIMEOUT_S` window; default 600s). Companion vars:
+  `QL_PARALLEL_POLL_INTERVAL_S` (poll cadence; default 60s). Default
+  OFF preserves backwards compat — Git Bash bg-process supervision is
+  fragile (see Platform Notes). Closes N43 (deferred MEDIUM since v0.8.1).
+- [`lib/orchestrator-liveness.sh::dispatch_with_parallel_poll`](lib/orchestrator-liveness.sh)
+  (v0.11.1 / US-001). New helper called from the legacy dispatch site
+  (gated by `QL_PARALLEL_POLL` above). Signature:
+  `dispatch_with_parallel_poll TIMEOUT_SEC INTERVAL_SEC CMD [WORKTREE_PATH]`.
+  Spawns CMD in bg via `bash -c`, polls commits in fg, kills child via
+  SIGTERM → 2s grace → SIGKILL on STALE. Race-safe: post-poll `kill -0`
+  re-check handles child-exits-during-poll. Coordinator mode does NOT
+  use this path — it has wallclock kill via `QL_COORDINATOR_TIMEOUT_S`
+  instead.
 - Coordinator-specific tests: `tests/test_coordinator_guard.sh`,
-  `tests/test_quantum_validate.sh`, `tests/test_coordinator_e2e.sh`,
-  `tests/test_coordinator_dispatch.sh`, `tests/test_next_wave.sh`.
+  `tests/test_quantum_validate.sh`, `tests/test_coordinator_e2e.sh`
+  (incl. v0.11.0 Test 9 N48 dogfood + v0.11.2 Test 10 N48 negative-path),
+  `tests/test_coordinator_dispatch.sh`, `tests/test_next_wave.sh`,
+  `tests/test_orchestrator_liveness.sh` (incl. v0.11.1 Tests 16/17/18
+  for `dispatch_with_parallel_poll`).
 
 ### Test-related
 

--- a/idea-stage/IDEA_REPORT_v52.md
+++ b/idea-stage/IDEA_REPORT_v52.md
@@ -1,0 +1,71 @@
+# IDEA_REPORT_v52 — what's open after v0.11.2
+
+**Date:** 2026-05-02
+**Source:** v0.11.2 closes 5 findings from post-v0.11.1 comprehensive review (D-medium scope: N48 negative-path + CLAUDE.md doc updates); 45 → 46 consecutive LOW G30.
+**Branch:** `ql/v0.11.2-bundle` (release tag v0.11.2 — pending)
+**Predecessor:** `idea-stage/IDEA_REPORT_v51.md`
+
+## Closed in v0.11.2
+
+| ID | Story | Notes |
+|---|---|---|
+| N48 negative-path test (Test 10) | US-001 | Symmetric to v0.11.0 Test 9; reuses `passed` stub mode |
+| CLAUDE.md line refs stale (HIGH-1) | US-002 edit 1 | iteration-loop.sh:~212/~215 → ~224/~227 |
+| QL_PARALLEL_POLL env var undocumented (MEDIUM-1) | US-002 edit 2 | New bullet in Coordinator-related |
+| dispatch_with_parallel_poll unreferenced (MEDIUM-2) | US-002 edit 3 | New bullet with signature + race-fix note |
+| Trap-RETURN-nesting invariant uncanonized (MEDIUM-3) | US-002 edit 4 | New Platform Notes entry |
+
+## Open: v0.11.x backlog (post-v0.11.2)
+
+### Operator-decision items
+
+| Item | Severity | Path |
+|------|----------|------|
+| **Path B: Real-feature dispatch via `--coordinator`** | blocked | operator-queued multi-story feature |
+| **Pre-Path-B: field-ownership WARN→FAIL escalation policy** | operator-decision | architectural; should v0.10.8 N48 WARN escalate before Path B? |
+| N47 — branch cleanup | operator | operator-decision-pending |
+
+### Autonomously-achievable backlog (v0.11.3 candidates)
+
+| Item | Severity | Effort |
+|------|----------|--------|
+| copilot-hooks::post_output test coverage | MEDIUM (real coverage gap) | ~150 LOC; 6 tests; own cycle |
+| build_coordinator_prompt content assertions | LOW-MEDIUM | ~30 LOC; 2-3 tests; could fold with above |
+| `emit_terminal_signal` direct test coverage | MEDIUM (called from 5 sites; zero direct tests) | future fixture-driven test cycle |
+| Path E: test_orchestrator_liveness.sh split | LOW | ~615 LOC; at threshold but not over critical mass |
+
+### Architectural debt (deferred to future cycles)
+
+| Item | Severity | Path |
+|------|----------|------|
+| `run_iteration_loop` 471-LOC decomposition | HIGH structural | future architectural cycle (high regression risk) |
+| `run_parallel_mode` 379-LOC decomposition | MEDIUM | future |
+
+## v0.11.3 recommendation
+
+If operator wants to continue autonomous progression: **bundle copilot-hooks::post_output coverage + build_coordinator_prompt content assertions** as v0.11.3 (4-5 stories, ~180 LOC). Both are real coverage gaps surfaced by the comprehensive review.
+
+Alternative: hold for Path B (operator-queued real feature).
+
+## Recurring observations
+
+- **46 consecutive LOW G30 self-validations** (v0.6.5..v0.11.2).
+- **Bundle size sequence: ...3-4-4-4-4-4-4-4-4-4-3-4-4-4-4.** v0.11.2 = 4 stories.
+- **Manual-takeover streak: maintained through v0.11.2** — 2 operator gates this cycle (Path A→D-medium scope choice + scope expansion approval after comprehensive review).
+- **p013 (operator-staged kickoff): 20 applications.** v0.11.2 operator-staged.
+- **p014 (composite review trio): 27 review applications. 14 review-gate catches in 27 applications (~52% career hit-rate; up from 50% at v0.11.1).** Pattern climbing past 50% threshold.
+  - Note: v0.11.2's code-reviewer agent timed out twice; 2-of-3 reviewer coverage with architect+security convergence accepted.
+- **p015 (post-cycle 3-agent doc-vs-code audit): 6 applications**, canonized at 2; 25 gaps closed.
+- **p016 (dogfood-driven LOW sweep wave): 1 application**, canonized at 1.
+- **NEW pattern candidate (post-v0.11.1):** comprehensive review at major version boundaries — see PIPELINE_REPORT_v52 lessons-learned. May warrant canonization as p017 if applied 2+ times.
+
+## v0.11.2 → v0.11.x transition
+
+```
+v0.11.0 (FIRST --coordinator dispatch dogfood; N48 closure) ✓
+v0.11.1 (N43 parallel-with-dispatch wrap pattern; opt-in) ✓
+v0.11.2 (D-medium: N48 symmetry + CLAUDE.md docs from comprehensive review) ✓ ← THIS CYCLE
+v0.11.3 (operator decides: Path B real-feature OR copilot-hooks coverage)
+```
+
+**Operator decision required for v0.11.3.** Pre-Path-B item (field-ownership escalation policy) should be decided before any operator-queued real feature.

--- a/idea-stage/PIPELINE_REPORT_v52.md
+++ b/idea-stage/PIPELINE_REPORT_v52.md
@@ -1,0 +1,124 @@
+# PIPELINE_REPORT_v52 — v0.11.2 retrospective (D-medium: N48 negative-path + CLAUDE.md doc updates)
+
+**Date:** 2026-05-02
+**Bundle:** `ql/v0.11.2-bundle` (release tag v0.11.2 — pending push/PR/merge/tag/release)
+**Predecessor report:** `idea-stage/PIPELINE_REPORT_v51.md`
+**Master parent:** `3636526` (v0.11.1 ship state)
+**Source:** `tasks/prd-v0.11.2-bundle.md` (operator-approved D-medium scope post-comprehensive-review).
+
+## Overview
+
+4-story patch closing **5 findings from the post-v0.11.1 comprehensive review**:
+1. **N48 negative-path test** (US-001) — pairs with v0.11.0 Test 9 to validate detection symmetry.
+2. **CLAUDE.md `iteration-loop.sh:~212/~215` line refs stale** (US-002 HIGH-1) — bumped to ~224/~227.
+3. **CLAUDE.md missing `QL_PARALLEL_POLL` env var docs** (US-002 MEDIUM-1).
+4. **CLAUDE.md missing `dispatch_with_parallel_poll` reference** (US-002 MEDIUM-2).
+5. **Platform Notes missing trap-RETURN-nesting invariant** (US-002 MEDIUM-3).
+
+**46th consecutive LOW G30 self-validation.**
+
+## The 4 stories
+
+| # | ID | Title | Outcome |
+|:-:|---|---|:-:|
+| 0 | (cycle setup) | chore: v0.11.2 cycle kickoff (PRD only) | committed at `568351d` |
+| 1 | US-001 | N48 negative-path test (Test 10) | first-attempt PASS at `a0dc1d9` |
+| 2 | US-002 | CLAUDE.md doc updates (4 gaps) | first-attempt PASS at `588c162` |
+| 3 | US-003 | 27th p014 review trio (SHIP; 1 LOW retro-noted) | committed at `2e80908` |
+| 4 | US-004 | Retrospective + IDEA_REPORT_v52 + version bump 0.11.1 → 0.11.2 | this report |
+
+## US-001 deep-dive: N48 detection symmetry
+
+**Test 10 (`tests/test_coordinator_e2e.sh:433-481`):**
+- Reuses existing `passed` stub mode (line 97-106) — already field-ownership-compliant by construction (writes only `.review.specCompliance` + `.review.codeQuality`; never touches `.stories[].status`).
+- 5 sub-asserts (PRD planned 4; actual 5):
+  - Positive control: `Wave (wave-1) PASSED` appears (matches Test 1).
+  - Negative — WARN absence: `[FIELD-OWNERSHIP] WARN` does NOT appear.
+  - Negative — before:/after: absence: side-effect of WARN absence.
+  - US-A status=passed (parent processed WAVE_PASSED).
+  - US-B status=passed (parent processed WAVE_PASSED).
+
+**Symmetry rationale:** Without Test 10, N48 could in principle be over-firing (always WARNing regardless of actual violation) and Test 9 would still pass. The negative-path test confirms detection is **symmetric**: WARN fires iff contract is violated.
+
+## US-002 deep-dive: CLAUDE.md updates (4 gaps in same section)
+
+| Edit | Section | Change |
+|------|---------|--------|
+| 1 | Coordinator-related | `lib/iteration-loop.sh:~212/~215` → `~224/~227` (HIGH-1 fix; 3rd line-ref bump since v0.9.5) |
+| 2 | Coordinator-related | New `QL_PARALLEL_POLL` env var bullet (MEDIUM-1) — explicit "(non-coordinator)" qualifier |
+| 3 | Coordinator-related | New `dispatch_with_parallel_poll` function reference bullet (MEDIUM-2) |
+| 4 | Platform Notes | New "Bash trap RETURN is last-write-wins" entry (MEDIUM-3) — canonizes v0.11.1 inline invariant |
+
+**Section naming note:** "Coordinator-related" is becoming a misnomer with `QL_PARALLEL_POLL` (legacy non-coordinator). Disambiguated via explicit "(non-coordinator)" qualifier in new bullets. Future cycle could rename to "Dispatch helpers" but that's cosmetic.
+
+## Multi-perspective review synthesis (US-003; 27th p014 application)
+
+| Reviewer | Verdict | Score | Key findings |
+|---|---|---:|---|
+| **Architect** | SHIP | 94 | **1 LOW (retro-noted):** PRD counter said +4, actual Test 10 has +5 sub-asserts. Inline-fix optional. Verified: Test 10 symmetry sound; CLAUDE.md line refs accurate against current master; QL_PARALLEL_POLL gate location verified; Test 10 false-positive risk negligible (`-F` flag + unique `[FIELD-OWNERSHIP]` prefix). |
+| **Code-reviewer** | (truncated x2) | n/a | Agent response truncated mid-test-execution both attempts. Coverage gap mitigated by architect convergence on same items. |
+| **Security** | SHIP | 95 | **0 findings.** Docs+test surface, no new attack surface, no secrets. |
+
+**14th p014 catch in 27 applications career; ~52% career hit-rate.** Pattern continues climbing.
+
+**Note on code-reviewer truncation:** the agent timed out twice waiting on the actual test execution. Architect's review verified the same code-quality items (line refs, false-positive risk, counter accuracy). 2-of-3 reviewer coverage with convergence is acceptable for a docs+small-test patch where the surface is minimal.
+
+## Test-suite delta vs v0.11.1
+
+`tests/test_coordinator_e2e.sh`: 27 → 32 tests (+5 sub-asserts in Test 10; PRD planned +4, actual +5).
+6 baseline suites total: 15+32+44+39+18+46 = **194 total** (+5 vs v0.11.1).
+
+## v0.11.2 fixes shipped + deferrals
+
+### Closed (5 findings from comprehensive review)
+
+| Finding | Severity | Source | Resolution |
+|---|---|---|---|
+| **N48 negative-path test** | LOW (coverage gap) | comprehensive review | US-001 |
+| CLAUDE.md line refs stale | HIGH (live cross-ref) | doc-specialist HIGH-1 | US-002 edit 1 |
+| `QL_PARALLEL_POLL` env var undocumented | MEDIUM | doc-specialist MEDIUM-1 | US-002 edit 2 |
+| `dispatch_with_parallel_poll` unreferenced | MEDIUM | doc-specialist MEDIUM-2 | US-002 edit 3 |
+| Trap-RETURN-nesting invariant uncanonized | MEDIUM | doc-specialist MEDIUM-3 | US-002 edit 4 |
+
+### Deferred (unchanged + new)
+
+| Finding | Severity | Path |
+|---|---|---|
+| **Path B: Real-feature dispatch** | blocked | operator-queued multi-story feature |
+| Pre-Path-B: field-ownership WARN→FAIL escalation policy | operator-decision | architectural; pre-real-feature decision |
+| copilot-hooks::post_output test coverage | MEDIUM | v0.11.3 candidate (~150 LOC own cycle) |
+| build_coordinator_prompt content assertions | LOW-MEDIUM | v0.11.3 candidate |
+| Path E: test_orchestrator_liveness.sh split | LOW | defer; ~615 LOC at threshold but not over |
+| `run_iteration_loop` / `run_parallel_mode` decomposition | HIGH structural debt | future architectural cycle |
+| `emit_terminal_signal` direct test coverage | MEDIUM | future fixture-driven test cycle |
+| N47 — branch cleanup | operator | operator-decision-pending |
+
+## G30 self-validation — 46th consecutive LOW
+
+Patch-tier delta: ~50 LOC test + ~40 lines CLAUDE.md edits + retro + version bump. **46 consecutive LOW** (v0.6.5..v0.11.2).
+
+## Manual-takeover streak
+
+v0.11.2 driven via operator-staged scope (D-medium choice from comprehensive-review summary). **Streak: maintained through v0.11.2** — operator gates: scope choice (Path A→D-medium) + scope expansion approval after review.
+
+## Lessons learned
+
+**Comprehensive review beats per-cycle p015 audits for cross-cutting concerns.** The post-v0.11.1 comprehensive review surfaced 4 doc gaps + 2 code coverage gaps in CLAUDE.md/test areas that 6 prior p015 audits hadn't fully caught. This is because:
+- p015 audits focus on rolling-forward IDEA_REPORT/PIPELINE_REPORT chain consistency.
+- Comprehensive review walks the entire codebase + docs surface holistically.
+
+For future cycles: schedule a comprehensive review at major version boundaries (e.g., post-v0.11.x ship before v0.12.x kickoff).
+
+**Code-reviewer agent timeout pattern (re-emerged at v0.11.2).** Last seen at v0.10.9 (where the agent waited mid-test-run). Mitigation: when running real test suites with multi-second wallclock, the test should be invoked OUTSIDE the agent's prompt scope, OR the agent prompt should be re-architected to read test results from a pre-existing log file rather than running tests themselves. Track for future agent-prompt iteration.
+
+## codebasePatterns
+
+p001-p016 carried forward. **17 named patterns canonized** as of v0.11.2. No new pattern additions.
+
+## Recommendation pointer
+
+See `idea-stage/IDEA_REPORT_v52.md`. With v0.11.2 closing 5 findings from comprehensive review, autonomous backlog reduces further. Next operator decisions:
+
+- **Path B: Real-feature dispatch** — awaits operator-queued multi-story feature.
+- **Pre-Path-B: field-ownership escalation policy** — should v0.10.8 N48 WARN escalate to WAVE_FAILED before Path B?
+- **v0.11.3 candidates:** copilot-hooks::post_output coverage (~150 LOC) + build_coordinator_prompt content assertions. Both are real but defer-able.

--- a/tasks/prd-v0.11.2-bundle.md
+++ b/tasks/prd-v0.11.2-bundle.md
@@ -1,0 +1,105 @@
+# PRD: v0.11.2 — patch-tier (D-medium: N48 negative-path test + CLAUDE.md doc updates)
+
+**Status:** Operator-approved D-medium scope (post-comprehensive-review). Closes 5 findings.
+**Date:** 2026-05-02
+**Predecessor:** `tasks/prd-v0.11.1-bundle.md`.
+**Branch:** `ql/v0.11.2-bundle`.
+**Target version:** 0.11.1 → 0.11.2 (patch).
+**Total effort:** ~1 hour.
+
+## Section 1: Introduction / Overview
+
+4-story patch closing 5 findings from the post-v0.11.1 comprehensive review:
+1. **N48 negative-path test** — pairs with v0.11.0 Test 9 (positive); confirms detection symmetry.
+2. **CLAUDE.md `iteration-loop.sh:~212` line refs stale** (HIGH-1; v0.11.1 wire shifted dispatch to ~224/~227).
+3. **CLAUDE.md missing `QL_PARALLEL_POLL` env var docs** (MEDIUM-1).
+4. **CLAUDE.md missing `dispatch_with_parallel_poll` reference** (MEDIUM-2).
+5. **Platform Notes missing trap-RETURN-nesting invariant** (MEDIUM-3).
+
+## Section 2: Goals
+
+- Add Test 10 (N48 negative-path) to `tests/test_coordinator_e2e.sh`.
+- Update CLAUDE.md "Coordinator-related" section with v0.11.1 surface (line refs + 2 new bullets).
+- Add Platform Notes entry for trap-RETURN-nesting invariant.
+- 27th p014 review.
+- Bump 0.11.1 → 0.11.2.
+- 46 consecutive LOW G30.
+
+## Section 3: User Stories
+
+### US-001: N48 negative-path test (Test 10)
+
+**Acceptance Criteria:**
+- [ ] New Test 10 added to `tests/test_coordinator_e2e.sh` after Test 9 (before "=== Results:" line).
+- [ ] Reuses existing `passed` stub mode (line 97-106) — already field-ownership-compliant by design (writes only `review.*` fields, never touches `.stories[].status`). No new stub mode required.
+- [ ] 4 sub-asserts:
+  - **Positive control:** `assert_contains "Test 10: stdout mentions Wave PASSED" "Wave (wave-1) PASSED" "$OUT"` (matches Test 1's assertion).
+  - **Negative — WARN absence:** assert `[FIELD-OWNERSHIP] WARN` does NOT appear in `$OUT`. Pattern: `! grep -qF "[FIELD-OWNERSHIP] WARN"`.
+  - **Negative — before:/after: absence:** assert `before:` JSON line does NOT appear (negative side-effect of WARN absence).
+  - **Status correctness:** `assert_eq "Test 10: US-A status=passed" "passed" "$US_A_STATUS"` AND `US-B status=passed`.
+- [ ] Test counter increments: 27 → 31 (4 new sub-asserts; matches positive Test 9's 6-assert structure but smaller scope since the "no-op" case has fewer state-changes to verify).
+- [ ] `bash -n tests/test_coordinator_e2e.sh` clean.
+- [ ] `bash tests/test_coordinator_e2e.sh` rc=0; 31/31.
+
+### US-002: CLAUDE.md doc updates (4 gaps)
+
+**Acceptance Criteria:**
+- [ ] **Edit 1 (HIGH-1):** CLAUDE.md lines 263-264 — bump line refs:
+  - `lib/iteration-loop.sh:~212` → `lib/iteration-loop.sh:~224` (timeout-guarded dispatch; v0.11.1 wire-insertion shifted).
+  - `line 215` → `line 227` (no-timeout fallback).
+- [ ] **Edit 2 (MEDIUM-1 + MEDIUM-2):** Add new bullet(s) to "Coordinator-related" section documenting:
+  - `QL_PARALLEL_POLL` env var (default `false`; v0.11.1 / US-002).
+  - `QL_PARALLEL_POLL_TIMEOUT_S` (default 600s).
+  - `QL_PARALLEL_POLL_INTERVAL_S` (default 60s).
+  - Wire site: `lib/iteration-loop.sh:247-253`.
+  - Explicit clarification: this is for LEGACY (non-coordinator) dispatch path; coordinator uses `QL_COORDINATOR_TIMEOUT_S` instead.
+  - `lib/orchestrator-liveness.sh::dispatch_with_parallel_poll` function reference (signature, opt-in gate, race-fix note).
+- [ ] **Edit 3 (MEDIUM-3):** CLAUDE.md "Platform Notes" section — add trap-RETURN-nesting invariant entry. Cross-reference inline invariant comment at `lib/orchestrator-liveness.sh:~211`.
+
+### US-003: Multi-perspective post-merge review (27th application)
+
+**Acceptance Criteria:**
+- [ ] 3 reviewer agents (architect + code-reviewer + security) invoked in parallel.
+- [ ] No score-≥85 finding deferred.
+
+### US-004: Retrospective + IDEA_REPORT_v52 + version bump 0.11.1 → 0.11.2
+
+**Acceptance Criteria:**
+- [ ] `idea-stage/PIPELINE_REPORT_v52.md` documents v0.11.2 (4 stories) + comprehensive-review credit (5 findings closed).
+- [ ] `idea-stage/IDEA_REPORT_v52.md` rolling forward state. Remaining v0.11.x backlog: Path B (operator-queued), Path E (test file split when worth it), copilot-hooks coverage (v0.11.3 candidate), pre-Path-B field-ownership escalation policy.
+- [ ] `CHANGELOG.md [0.11.2]` entry.
+- [ ] 4 plugin manifest version fields bumped 0.11.1 → 0.11.2.
+- [ ] G30 self-validation (46th consecutive LOW expected).
+
+## Section 4: Functional Requirements
+
+- **FR-1:** Test 10 reuses existing `passed` stub mode; no new stub authoring.
+- **FR-2:** CLAUDE.md "Coordinator-related" section now accurately reflects both coordinator (`QL_COORDINATOR_TIMEOUT_S`) and legacy non-coordinator (`QL_PARALLEL_POLL`) dispatch paths.
+- **FR-3:** Platform Notes documents trap-RETURN-nesting as a project-wide bash invariant.
+- **FR-4:** Plugin version 0.11.1 → 0.11.2 (4 fields).
+
+## Section 5: Non-Goals
+
+- No copilot-hooks::post_output test coverage (deferred to v0.11.3 per critic recommendation; ~150 LOC own cycle).
+- No build_coordinator_prompt content assertions (deferred to v0.11.3).
+- No Path E test file split (deferred; file at ~615 LOC = AT threshold but not OVER critical mass).
+- No field-ownership WARN→FAIL escalation policy decision (pre-Path-B operator-decision item; separate from D-medium).
+- No `run_iteration_loop` / `run_parallel_mode` decomposition (architect HIGH structural debt; future architectural cycle).
+
+## Section 6: Design Notes
+
+**Test 10 negative-path design rationale:** The positive Test 9 (v0.11.0) validates that the v0.10.8 N48 WARN fires when contract is violated. Test 10's job is to validate that the WARN does NOT fire when contract is respected — proving N48 detection is symmetric (no false positives). Without Test 10, N48 could in principle be over-firing (e.g., always WARNing regardless of actual violation) and Test 9 would still pass. Together they form a complete observational pair.
+
+**CLAUDE.md "Coordinator-related" naming:** technically the section name is becoming a misnomer with `QL_PARALLEL_POLL` (non-coordinator). Consider renaming to "Dispatch helpers" in a future cycle — for v0.11.2, keep the name and add explicit "(non-coordinator)" qualifiers in the new bullets to disambiguate.
+
+## Section 7: Technical Notes
+
+Markdown-only (CLAUDE.md) + bash test addition (~30 LOC). No new dependencies.
+
+## Section 8: Success Metrics
+
+- All 4 stories first-attempt PASS.
+- `tests/test_coordinator_e2e.sh`: 27 → 31 tests (+4 sub-asserts in Test 10).
+- 6 baseline test suites green: 15+31+44+39+18+46 = 193.
+- 46 consecutive LOW G30.
+- 5 comprehensive-review findings closed (1 N48 coverage gap + 4 doc gaps).

--- a/tests/test_coordinator_e2e.sh
+++ b/tests/test_coordinator_e2e.sh
@@ -430,6 +430,57 @@ assert_eq "Test 9: US-B status=passed (parent processed WAVE_PASSED)" "passed" "
 
 rm -rf "$TEST_ROOT/work"
 
+# ─ Test 10: N48 field-ownership negative-path (v0.11.2 / US-001) ──────────
+# v0.11.2: pair with Test 9 to validate N48 detection symmetry. Test 9
+# proves WARN fires on contract violation; Test 10 proves WARN does NOT
+# fire on contract compliance. Together they confirm no false-positive
+# WARN emission. Reuses existing 'passed' stub mode (line 97-106) which
+# is already field-ownership-compliant by design (writes only review.*
+# fields; never touches .stories[].status).
+echo ""
+echo "Test 10: N48 field-ownership compliance — WARN does NOT fire (v0.11.2 negative-path)"
+mkdir -p "$TEST_ROOT/work"
+write_2story_plan "$TEST_ROOT/work/quantum.json"
+( cd "$TEST_ROOT/work" && \
+  git init -q && \
+  git config user.email t@t.test && git config user.name testuser && \
+  git add quantum.json 2>/dev/null && \
+  git commit -q -m "init" )
+
+OUT=$(run_ql_coord passed)
+
+US_A_STATUS=$(jq -r '.stories[] | select(.id == "US-A") | .status' "$TEST_ROOT/work/quantum.json")
+US_B_STATUS=$(jq -r '.stories[] | select(.id == "US-B") | .status' "$TEST_ROOT/work/quantum.json")
+
+# Positive control: dispatch must complete normally.
+assert_contains "Test 10: stdout mentions Wave PASSED (positive control)" "Wave (wave-1) PASSED" "$OUT"
+
+# Negative — WARN absence: validate N48 detection symmetry.
+TOTAL=$((TOTAL + 1))
+if echo "$OUT" | grep -qF "[FIELD-OWNERSHIP] WARN"; then
+  echo "  FAIL: Test 10: FIELD-OWNERSHIP WARN fired on compliant coordinator (false positive)"
+  FAIL=$((FAIL + 1))
+else
+  echo "  PASS: Test 10: FIELD-OWNERSHIP WARN absent (no false positive)"
+  PASS=$((PASS + 1))
+fi
+
+# Negative — before:/after: absence (side-effect of WARN absence).
+TOTAL=$((TOTAL + 1))
+if echo "$OUT" | grep -qE '^\s*before:'; then
+  echo "  FAIL: Test 10: before: line appeared without WARN (inconsistent state)"
+  FAIL=$((FAIL + 1))
+else
+  echo "  PASS: Test 10: before:/after: lines absent (consistent with WARN absence)"
+  PASS=$((PASS + 1))
+fi
+
+# Status correctness: parent processed WAVE_PASSED normally.
+assert_eq "Test 10: US-A status=passed (parent processed WAVE_PASSED)" "passed" "$US_A_STATUS"
+assert_eq "Test 10: US-B status=passed (parent processed WAVE_PASSED)" "passed" "$US_B_STATUS"
+
+rm -rf "$TEST_ROOT/work"
+
 echo ""
 echo "=== Results: $PASS/$TOTAL passed, $FAIL failed ==="
 if (( FAIL > 0 )); then


### PR DESCRIPTION
## Summary

4-story patch closing **5 findings from post-v0.11.1 comprehensive review**:

- **US-001** — `tests/test_coordinator_e2e.sh:433-481` Test 10 N48 negative-path. Reuses existing `passed` stub mode (already field-ownership-compliant). Pairs with v0.11.0 Test 9 to validate detection symmetry (no false positives).
- **US-002** — CLAUDE.md updates: Edit 1 line refs `~212/~215` → `~224/~227` (HIGH-1; v0.11.1 wire shifted). Edit 2 new `QL_PARALLEL_POLL` env var docs (MEDIUM-1). Edit 3 new `dispatch_with_parallel_poll` reference (MEDIUM-2). Edit 4 new "Bash trap RETURN is last-write-wins" Platform Notes entry (MEDIUM-3).
- **US-003** — 27th p014 review trio (architect SHIP 94, security SHIP 95). Code-reviewer agent timed out twice mid-test-run; coverage gap mitigated by architect convergence. 1 LOW retro-noted (PRD counter +4 vs actual +5). **14th p014 catch in 27 applications career (~52%).**
- **US-004** — Retro + IDEA_REPORT_v52 + 4-manifest bump 0.11.1 → 0.11.2.

## Test plan

- [x] `bash -n tests/test_coordinator_e2e.sh` clean
- [x] `tests/test_coordinator_e2e.sh`: 32/32 (was 27; +5 sub-asserts in Test 10)
- [x] 5 baseline suites green (no regression)
- [x] 46 consecutive LOW G30 self-validations (v0.6.5..v0.11.2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)