### PR TITLE
feat(reuse): reuse-first candidate search + opt-in reuse-or-justify gate (Q2)

### DIFF
--- a/agents/implementer.md
+++ b/agents/implementer.md
@@ -170,6 +170,15 @@ Before creating any new component, function, or module, check if another task ha
 
 This prevents the "two agents independently implement the same thing" failure pattern.
 
+### Reuse-first (Track A / Q2)
+
+`consumedBy` covers reuse WITHIN this plan. `reuseCandidates[]` (set by `/ql-plan`) covers reuse of the EXISTING codebase. Before writing a new function / class / module, check your story's `reuseCandidates`:
+
+1. If a candidate already provides what you need: **call it** (import the `symbol` from its `file`) rather than writing a new one.
+2. If you must write new code anyway (the candidates don't fit): add a one-line `noReuseJustification: <why>` to your output message, naming the candidate you rejected and why.
+
+`lib/reuse-scan.sh gate` checks this — advisory by default, blocking under `QL_QUALITY_BLOCKING`. This directly attacks the "reinvent instead of reuse" + duplication slop classes.
+
 ## After Wiring Check
 
 Run the project's quality checks in order:
@@ -205,6 +214,7 @@ Answer each item with a one-line status. If any item fails, **do not signal yet*
 - [ ] Every acceptance criterion has a concrete evidence line (test name, file:line, or command output) cited in my output message.
 - [ ] Every `wiring_verification.must_contain` string appears verbatim in its target file.
 - [ ] Any `consumedBy` contract for this story is satisfied (I imported, not re-created).
+- [ ] Each `reuseCandidates` entry was reused, or I recorded a `noReuseJustification` for it (Track A / Q2).
 - [ ] No task in this story is left `in_progress` or `pending`.
 
 **Quality**

--- a/lib/reuse-scan.sh
+++ b/lib/reuse-scan.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# lib/reuse-scan.sh — reuse-first candidate search + gate (Track A / Q2).
+#
+# Forces the build agent to REUSE existing code instead of reinventing it.
+# Two pieces:
+#   scan_reuse_candidates — the graph-FREE fallback: grep the existing tree for
+#                           symbol DEFINITIONS whose name relates to a story's
+#                           concept terms, so ql-plan can populate
+#                           story.reuseCandidates[]. When the code graph is
+#                           available, prefer the relational_envelope verb (see
+#                           skills/ql-plan/SKILL.md); this is the no-graph path.
+#   reuse_gate            — reuse-or-justify check: if a story has reuseCandidates
+#                           and the implementer's diff neither references one nor
+#                           records a noReuseJustification, warn (advisory) or
+#                           fail (under QL_QUALITY_BLOCKING).
+#
+# Why grep not a language tool: quantum-loop runs in a bare Git Bash shell on
+# Windows; grep + jq are the only guaranteed deps (same rationale as
+# lib/dead-code.sh). This is a coarse candidate finder, not a precise index.
+#
+# Library contract: no shell flags at source time; strict mode only in the CLI
+# block at bottom.
+
+if [[ -n "${_QL_REUSE_SCAN_LIB:-}" ]]; then
+  return 0 2>/dev/null || true
+fi
+readonly _QL_REUSE_SCAN_LIB=1
+
+_REUSE_DEF_KW='(def|function|func|class|interface|type|struct)'
+_REUSE_INCLUDES=(--include='*.py' --include='*.ts' --include='*.tsx' --include='*.js' --include='*.jsx' --include='*.mjs' --include='*.go' --include='*.rs' --include='*.java')
+_REUSE_TEST_RE='(/tests?/|/__tests__/|_test\.|\.test\.|\.spec\.)'
+
+# scan_reuse_candidates(terms_csv, [path]) -> JSON array
+# Existing symbol definitions whose name contains any term (test files excluded).
+scan_reuse_candidates() {
+  local terms="${1:?scan_reuse_candidates: terms (csv) required}"
+  local path="${2:-.}"
+  local out='[]'
+  local -a term_arr
+  IFS=',' read -r -a term_arr <<< "$terms"
+  local term file line text sym hits
+  for term in "${term_arr[@]}"; do
+    term=$(printf '%s' "$term" | tr -cd '[:alnum:]_')
+    [[ -z "$term" ]] && continue
+    hits=$(grep -rEIni "${_REUSE_INCLUDES[@]}" \
+             "${_REUSE_DEF_KW}[[:space:]]+[A-Za-z0-9_]*${term}[A-Za-z0-9_]*" "$path" 2>/dev/null \
+           | grep -vEi "$_REUSE_TEST_RE" || true)
+    [[ -z "$hits" ]] && continue
+    while IFS=: read -r file line text; do
+      [[ -z "$file" || -z "$line" ]] && continue
+      sym=$(printf '%s' "$text" | grep -oiE "${_REUSE_DEF_KW}[[:space:]]+[A-Za-z_][A-Za-z0-9_]*" | head -1 | awk '{print $NF}')
+      [[ -z "$sym" ]] && continue
+      out=$(jq -c --arg s "$sym" --arg f "$file" --argjson l "$line" --arg t "$term" \
+        '. + [{symbol:$s, file:$f, line:$l, term:$t}]' <<< "$out")
+    done <<< "$hits"
+  done
+  jq -c 'unique_by(.symbol + "@" + .file + ":" + (.line|tostring))' <<< "$out"
+}
+
+# reuse_gate(candidates_json, text) -> 0 | 1
+# Pass if: no candidates, OR text has a noReuseJustification marker, OR text
+# references at least one candidate symbol. Otherwise advisory (rc 0 + warn) by
+# default; rc 1 under QL_QUALITY_BLOCKING (the Q4 opt-in pattern).
+reuse_gate() {
+  local candidates="${1:?reuse_gate: candidates json required}"
+  local text="${2:?reuse_gate: text required}"
+  local n; n=$(jq 'length' <<< "$candidates" 2>/dev/null)
+  [[ "${n:-0}" -eq 0 ]] && return 0
+  if printf '%s' "$text" | grep -qiE 'noReuseJustification|NO-REUSE:'; then return 0; fi
+  local sym matched=0
+  while IFS= read -r sym; do
+    sym="${sym%$'\r'}"   # jq -r on Git Bash/MSYS appends CR; strip it (repo convention)
+    [[ -z "$sym" ]] && continue
+    if printf '%s' "$text" | grep -qwF -- "$sym"; then matched=1; break; fi
+  done < <(jq -r '.[].symbol' <<< "$candidates")
+  [[ "$matched" -eq 1 ]] && return 0
+  case "${QL_QUALITY_BLOCKING:-}" in
+    1|true|TRUE|yes|on)
+      printf "[REUSE] BLOCK: %s existing candidate(s) not reused and no noReuseJustification.\n" "$n" >&2
+      return 1 ;;
+    *)
+      printf "WARNING: [REUSE] %s existing candidate(s) available but not reused (advisory).\n" "$n" >&2
+      return 0 ;;
+  esac
+}
+
+# ------------------------------------------------------------------------------
+# CLI entry. Strict mode only here.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  set -euo pipefail
+  subcmd="${1:-}"; shift || true
+  case "$subcmd" in
+    scan)  scan_reuse_candidates "$@" ;;
+    gate)  reuse_gate "$@" ;;
+    *)
+      cat >&2 <<USAGE
+Usage: bash lib/reuse-scan.sh <subcmd> [args...]
+  scan TERMS_CSV [PATH]        — JSON array of existing symbol defs matching terms (tests excluded)
+  gate CANDIDATES_JSON TEXT    — reuse-or-justify; rc 1 under QL_QUALITY_BLOCKING if violated
+USAGE
+      exit 2 ;;
+  esac
+fi

