### PR TITLE
feat(dead-code): opt-in blocking quality gate on high-precision dead code (Q4)

### DIFF
--- a/agents/orchestrator-modules/dead-code-detection.md
+++ b/agents/orchestrator-modules/dead-code-detection.md
@@ -29,6 +29,18 @@ else
 fi
 ```
 
+### Opt-in blocking (Track A / Q4)
+
+By default this check is advisory (above). When `QL_QUALITY_BLOCKING` is set (`1|true|yes|on`), a HIGH-PRECISION dead-code signal — an unused **new import** introduced by this story — fails the story so it is fixed before commit rather than only annotated. Unused **privates** stay advisory even under blocking (the documented false-positive: a helper exercised only by a later commit's test). This default-off opt-in preserves the one-retry-budget rationale for teams that don't enable it, mirroring the `QL_VALIDATE_BLOCKING` pattern.
+
+```bash
+# After computing DEAD_CODE_REPORT / DEAD_IMP above:
+if [[ "$DEAD_CODE_AVAILABLE" != "false" ]] && ! dead_code_blocking_verdict "$DEAD_CODE_REPORT"; then
+  echo "<quantum>STORY_FAILED</quantum>  dead_code_blocked: $DEAD_IMP unused new import(s)"
+  # record reason in retries.failureLog; the story re-runs to remove the dead import.
+fi
+```
+
 Why advisory not blocking:
 - False positives are real. A private helper called only from a test file in a future commit would be flagged here incorrectly. Blocking would train the loop to retry-until-empty, breaking the one-retry budget.
 - Deslop (3A.5B) already has the blocking authority when it wants to. Dead-code is a secondary read for reviewer context.

--- a/lib/dead-code.sh
+++ b/lib/dead-code.sh
@@ -372,6 +372,26 @@ find_post_commit_dead() {
   '
 }
 
+# dead_code_blocking_verdict(report_json) -> 0 (ok) | 1 (block)
+# Track A / Q4 — OPT-IN quality gate. Default OFF: returns 0 (advisory) so the
+# documented advisory-by-design behavior is unchanged. Under QL_QUALITY_BLOCKING
+# (1|true|yes|on) it returns 1 when the diff introduces HIGH-PRECISION dead code
+# — an unused NEW import (.summary.by_kind.import > 0). Unused PRIVATES stay
+# advisory even when blocking is on (documented false-positive: a private helper
+# exercised only by a later commit's test). report_json is the output of
+# find_post_commit_dead / scan_dead_code. Mirrors the QL_VALIDATE_BLOCKING opt-in
+# so default pipelines keep the one-retry-budget behavior.
+dead_code_blocking_verdict() {
+  local report="${1:?dead_code_blocking_verdict: report json required}"
+  case "${QL_QUALITY_BLOCKING:-}" in
+    1|true|TRUE|yes|on) ;;
+    *) return 0 ;;
+  esac
+  local imports
+  imports=$(jq -r '.summary.by_kind.import // 0' <<< "$report" 2>/dev/null)
+  [[ "${imports:-0}" -eq 0 ]]
+}
+
 # ------------------------------------------------------------------------------
 # CLI entry
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
@@ -383,6 +403,7 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     privates)  scan_unused_privates "$@" ;;
     scan)      scan_dead_code "$@" ;;
     commit)    find_post_commit_dead "$@" ;;
+    verdict)   dead_code_blocking_verdict "$@" ;;
     *)
       cat >&2 <<USAGE
 Usage: bash lib/dead-code.sh <subcmd> [args...]
@@ -390,6 +411,7 @@ Usage: bash lib/dead-code.sh <subcmd> [args...]
   privates FILE                  — JSON array of unused private symbols
   scan     FILE_OR_DIR           — aggregated dead-code report
   commit   BASE HEAD [FILTER]    — scan files changed between two SHAs
+  verdict  REPORT_JSON           — rc 1 under QL_QUALITY_BLOCKING if unused new imports > 0
 USAGE
       exit 2
       ;;

--- a/tests/test_dead_code.sh
+++ b/tests/test_dead_code.sh
@@ -313,6 +313,33 @@ out=$(scan_unused_privates "$TEST_TMPDIR/a.xyz")
 assert "unknown ext privates=[]" "[]" "$out"
 rm -rf "$TEST_TMPDIR"
 
+# Test 18-21: Track A Q4 — opt-in blocking verdict (dead_code_blocking_verdict)
+R_IMP='{"summary":{"total":1,"by_kind":{"import":1,"private":0}}}'
+R_PRIV='{"summary":{"total":1,"by_kind":{"import":0,"private":1}}}'
+R_CLEAN='{"summary":{"total":0,"by_kind":{"import":0,"private":0}}}'
+
+echo ""
+echo "Test 18: verdict advisory by default (env unset)"
+unset QL_QUALITY_BLOCKING
+dead_code_blocking_verdict "$R_IMP" >/dev/null 2>&1
+assert "default: imports>0 -> rc 0 (advisory)" "0" "$?"
+
+echo ""
+echo "Test 19: blocking on unused new import"
+QL_QUALITY_BLOCKING=1 dead_code_blocking_verdict "$R_IMP" >/dev/null 2>&1
+assert "blocking: imports>0 -> rc 1" "1" "$?"
+
+echo ""
+echo "Test 20: privates stay advisory under blocking"
+QL_QUALITY_BLOCKING=1 dead_code_blocking_verdict "$R_PRIV" >/dev/null 2>&1
+assert "blocking: privates-only -> rc 0" "0" "$?"
+
+echo ""
+echo "Test 21: clean report passes under blocking"
+QL_QUALITY_BLOCKING=1 dead_code_blocking_verdict "$R_CLEAN" >/dev/null 2>&1
+assert "blocking: clean -> rc 0" "0" "$?"
+unset QL_QUALITY_BLOCKING
+
 echo ""
 echo "=== Results: $PASS/$TOTAL passed, $FAIL failed ==="
 exit $((FAIL > 0 ? 1 : 0))


### PR DESCRIPTION
## Summary
Track-A generation hardening (build side). **Q4 — opt-in blocking dead-code quality gate.**

- `lib/dead-code.sh` gains `dead_code_blocking_verdict`, opt-in via `QL_QUALITY_BLOCKING` (default OFF).
- Blocks **only** high-precision unused **new** imports; privates stay advisory — respecting the module's documented advisory-by-design choice.
- Delta-gated (new code only), never absolute.

## Test plan
- `tests/test_dead_code.sh` — 33/33 ✅

Context: `ai-native-project/docs/plans/2026-06-17-track-a-antislop-implementation.md`.