--- a/skills/ql-plan/SKILL.md
+++ b/skills/ql-plan/SKILL.md
@@ -415,6 +415,15 @@ Set the top-level `coverageThreshold` field in quantum.json:
 
 The quality-reviewer will enforce this threshold during review. If the project has no coverage tooling, the reviewer will skip enforcement on the first story and enforce after first successful measurement.
 
+### reuseCandidates Generation (Track A / Q2 — reuse-first)
+
+For each story, populate `reuseCandidates[]` with existing symbols the implementer should REUSE instead of reinventing. This extends `consumedBy` (intra-plan) to the whole existing codebase, attacking the "reinvent instead of reuse" + duplication slop classes.
+
+1. **With the code graph** (preferred): run the `relational_envelope` verb keyed on the story's acceptance-criteria nouns/verbs → existing FUNCTION/CLASS nodes + near-duplicate candidates, with per-edge confidence tiers (surface EXTRACTED/INFERRED candidates as "must consider"; leave AMBIGUOUS advisory).
+2. **Without a graph** (fallback): `bash lib/reuse-scan.sh scan "<comma-separated concept terms>" .` → existing symbol definitions whose names relate to the story (test files excluded).
+
+Write the result as `reuseCandidates: [{symbol, file, line}]` on the story. The implementer (`agents/implementer.md`) must then reuse one or record a `noReuseJustification`; `lib/reuse-scan.sh gate` enforces it (advisory by default, blocking under `QL_QUALITY_BLOCKING`). Empty `reuseCandidates` (nothing relevant exists) is fine — the gate is a no-op.
+
 ## Step 3: Decompose Stories into Tasks
 
 For each story, break it into granular tasks. Each task should take 2-5 minutes for an AI agent.
@@ -527,6 +536,7 @@ Assemble the complete quantum.json with this structure:
       "title": "[Story title]",
       "description": "As a [user], I want [feature] so that [benefit]",
       "acceptanceCriteria": ["criterion 1", "criterion 2", "Typecheck passes"],
+      "reuseCandidates": [],
       "priority": 1,
       "status": "pending",
       "dependsOn": [],
@@ -558,6 +568,7 @@ Assemble the complete quantum.json with this structure:
 - `branchName`: Always prefixed with `ql/`, followed by kebab-case feature name
 - `priority`: Integer starting at 1. Used as tiebreaker when DAG allows multiple stories.
 - `dependsOn`: Array of story IDs (e.g., `["US-001", "US-002"]`). Empty array for stories with no dependencies.
+- `reuseCandidates`: Existing symbols `[{symbol, file, line}]` the implementer should reuse before writing new code (Track A / Q2 reuse-first). Populated by the reuseCandidates Generation step below; empty is fine.
 - `status`: Always "pending" for all stories and tasks when first created.
 - `retries.maxAttempts`: Default 3. Increase for complex stories if needed.
 

--- a/tests/test_reuse_scan.sh
+++ b/tests/test_reuse_scan.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# tests/test_reuse_scan.sh — Track A / Q2 reuse-first search + gate tests.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR/.."
+PASS=0
+FAIL=0
+TOTAL=0
+
+assert() {
+  local name="$1" expected="$2" actual="$3"
+  TOTAL=$((TOTAL + 1))
+  if [[ "$expected" == "$actual" ]]; then
+    echo "  PASS: $name"; PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $name (expected [$expected] got [$actual])"; FAIL=$((FAIL + 1))
+  fi
+}
+
+# shellcheck disable=SC1091
+source "$REPO_ROOT/lib/reuse-scan.sh"
+unset QL_QUALITY_BLOCKING
+
+echo "=== Track A Q2 reuse-scan tests ==="
+
+# Build a fixture tree: src defs + a test-file def that must be excluded.
+TEST_TMPDIR=$(mktemp -d)
+mkdir -p "$TEST_TMPDIR/src" "$TEST_TMPDIR/tests"
+cat > "$TEST_TMPDIR/src/config.py" << 'PY'
+def parse_config(path):
+    return {}
+
+
+class ConfigLoader:
+    pass
+PY
+cat > "$TEST_TMPDIR/tests/test_config.py" << 'PY'
+def parse_config_helper():
+    pass
+PY
+
+# Test 1: scan finds existing src symbols for term "config"
+echo ""
+echo "Test 1: scan finds existing symbols"
+cands=$(scan_reuse_candidates "config" "$TEST_TMPDIR")
+assert "2 candidates (parse_config + ConfigLoader)" "2" "$(jq 'length' <<< "$cands")"
+assert "symbols sorted" "ConfigLoader,parse_config" "$(jq -r '[.[].symbol] | sort | join(",")' <<< "$cands")"
+
+# Test 2: test files are excluded
+echo ""
+echo "Test 2: test files excluded"
+assert "no candidate from tests/" "false" "$(jq -c '[.[].file | test("tests/")] | any' <<< "$cands")"
+
+# Test 3: no match -> empty
+echo ""
+echo "Test 3: unmatched term -> []"
+assert "empty for nonexistent term" "[]" "$(scan_reuse_candidates "zzznotathing" "$TEST_TMPDIR")"
+rm -rf "$TEST_TMPDIR"
+
+CANDS='[{"symbol":"parse_config","file":"src/config.py","line":1}]'
+
+# Test 4: gate passes when no candidates
+echo ""
+echo "Test 4: gate passes with no candidates"
+reuse_gate '[]' "def my_new_thing(): pass" >/dev/null 2>&1
+assert "no candidates -> rc 0" "0" "$?"
+
+# Test 5: gate passes when a candidate is referenced
+echo ""
+echo "Test 5: gate passes when candidate reused"
+QL_QUALITY_BLOCKING=1 reuse_gate "$CANDS" "cfg = parse_config(path)" >/dev/null 2>&1
+assert "candidate referenced -> rc 0" "0" "$?"
+
+# Test 6: gate passes with a noReuseJustification marker
+echo ""
+echo "Test 6: gate passes with justification"
+QL_QUALITY_BLOCKING=1 reuse_gate "$CANDS" "noReuseJustification: needs a streaming parser" >/dev/null 2>&1
+assert "justification present -> rc 0" "0" "$?"
+
+# Test 7: advisory by default when candidate ignored
+echo ""
+echo "Test 7: ignored candidate is advisory by default"
+unset QL_QUALITY_BLOCKING
+reuse_gate "$CANDS" "def my_own_parser(): pass" >/dev/null 2>&1
+assert "ignored, env unset -> rc 0 (advisory)" "0" "$?"
+
+# Test 8: blocking when candidate ignored under QL_QUALITY_BLOCKING
+echo ""
+echo "Test 8: ignored candidate blocks under QL_QUALITY_BLOCKING"
+QL_QUALITY_BLOCKING=1 reuse_gate "$CANDS" "def my_own_parser(): pass" >/dev/null 2>&1
+assert "ignored, blocking -> rc 1" "1" "$?"
+unset QL_QUALITY_BLOCKING
+
+echo ""
+echo "=== Results: $PASS/$TOTAL passed, $FAIL failed ==="
+exit $((FAIL > 0 ? 1 : 0))


### PR DESCRIPTION
## Summary
Track-A generation hardening (build side). **Q2 — reuse-first.**

- `lib/reuse-scan.sh`: grep-fallback reuse search across the codebase.
- Reuse-or-justify gate; `ql-plan` emits `reuseCandidates`; implementer wiring consumes them.
- Intended to extend intra-plan `consumedBy` reuse to the whole codebase (graph `relational_envelope` is the documented richer path; the grep fallback is what's built+tested here).

## Test plan
- `tests/test_reuse_scan.sh` — 9/9 ✅

Context: `ai-native-project/docs/plans/2026-06-17-track-a-antislop-implementation.md`.
